### PR TITLE
watch script + contrib guide

### DIFF
--- a/.env.json.example
+++ b/.env.json.example
@@ -1,0 +1,3 @@
+{
+"destination":"/your/path/here"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 resources/Thumbs.db
 *~
 node_modules
+.env.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 resources/Thumbs.db
 *~
+node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+Contribution Guide
+===

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,46 @@
 Contribution Guide
 ===
+
+# Project Overview
+
+TODO
+
+# Development setup
+
+In both Chrome & Firefox, you can edit the .js directly in the plugin's editor, but it's not really handy, esp. regarding source control.
+
+## With Firefox + GreaseMonkey
+
+We recommand using Firefox, because with GreaseMonkey the scripts are stored directly on the file system, whereas with Tampermonkey (Chrome), the files are stored in a binary that is not easily accessible.
+
+### Files location
+
+The GM files are located under the user's directory (%appdata% in Windows, /home/\<user> on Linux), somewhere like :
+
+> /home/\<user>/.mozilla/firefox/mg2d2veg.default-1456933402886/gm_scripts/Better_Dynamo_Administration
+
+### Gulp watch
+
+Once you know where the files are, it's a simple matter of updating the files from your workspace. A gulp script is provided, with a watch task.
+
+It requires gulp
+> npm install -g gulp
+
+And in your BDA workspace
+> npm install\
+> cp .env.json.sample .env.json
+
+Edit .env.json to set the greasemonkey folder
+
+Run with:
+> gulp watch
+
+It will watch your workspace and update the GM folder. Simply refresh your browser to see the changes.
+
+## Troubleshooting
+
+If you reinstall the script from the browser, the folder might change, so check that if your changes are not reflected
+
+### New files
+If new files are added to the project, the userscript must be reinstalled from the browser for the new files to be taken into account.
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ env({
     file: '.env'
   });
 
-let source = ['*.js','*.css','parser/**','lib/**']; 
+let source = ['*.js','*.css','parser/**','lib/**','html/**']; 
 let destination =   './dest';
 
 console.log('dest %s, env js',destination, process.env.destination);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ env({
   });
 
 let source = ['*.js','*.css','parser/**','lib/**','html/**']; 
-let destination =   './dest';
+let destination =   process.env.destination;
 
 console.log('dest %s, env js',destination, process.env.destination);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,21 @@
+const watch = require('gulp-watch');
+const gulp = require('gulp');
+const env = require('gulp-env');
+
+env({
+    file: '.env'
+  });
+
+let source = ['*.js','*.css','parser/**','lib/**']; 
+let destination =   './dest';
+
+console.log('dest %s',destination);
+
+gulp.task('watch', function() {  
+
+
+  gulp.src(source, {base: '.'})
+    .pipe(watch(source, {base: '.'}))
+    .pipe(gulp.dest(destination));
+});
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ env({
 let source = ['*.js','*.css','parser/**','lib/**']; 
 let destination =   './dest';
 
-console.log('dest %s',destination);
+console.log('dest %s, env js',destination, process.env.destination);
 
 gulp.task('watch', function() {  
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "better-dyn-admin",
+  "version": "1.0.0",
+  "description": "Better Dynamo Administration",
+  "main": "none.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jc7447/BetterDynAdmin.git"
+  },
+  "keywords": [
+    "atg",
+    "dynadmin",
+    "oracle"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/jc7447/BetterDynAdmin/issues"
+  },
+  "homepage": "https://github.com/jc7447/BetterDynAdmin#readme",
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-env": "^0.4.0",
+    "gulp-watch": "^4.3.11"
+  }
+}


### PR DESCRIPTION
Hey JC, I'm submitting this change as a PR, since it adds (optional) npm dependencies to the project , you might wait to weigh on this ;) 

Basically just adds a gulp watch script, nothing fancy. One thing that bothers me in the script is that, since sources are directly at the root the project, new folders must be added at in the gulp script manually. But moving everything to a /src folder opens up a whole new can of worms...