### PR TITLE
fix empty space regex in repo page

### DIFF
--- a/bda.repository.js
+++ b/bda.repository.js
@@ -228,7 +228,7 @@
 
       $('body').on('click', '.dataTable .fa-pencil-square-o', function(item) {
         var $target = $(item.target).parent();
-        $target.html('<input type="text" value="' + $target.text().replace('●', ' ') + '"/>');
+        $target.html('<input type="text" value="' + $target.text().replace(/●/g, ' ') + '"/>');
         var $input = $($target.children()[0]);
         $input.focus().blur(function(item) {
           if (confirm('do you really want to update that value ?')) {
@@ -660,7 +660,7 @@
     renderProperty: function(curProp, propValue, itemId, isItemTree) {
       var html = "";
       if (propValue !== null && propValue !== undefined) {
-        propValue = propValue.replace(' ', '●');
+        propValue = propValue.replace(/ /g, '●');
         // Remove "_"
         if (curProp.name == "descriptor")
           propValue = propValue.substr(1);


### PR DESCRIPTION
On a repo page, when you query objects, the first empty space is replaced by a ● char. But the initial goal was to replace every empty space by a ●, that's what I have done in this PR.