### PR TITLE
WIP : Repository Refactor/Revamp

### DIFF
--- a/bda.common.js
+++ b/bda.common.js
@@ -3,6 +3,7 @@
 try {
 
   var isLoggingTrace = false;
+  var isLoggingInfo = true;
   var xmlDefinitionCacheTimeout = 1200; // 20min
 
   // ----- Standard Javascript override -----
@@ -132,20 +133,25 @@ try {
     };
 
   this.getXmlDef = function(componentPath) {
-    console.time('processRepositoryXmlDef');
-    logTrace("Getting XML def for : " + componentPath);
+    console.time('getXmlDef');
+    logInfo("Getting XML def for : " + componentPath);
     var timestamp = Math.floor(Date.now() / 1000);
     var xmlDefMetaData = JSON.parse(localStorage.getItem("XMLDefMetaData"));
-    if (!xmlDefMetaData)
-        console.timeEnd('processRepositoryXmlDef');
+    if (!xmlDefMetaData){
+          console.timeEnd('getXmlDef');
+      logInfo("getXmlDef Xml is null");
       return null;
+      
+    }
     if (xmlDefMetaData.componentPath != componentPath || (xmlDefMetaData.timestamp + xmlDefinitionCacheTimeout) < timestamp) {
-        console.timeEnd('processRepositoryXmlDef');
-      logTrace("Xml def is outdated or from a different component");
+        console.timeEnd('getXmlDef');
+      logInfo("getXmlDef Xml def is outdated or from a different component");
       return null;
     }
     let xml = localStorage.getItem("XMLDefData");
-    console.timeEnd('processRepositoryXmlDef');
+        console.timeEnd('getXmlDef');
+      logInfo("getXmlDef returning value from storage");
+    console.timeEnd('getXmlDef');
     return xml;
   };
 
@@ -224,7 +230,12 @@ try {
 
   this.logTrace = function() {
     if (isLoggingTrace && window.console != undefined) {
-      console.log.apply(this, arguments);
+      window.console.log.apply(window.console, arguments);
+    }
+  };
+   this.logInfo = function() {
+    if (isLoggingInfo && window.console != undefined) {
+      window.console.log.apply(window.console, arguments);
     }
   };
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -460,15 +460,15 @@ try {
     this.css('height', value + 'px');
     return this;
   };
-  $.fn.scrollTo = function() {
+  // $.fn.scrollTo = function() {
 
-    $(this).get()[0].scrollIntoView({
-      behavior: "smooth",
-      start: "start",
-      inline: "start"
-    });
+  //   $(this).get()[0].scrollIntoView({
+  //     behavior: "smooth",
+  //     start: "start",
+  //     inline: "start"
+  //   });
 
-  }
+  // }
 
   $.fn.toCSV = function() {
     var data = [];

--- a/bda.common.js
+++ b/bda.common.js
@@ -463,7 +463,9 @@ try {
   $.fn.scrollTo = function() {
 
     $(this).get()[0].scrollIntoView({
-      behavior: "smooth"
+      behavior: "smooth",
+      start: "start",
+      inline: "start"
     });
 
   }
@@ -763,7 +765,7 @@ Johann Burkard
       }
     });
 
-    PerformanceMonitor = function(active){
+    PerformanceMonitor = function(active) {
       this.active = active;
       this.values = {};
     }

--- a/bda.common.js
+++ b/bda.common.js
@@ -764,7 +764,7 @@ Johann Burkard
 
       let record = this.values[task];
       if(_.isNil(record)){
-         record = {total:0};
+         record = {total:0,occurences:0};
         this.values[task] = record;
       }
       record.start = new Date().getTime();
@@ -777,6 +777,7 @@ Johann Burkard
           if(!!record && !!record.start){
             let current = new Date().getTime() - record.start;
             record.total += current;
+            record.occurences++;
          //    console.log('cumul',task,record.start,record.total,current);
           }
         }
@@ -784,7 +785,8 @@ Johann Burkard
     PerformanceMonitor.prototype.log = function(){
       console.log('PerformanceMonitor :');
       _.forEach(this.values,(record,task)=>{
-        console.log('%s - %s',task,record.total);
+        let average = record.total / record.occurences;
+        console.log('%s - total : %s, average : %s, occurences %s',task,record.total, average,record.occurences);
       })
     }
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -3,7 +3,7 @@
 try {
 
   var isLoggingTrace = false;
-  var isLoggingInfo = true;
+  var isLoggingInfo = false;
   var xmlDefinitionCacheTimeout = 1200; // 20min
 
   // ----- Standard Javascript override -----
@@ -89,7 +89,7 @@ try {
           logTrace("Getting XML def from cache");
           var xmlDoc = jQuery.parseXML(rawXmlDef);
           console.timeEnd('processRepositoryXmlDef');
-          if (callback !== undefined){
+          if (callback !== undefined) {
             callback($(xmlDoc));
           }
         }
@@ -121,7 +121,7 @@ try {
                   callback(null);
                   logTrace(err);
                 }
-              } else{
+              } else {
 
                 console.timeEnd('processRepositoryXmlDef');
                 callback(null);
@@ -137,20 +137,20 @@ try {
     logInfo("Getting XML def for : " + componentPath);
     var timestamp = Math.floor(Date.now() / 1000);
     var xmlDefMetaData = JSON.parse(localStorage.getItem("XMLDefMetaData"));
-    if (!xmlDefMetaData){
-          console.timeEnd('getXmlDef');
+    if (!xmlDefMetaData) {
+      console.timeEnd('getXmlDef');
       logInfo("getXmlDef Xml is null");
       return null;
-      
+
     }
     if (xmlDefMetaData.componentPath != componentPath || (xmlDefMetaData.timestamp + xmlDefinitionCacheTimeout) < timestamp) {
-        console.timeEnd('getXmlDef');
+      console.timeEnd('getXmlDef');
       logInfo("getXmlDef Xml def is outdated or from a different component");
       return null;
     }
     let xml = localStorage.getItem("XMLDefData");
-        console.timeEnd('getXmlDef');
-      logInfo("getXmlDef returning value from storage");
+    console.timeEnd('getXmlDef');
+    logInfo("getXmlDef returning value from storage");
     console.timeEnd('getXmlDef');
     return xml;
   };
@@ -233,7 +233,7 @@ try {
       window.console.log.apply(window.console, arguments);
     }
   };
-   this.logInfo = function() {
+  this.logInfo = function() {
     if (isLoggingInfo && window.console != undefined) {
       window.console.log.apply(window.console, arguments);
     }
@@ -767,37 +767,40 @@ Johann Burkard
       this.active = active;
       this.values = {};
     }
-    PerformanceMonitor.prototype.reset = function(){
+    PerformanceMonitor.prototype.reset = function() {
       this.values = {};
     }
-    PerformanceMonitor.prototype.start = function(task){
-      if(this.active){
+    PerformanceMonitor.prototype.start = function(task) {
+      if (this.active) {
 
-      let record = this.values[task];
-      if(_.isNil(record)){
-         record = {total:0,occurences:0};
-        this.values[task] = record;
-      }
-      record.start = new Date().getTime();
-     //  console.log('start',task,record.start);
-      }
-    }
-    PerformanceMonitor.prototype.cumul = function(task){
-      if (this.active){
         let record = this.values[task];
-          if(!!record && !!record.start){
-            let current = new Date().getTime() - record.start;
-            record.total += current;
-            record.occurences++;
-         //    console.log('cumul',task,record.start,record.total,current);
-          }
+        if (_.isNil(record)) {
+          record = {
+            total: 0,
+            occurences: 0
+          };
+          this.values[task] = record;
         }
+        record.start = new Date().getTime();
+        //  console.log('start',task,record.start);
+      }
     }
-    PerformanceMonitor.prototype.log = function(){
+    PerformanceMonitor.prototype.cumul = function(task) {
+      if (this.active) {
+        let record = this.values[task];
+        if (!!record && !!record.start) {
+          let current = new Date().getTime() - record.start;
+          record.total += current;
+          record.occurences++;
+          //    console.log('cumul',task,record.start,record.total,current);
+        }
+      }
+    }
+    PerformanceMonitor.prototype.log = function() {
       console.log('PerformanceMonitor :');
-      _.forEach(this.values,(record,task)=>{
+      _.forEach(this.values, (record, task) => {
         let average = record.total / record.occurences;
-        console.log('%s - total : %s, average : %s, occurences %s',task,record.total, average,record.occurences);
+        console.log('%s - total : %s, average : %s, occurences %s', task, record.total, average, record.occurences);
       })
     }
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -712,6 +712,21 @@ Johann Burkard
       return this;
     }
 
+
+
+    _.mixin({
+      'sortKeysBy': function(object, comparator) {
+
+        const keys = Object.keys(object)
+        const sortedKeys = _.sortBy(keys, comparator)
+
+        return _.fromPairs(
+          _.map(sortedKeys, key => [key, object[key]])
+        )
+
+      }
+    });
+
   })(jQuery);
 
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -714,8 +714,18 @@ Johann Burkard
       return this;
     }
 
+    $.fn.flash = function(options) {
+      let $this = $(this);
+      this.addClass("flash");
+      setTimeout(function() {
+        $this.removeClass("flash");
+      }, 3000);
+
+      return this;
+    }
 
 
+    // lodash mixin to sort an js object by keys
     _.mixin({
       'sortKeysBy': function(object, comparator) {
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -4,7 +4,7 @@ try {
 
   var isLoggingTrace = false;
   var isLoggingInfo = true;
-  var isLoggingDebug = true;
+  var isLoggingDebug = false;
   var xmlDefinitionCacheTimeout = 1200; // 20min
 
   // ----- Standard Javascript override -----

--- a/bda.common.js
+++ b/bda.common.js
@@ -437,9 +437,11 @@ try {
     return this;
   };
   $.fn.scrollTo = function() {
-    $('html, body').animate({
-      scrollTop: $(this).offset().top
-    }, 300);
+
+    $(this).get()[0].scrollIntoView({
+      behavior: "smooth"
+    });
+
   }
 
   $.fn.toCSV = function() {

--- a/bda.common.js
+++ b/bda.common.js
@@ -210,8 +210,8 @@ try {
   };
 
   this.logTrace = function() {
-    if (isLoggingTrace) {
-      logTrace.apply(this, arguments);
+    if (isLoggingTrace && window.console != undefined) {
+      console.log.apply(this, arguments);
     }
   };
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -438,7 +438,7 @@ try {
   };
   $.fn.scrollTo = function() {
     $('html, body').animate({
-      scrollTop: $(this).offset().top
+      scrollTop: $(this).position().top
     }, 300);
   }
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -526,6 +526,10 @@ try {
     }
   }
 
+  function getEvenOddClass(i) {
+    return (i % 2 === 0) ? 'even' : 'odd';
+  }
+
 
   /*
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -3,7 +3,8 @@
 try {
 
   var isLoggingTrace = false;
-  var isLoggingInfo = false;
+  var isLoggingInfo = true;
+  var isLoggingDebug = true;
   var xmlDefinitionCacheTimeout = 1200; // 20min
 
   // ----- Standard Javascript override -----
@@ -235,6 +236,11 @@ try {
   };
   this.logInfo = function() {
     if (isLoggingInfo && window.console != undefined) {
+      window.console.log.apply(window.console, arguments);
+    }
+  };
+  this.logDebug = function() {
+    if (isLoggingDebug && window.console != undefined) {
       window.console.log.apply(window.console, arguments);
     }
   };
@@ -807,6 +813,17 @@ Johann Burkard
     }
 
   })(jQuery);
+
+  function delayBy(func, delay) {
+    logTrace('delayBy', func, delay);
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        let res = func();
+        logTrace('delayBy resolve', res);
+        resolve(res);
+      }, delay);
+    })
+  }
 
 
 } catch (e) {

--- a/bda.common.js
+++ b/bda.common.js
@@ -77,6 +77,7 @@ try {
     },
 
     this.processRepositoryXmlDef = function(property, callback, componentPath) {
+      console.time('processRepositoryXmlDef');
       if (callback !== undefined) {
         // First check cache value if any
         if (_.isNil(componentPath)) {
@@ -86,8 +87,10 @@ try {
         if (rawXmlDef !== null) {
           logTrace("Getting XML def from cache");
           var xmlDoc = jQuery.parseXML(rawXmlDef);
-          if (callback !== undefined)
+          console.timeEnd('processRepositoryXmlDef');
+          if (callback !== undefined){
             callback($(xmlDoc));
+          }
         }
         // If no cache entry, fetch the XML def in ajax
         else {
@@ -109,14 +112,19 @@ try {
                   logTrace("XML def length : " + rawXmlDef.length);
                   var xmlDoc = jQuery.parseXML(rawXmlDef);
                   storeXmlDef(componentPath, rawXmlDef);
+                  console.timeEnd('processRepositoryXmlDef');
                   callback($(xmlDoc));
                 } catch (err) {
                   logTrace("Unable to parse XML def file !");
+                  console.timeEnd('processRepositoryXmlDef');
                   callback(null);
                   logTrace(err);
                 }
-              } else
+              } else{
+
+                console.timeEnd('processRepositoryXmlDef');
                 callback(null);
+              }
             },
           });
         }
@@ -124,16 +132,21 @@ try {
     };
 
   this.getXmlDef = function(componentPath) {
+    console.time('processRepositoryXmlDef');
     logTrace("Getting XML def for : " + componentPath);
     var timestamp = Math.floor(Date.now() / 1000);
     var xmlDefMetaData = JSON.parse(localStorage.getItem("XMLDefMetaData"));
     if (!xmlDefMetaData)
+        console.timeEnd('processRepositoryXmlDef');
       return null;
     if (xmlDefMetaData.componentPath != componentPath || (xmlDefMetaData.timestamp + xmlDefinitionCacheTimeout) < timestamp) {
+        console.timeEnd('processRepositoryXmlDef');
       logTrace("Xml def is outdated or from a different component");
       return null;
     }
-    return localStorage.getItem("XMLDefData");
+    let xml = localStorage.getItem("XMLDefData");
+    console.timeEnd('processRepositoryXmlDef');
+    return xml;
   };
 
   this.storeXmlDef = function(componentPath, rawXML) {

--- a/bda.common.js
+++ b/bda.common.js
@@ -752,6 +752,42 @@ Johann Burkard
       }
     });
 
+    PerformanceMonitor = function(active){
+      this.active = active;
+      this.values = {};
+    }
+    PerformanceMonitor.prototype.reset = function(){
+      this.values = {};
+    }
+    PerformanceMonitor.prototype.start = function(task){
+      if(this.active){
+
+      let record = this.values[task];
+      if(_.isNil(record)){
+         record = {total:0};
+        this.values[task] = record;
+      }
+      record.start = new Date().getTime();
+     //  console.log('start',task,record.start);
+      }
+    }
+    PerformanceMonitor.prototype.cumul = function(task){
+      if (this.active){
+        let record = this.values[task];
+          if(!!record && !!record.start){
+            let current = new Date().getTime() - record.start;
+            record.total += current;
+         //    console.log('cumul',task,record.start,record.total,current);
+          }
+        }
+    }
+    PerformanceMonitor.prototype.log = function(){
+      console.log('PerformanceMonitor :');
+      _.forEach(this.values,(record,task)=>{
+        console.log('%s - %s',task,record.total);
+      })
+    }
+
   })(jQuery);
 
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -438,7 +438,7 @@ try {
   };
   $.fn.scrollTo = function() {
     $('html, body').animate({
-      scrollTop: $(this).position().top
+      scrollTop: $(this).offset().top
     }, 300);
   }
 

--- a/bda.common.js
+++ b/bda.common.js
@@ -436,6 +436,11 @@ try {
     this.css('height', value + 'px');
     return this;
   };
+  $.fn.scrollTo = function() {
+    $('html, body').animate({
+      scrollTop: $(this).offset().top
+    }, 300);
+  }
 
   $.fn.toCSV = function() {
     var data = [];

--- a/bda.common.js
+++ b/bda.common.js
@@ -76,10 +76,13 @@ try {
       return tags;
     },
 
-    this.processRepositoryXmlDef = function(property, callback) {
+    this.processRepositoryXmlDef = function(property, callback, componentPath) {
       if (callback !== undefined) {
         // First check cache value if any
-        var rawXmlDef = getXmlDef(getCurrentComponentPath());
+        if (_.isNil(componentPath)) {
+          componentPath = getCurrentComponentPath();
+        }
+        var rawXmlDef = getXmlDef(componentPath);
         if (rawXmlDef !== null) {
           logTrace("Getting XML def from cache");
           var xmlDoc = jQuery.parseXML(rawXmlDef);
@@ -88,7 +91,7 @@ try {
         }
         // If no cache entry, fetch the XML def in ajax
         else {
-          var url = location.protocol + '//' + location.host + location.pathname + "?propertyName=" + property;
+          var url = location.protocol + '//' + location.host + '/dyn/admin/nucleus' + componentPath + "?propertyName=" + property;
           logTrace(url);
           jQuery.ajax({
             url: url,
@@ -105,7 +108,7 @@ try {
                 try {
                   logTrace("XML def length : " + rawXmlDef.length);
                   var xmlDoc = jQuery.parseXML(rawXmlDef);
-                  storeXmlDef(getCurrentComponentPath(), rawXmlDef);
+                  storeXmlDef(componentPath, rawXmlDef);
                   callback($(xmlDoc));
                 } catch (err) {
                   logTrace("Unable to parse XML def file !");

--- a/bda.css
+++ b/bda.css
@@ -804,14 +804,37 @@ table.tablesorter tr.alt-row:hover td {
     display: none;
 }
 
-
 .show-long .short {
     display: none;
 }
 
+.expand, .collapse{
+  display: none;
+}
+
+.toggable.show-short .expand {
+    display: block;
+}
+
+.toggable.show-long .collapse {
+    display: block;
+}
+
 td.property .actions{
   float:right;
-  margin-left: 5px;
+  margin-left: 3px;
+}
+
+.actions i{
+  float:right;
+  margin-left: 2px;
+}
+
+td.property .actions .passive-loading-icon{
+  display: none;
+}
+td.property.loading .actions .passive-loading-icon{
+  display: block;
 }
 
 /* DASH */

--- a/bda.css
+++ b/bda.css
@@ -800,17 +800,44 @@ table.tablesorter tr.alt-row:hover td {
   margin: 0;
 }
 
+.action{
+cursor: pointer;
+}
+
 .clickable_property {
   text-decoration: underline;
   cursor: pointer;
 }
 
-.show-short .long {
-    display: none;
+.long, .short, .edit{
+  display: none;
 }
 
-.show-long .short {
-    display: none;
+.show-edit .start-edit,.derived .start-edit,.rdonly .start-edit {
+  display: none;
+}
+
+.show-edit.show-short .short,.show-edit.show-long .long, .show-edit .propertyValue{
+  display: none ;
+}
+
+.show-edit .edit {
+  display: block;
+}
+.show-edit .actions{
+  display: none;
+}
+
+.property .value-elem{
+  display: inline-flex;
+}
+
+.property .edit input{
+  width: 100%;
+  height: 100%;
+  border:0;
+  margin:0;
+  padding: 0;
 }
 
 .expand, .collapse{

--- a/bda.css
+++ b/bda.css
@@ -808,6 +808,12 @@ table.tablesorter tr.alt-row:hover td {
 .show-long .short {
     display: none;
 }
+
+td.property .actions{
+  float:right;
+  margin-left: 5px;
+}
+
 /* DASH */
 .modal-dialog.modal-lg {
   width: 60%;

--- a/bda.css
+++ b/bda.css
@@ -875,6 +875,10 @@ td.property .actions {
   margin-left: 4px;
 }
 
+.default {
+  color: #777;
+}
+
 td.property .actions .passive-loading-icon {
   display: none;
 }

--- a/bda.css
+++ b/bda.css
@@ -796,6 +796,10 @@ table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td 
   cursor: pointer;
 }
 
+.newpage{
+  font-style: italic;
+}
+
 .show-edit .start-edit, .derived .start-edit, .rdonly .start-edit {
   display: none;
 }

--- a/bda.css
+++ b/bda.css
@@ -766,6 +766,7 @@ table.tablesorter tr.alt-row:hover td {
   font-size: 13px;
   padding: 10px;
   z-index: 100;
+  background-color: white;
 }
 
 #widget i {
@@ -1115,6 +1116,11 @@ button.cache {
 .sticky-top {
   position: fixed;
   top: 0;
+}
+
+.sticky-top-100 {
+  position: fixed;
+  top: 100;
 }
 
 .scroller {

--- a/bda.css
+++ b/bda.css
@@ -812,10 +812,10 @@ table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td 
   display: none;
 }
 
-.property .edit input {
+.property .edit .inline-input {
   width: 100%;
   height: 100%;
-  border: 0;
+ /* border: 0;*/
   margin: 0;
   padding: 0;
 }

--- a/bda.css
+++ b/bda.css
@@ -911,6 +911,12 @@ table.table {
   opacity: 1;
 }
 
+
+
+#dashModal  {
+  font-size: 0.9em;
+}
+
 .printItem {
   margin-top: 15px;
 }
@@ -985,6 +991,7 @@ kbd {
 #dashTips {
   margin-top: 10px;
   margin-bottom: 5px;
+  font-size: 0.7em;
 }
 
 .footer-right {

--- a/bda.css
+++ b/bda.css
@@ -800,6 +800,14 @@ table.tablesorter tr.alt-row:hover td {
   cursor: pointer;
 }
 
+.show-short .long {
+    display: none;
+}
+
+
+.show-long .short {
+    display: none;
+}
 /* DASH */
 .modal-dialog.modal-lg {
   width: 60%;

--- a/bda.css
+++ b/bda.css
@@ -1,4 +1,4 @@
-.hidden{
+.hidden {
   display: none;
 }
 
@@ -26,17 +26,13 @@ a {
   margin-bottom: 10px;
 }
 
-.select2-container.bda-repository .select2-choices .select2-search-field input,
-.select2-container.bda-repository .select2-choice,
-.select2-container.bda-repository .select2-choices {
+.select2-container.bda-repository .select2-choices .select2-search-field input, .select2-container.bda-repository .select2-choice, .select2-container.bda-repository .select2-choices {
   font-family: "Arial";
   font-size: 13px;
   color: black;
 }
 
-.bda-repository .select2-chosen,
-.bda-repository .select2-choice > span:first-child,
-.select2-container.bda-repository .select2-choices .select2-search-field input {
+.bda-repository .select2-chosen, .bda-repository .select2-choice > span:first-child, .select2-container.bda-repository .select2-choices .select2-search-field input {
   padding: 4px 6px;
 }
 
@@ -48,8 +44,7 @@ a {
   height: 24px;
 }
 
-.select2-container.bda-repository .select2-choice .select2-arrow b,
-.select2-container.bda-repository .select2-choice div b {
+.select2-container.bda-repository .select2-choice .select2-arrow b, .select2-container.bda-repository .select2-choice div b {
   background-position: 0 0;
 }
 
@@ -115,7 +110,7 @@ a {
   background-color: green;
 }
 
-.item-line.rdonly td{
+.item-line.rdonly td {
   color: #888;
 }
 
@@ -129,8 +124,7 @@ a {
   display: none;
 }
 
-.dataTable td,
-.dataTable th {
+.dataTable td, .dataTable th {
   padding: 3px;
 }
 
@@ -479,9 +473,7 @@ a {
   cursor: pointer;
 }
 
-.bda-button label,
-.bda-button input,
-.bda-button button {
+.bda-button label, .bda-button input, .bda-button button {
   vertical-align: middle;
 }
 
@@ -563,8 +555,7 @@ a {
   line-height: 16px;
 }
 
-.favLink a,
-.logdebug {
+.favLink a, .logdebug {
   color: white;
   text-decoration: none;
 }
@@ -601,12 +592,12 @@ a {
   text-align: left;
 }
 
-.favDelete, .favEdit{
+.favDelete, .favEdit {
   cursor: pointer;
   display: inline-block;
 }
 
-.favEdit{
+.favEdit {
   margin-left: 5px;
 }
 
@@ -656,8 +647,7 @@ a {
   border: 1px solid #ccc;
 }
 
-#sqlResult td,
-#sqlResult th {
+#sqlResult td, #sqlResult th {
   text-align: center;
   border-right: 1px solid #ccc;
   background: none;
@@ -678,8 +668,7 @@ table.tablesorter tbody tr.alt-row td {
   color: #3d3d3d;
 }
 
-table.tablesorter tr.normal-row:hover td,
-table.tablesorter tr.alt-row:hover td {
+table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td {
   background-color: #eee;
 }
 
@@ -714,7 +703,7 @@ table.tablesorter tr.alt-row:hover td {
   font-size: 14px;
 }
 
-.popup_title, .popup_title_update{
+.popup_title, .popup_title_update {
   margin-top: 0;
   display: none;
 }
@@ -732,8 +721,7 @@ table.tablesorter tr.alt-row:hover td {
   overflow: auto;
 }
 
-.close,
-#submitComponent {
+.close, #submitComponent {
   float: right;
   color: black;
 }
@@ -743,14 +731,12 @@ table.tablesorter tr.alt-row:hover td {
   color: black;
 }
 
-#methods,
-#vars {
+#methods, #vars {
   float: left;
   width: 50%;
 }
 
-#methods li,
-#vars li {
+#methods li, #vars li {
   list-style-position: inside;
   white-space: nowrap;
   overflow: hidden;
@@ -800,8 +786,8 @@ table.tablesorter tr.alt-row:hover td {
   margin: 0;
 }
 
-.action{
-cursor: pointer;
+.action {
+  cursor: pointer;
 }
 
 .clickable_property {
@@ -809,64 +795,80 @@ cursor: pointer;
   cursor: pointer;
 }
 
-.long, .short, .edit{
+.show-edit .start-edit, .derived .start-edit, .rdonly .start-edit {
   display: none;
 }
 
-.show-edit .start-edit,.derived .start-edit,.rdonly .start-edit {
+.show-edit .actions {
   display: none;
 }
 
-.show-edit.show-short .short,.show-edit.show-long .long, .show-edit .propertyValue{
-  display: none ;
+.property .value-elem {
+  display: inline-block;
+  flex: auto;
 }
 
-.show-edit .edit {
-  display: block;
-}
-.show-edit .actions{
+.show-short .value-elem.long, .show-long .value-elem.short, .show-edit .propertyValue {
   display: none;
 }
 
-.property .value-elem{
-  display: inline-flex;
-}
-
-.property .edit input{
+.property .edit input {
   width: 100%;
   height: 100%;
-  border:0;
-  margin:0;
+  border: 0;
+  margin: 0;
   padding: 0;
 }
 
-.expand, .collapse{
+.property .edit {
+  display: none;
+}
+
+.property.show-edit .edit {
+  display: inline-block;
+}
+
+.expand, .collapse {
   display: none;
 }
 
 .toggable.show-short .expand {
-    display: block;
+  display: inline-block;
 }
 
 .toggable.show-long .collapse {
-    display: block;
+  display: inline-block;
 }
 
-td.property .actions{
-  float:right;
-  margin-left: 3px;
+.start-edit {
+  display: inline-block;
 }
 
-.actions i{
-  float:right;
-  margin-left: 2px;
+td.property {
+  white-space: nowrap;
 }
 
-td.property .actions .passive-loading-icon{
+td.property .actions {
+  display: inline-block;
+  margin-left: 8px;
+  float: right;
+}
+
+.flex-wrapper {
+  display: flex;
+  flex-direction: row;
+}
+
+.actions i {
+  margin-left: 4px;
+}
+
+td.property .actions .passive-loading-icon {
   display: none;
 }
-td.property.loading .actions .passive-loading-icon{
-  display: block;
+
+td.property.loading .actions .passive-loading-icon {
+  display: table-cell;
 }
 
 /* DASH */
@@ -975,14 +977,11 @@ table.table {
   opacity: 0.8;
 }
 
-#dashModal .alert button.btn:hover,
-#dashModal .alert button.btn:focus {
+#dashModal .alert button.btn:hover, #dashModal .alert button.btn:focus {
   opacity: 1;
 }
 
-
-
-#dashModal  {
+#dashModal {
   font-size: 0.9em;
 }
 
@@ -1006,7 +1005,7 @@ table.table {
   padding-top: 2px;
 }
 
-.dash_screen_line{
+.dash_screen_line {
   font-size: 14px;
 }
 
@@ -1014,7 +1013,7 @@ table.table {
   display: none;
 }
 
-.alert-danger .dash_help_line{
+.alert-danger .dash_help_line {
   display: block;
 }
 
@@ -1083,7 +1082,7 @@ kbd {
   border: 1px solid transparent;
 }
 
-.dash_return_line{
+.dash_return_line {
   margin-top: 0.5em;
 }
 
@@ -1097,13 +1096,11 @@ table.cache {
   cursor: pointer;
 }
 
-.cache td,
-.cache th {
+.cache td, .cache th {
   padding: 6px;
 }
 
-.cache td,
-.cache th {
+.cache td, .cache th {
   border: 1px solid #ddd;
 }
 
@@ -1127,13 +1124,11 @@ button.cache {
   overflow: hidden;
 }
 
-.fixed_headers th,
-.fixed_headers td {
+.fixed_headers th, .fixed_headers td {
   width: 4%;
 }
 
-.fixed_headers.oldDynamo th,
-.fixed_headers.oldDynamo td {
+.fixed_headers.oldDynamo th, .fixed_headers.oldDynamo td {
   width: 5.3%;
 }
 
@@ -1184,15 +1179,13 @@ button.cache {
 
 /* XML DEF */
 #xmlDefAsTable {
-  margin-top: 15px;
-  /* for whatever reason on some pages
-  the whole section is inside an <a> tag
-  on native dyn/admin : need to reset color*/
+  margin-top: 15px;  /* for whatever reason on some pages
+        the whole section is inside an <a> tag
+        on native dyn/admin : need to reset color*/
   color: black;
 }
 
-.item-descriptor-heading,
-.table-def {
+.item-descriptor-heading, .table-def {
   text-transform: capitalize;
   cursor: pointer;
 }
@@ -1241,7 +1234,7 @@ button.cache {
   overflow-x: hidden;
 }
 
-#xmlDefQuickNav .btn.sorted{
+#xmlDefQuickNav .btn.sorted {
   background-color: #dff0d8;
 }
 
@@ -1288,18 +1281,15 @@ ol.itemDescAttributes {
   text-transform: none;
 }
 
-.property-type,
-.enum,
-.derivation {
+.property-type, .enum, .derivation {
   text-decoration: underline;
 }
 
-.data-type,
-.component-data-type {
+.data-type, .component-data-type {
   text-transform: capitalize;
 }
 
-.row.subtableHeader .col-lg-05{
+.row.subtableHeader .col-lg-05 {
   padding-left: 0;
   padding-right: 0;
   font-size: 8px;
@@ -1314,7 +1304,7 @@ ol.itemDescAttributes {
   padding-left: 10px;
 }
 
-#xmlDefAsTable .popover{
+#xmlDefAsTable .popover {
   max-width: inherit;
   width: 600px;
   width: intrinsic;           /* Safari/WebKit uses a non-standard name */
@@ -1338,10 +1328,7 @@ ol.itemDescAttributes {
 /** extend grid system**/
 
 /** 0.5 **/
-.twbs .col-xs-05,
-.twbs .col-sm-05,
-.twbs .col-md-05,
-.twbs .col-lg-05 {
+.twbs .col-xs-05, .twbs .col-sm-05, .twbs .col-md-05, .twbs .col-lg-05 {
   width: 4.166666665%;
   position: relative;
   min-height: 1px;
@@ -1349,17 +1336,18 @@ ol.itemDescAttributes {
   padding-right: 15px;
   float: left;
 }
+
 .notifyjs-bootstrap-base {
   font-size: 12px;
 }
 
 .legend {
-  display : inline-block;
-  color : white;
-  border-radius : 5px;
-  font-size : 11px;
-  padding : 3px;
-  margin : 5px;
+  display: inline-block;
+  color: white;
+  border-radius: 5px;
+  font-size: 11px;
+  padding: 3px;
+  margin: 5px;
 }
 
 #treePopup {
@@ -1369,28 +1357,28 @@ ol.itemDescAttributes {
 }
 
 .flexContainer {
-  display:flex;
+  display: flex;
   height: 100%;
 }
 
 #treeInfo {
-  display:none;
-  float:left;
+  display: none;
+  float: left;
 }
 
-#treeContainer  {
+#treeContainer {
   height: 100%;
-  flex : 1;
+  flex: 1;
 }
 
-.showActorXml{
+.showActorXml {
   margin-left: 10px;
 }
 
 .show-xml-close {
   display: none;
   }
-.bottom-panel{
+.bottom-panel {
   margin-top: 10px;
 }
 .open .show-xml-close {

--- a/bda.css
+++ b/bda.css
@@ -111,7 +111,8 @@ a {
 }
 
 .item-line.rdonly td {
-  color: #888;
+  /*color: #888;*/
+  font-style: italic;
 }
 
 .copyLink {

--- a/bda.css
+++ b/bda.css
@@ -724,6 +724,7 @@ table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td 
 .close, #submitComponent {
   float: right;
   color: black;
+  cursor: pointer;
 }
 
 .fav-submit-button {
@@ -743,14 +744,14 @@ table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td 
   text-overflow: ellipsis;
 }
 
-#speedbar {
+.speedbar {
   float: right;
   width: 210px;
   margin-right: 100px;
   margin-top: 100px;
 }
 
-#speedbar #widget {
+.speedbar .widget {
   width: 240px;
   border: 1px solid #999;
   font-size: 13px;
@@ -759,22 +760,22 @@ table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td 
   background-color: white;
 }
 
-#widget i {
+.widget i {
   font-size: 11px;
 }
 
-#widget ul {
+.widget ul {
   list-style-type: none;
   padding-inline-start: 0px;
   margin-block-end: 0;
   margin-block-start: 0;
 }
 
-#widget p {
+.widget p {
   margin-top: 0;
 }
 
-#widget li {
+.widget li {
   margin-top: 5px;
 }
 

--- a/bda.css
+++ b/bda.css
@@ -26,34 +26,34 @@ a {
   margin-bottom: 10px;
 }
 
-.select2-container .select2-choices .select2-search-field input,
-.select2-container .select2-choice,
-.select2-container .select2-choices {
+.select2-container.bda-repository .select2-choices .select2-search-field input,
+.select2-container.bda-repository .select2-choice,
+.select2-container.bda-repository .select2-choices {
   font-family: "Arial";
   font-size: 13px;
   color: black;
 }
 
-.select2-chosen,
-.select2-choice > span:first-child,
-.select2-container .select2-choices .select2-search-field input {
+.bda-repository .select2-chosen,
+.bda-repository .select2-choice > span:first-child,
+.select2-container.bda-repository .select2-choices .select2-search-field input {
   padding: 4px 6px;
 }
 
-#select2-drop {
+#select2-drop.bda-repository {
   font-size: 13px;
 }
 
-.select2-container .select2-choice {
+.select2-container.bda-repository .select2-choice {
   height: 24px;
 }
 
-.select2-container .select2-choice .select2-arrow b,
-.select2-container .select2-choice div b {
+.select2-container.bda-repository .select2-choice .select2-arrow b,
+.select2-container.bda-repository .select2-choice div b {
   background-position: 0 0;
 }
 
-.select2-results {
+.bda-repository .select2-results {
   max-height: 220px;
 }
 

--- a/bda.css
+++ b/bda.css
@@ -849,7 +849,6 @@ table.tablesorter tr.alt-row:hover td {
 }
 
 .fullscreen #dashScreen {
-  margin-bottom: 0;
   height: 100%;
   max-height: 100%;
 }
@@ -1293,6 +1292,9 @@ ol.itemDescAttributes {
 
 .show-xml-close {
   display: none;
+  }
+.bottom-panel{
+  margin-top: 10px;
 }
 .open .show-xml-close {
   display: block;

--- a/bda.css
+++ b/bda.css
@@ -808,7 +808,7 @@ table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td 
   flex: auto;
 }
 
-.show-short .value-elem.long, .show-long .value-elem.short, .show-edit .propertyValue {
+.show-short .value-elem.long, .show-long .value-elem.short, .show-edit .propertyValue,.show-edit .value-elem {
   display: none;
 }
 
@@ -822,10 +822,18 @@ table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td 
 
 .property .edit {
   display: none;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 .property.show-edit .edit {
   display: inline-block;
+}
+
+.property.show-edit .actions {
+  display: none;
 }
 
 .expand, .collapse {
@@ -1180,8 +1188,8 @@ button.cache {
 /* XML DEF */
 #xmlDefAsTable {
   margin-top: 15px;  /* for whatever reason on some pages
-        the whole section is inside an <a> tag
-        on native dyn/admin : need to reset color*/
+          the whole section is inside an <a> tag
+          on native dyn/admin : need to reset color*/
   color: black;
 }
 

--- a/bda.css
+++ b/bda.css
@@ -1425,3 +1425,4 @@ ol.itemDescAttributes {
   animation-iteration-count: 1;
   animation-timing-function: ease-in-out;
 }
+

--- a/bda.css
+++ b/bda.css
@@ -64,6 +64,15 @@ a {
   margin-top: 10px;
 }
 
+.rqlResultContainer .progress{
+  width: 600px;
+}
+
+.rqlResultContainer .progress-bar{
+  animation: none;
+  min-width: 10px;
+}
+
 #RQLLog {
   overflow-x: scroll;
   overflow-x: hidden;

--- a/bda.css
+++ b/bda.css
@@ -882,10 +882,13 @@ td.property.loading .actions .passive-loading-icon {
 /* DASH */
 .modal-dialog.modal-lg {
   width: 60%;
+  padding-top:10px;
 }
 
 .fullscreen .modal-dialog.modal-lg {
-  width: 95%;
+  width: 100%;
+  padding:10 ;
+
 }
 
 #dashModal .modal-content {

--- a/bda.css
+++ b/bda.css
@@ -115,6 +115,10 @@ a {
   background-color: green;
 }
 
+.item-line.rdonly td{
+  color: #888;
+}
+
 .copyLink {
   text-decoration: none;
   color: #00214a;

--- a/bda.css
+++ b/bda.css
@@ -796,7 +796,7 @@ table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td 
   cursor: pointer;
 }
 
-.newpage{
+.newpage {
   font-style: italic;
 }
 
@@ -813,14 +813,13 @@ table.tablesorter tr.normal-row:hover td, table.tablesorter tr.alt-row:hover td 
   flex: auto;
 }
 
-.show-short .value-elem.long, .show-long .value-elem.short, .show-edit .propertyValue,.show-edit .value-elem {
+.show-short .value-elem.long, .show-long .value-elem.short, .show-edit .propertyValue, .show-edit .value-elem {
   display: none;
 }
 
 .property .edit .inline-input {
   width: 100%;
-  height: 100%;
- /* border: 0;*/
+  height: 100%; /* border: 0;*/
   margin: 0;
   padding: 0;
 }
@@ -887,13 +886,12 @@ td.property.loading .actions .passive-loading-icon {
 /* DASH */
 .modal-dialog.modal-lg {
   width: 60%;
-  padding-top:10px;
+  padding-top: 10px;
 }
 
 .fullscreen .modal-dialog.modal-lg {
   width: 100%;
-  padding:10 ;
-
+  padding: 10;
 }
 
 #dashModal .modal-content {
@@ -1196,8 +1194,8 @@ button.cache {
 /* XML DEF */
 #xmlDefAsTable {
   margin-top: 15px;  /* for whatever reason on some pages
-          the whole section is inside an <a> tag
-          on native dyn/admin : need to reset color*/
+            the whole section is inside an <a> tag
+            on native dyn/admin : need to reset color*/
   color: black;
 }
 
@@ -1402,4 +1400,24 @@ ol.itemDescAttributes {
 }
 .open .show-xml-open {
   display: none;
+
+
+
+@keyframes flash {
+  0% {
+    background-color: inherit;
+  }
+
+  10% {
+    background-color: yellow;
+  }
+
+}
+
+.flash {
+ 
+  animation-name: flash;
+  animation-duration: 3000ms;
+  animation-iteration-count: 1;
+  animation-timing-function: ease-in-out;
 }

--- a/bda.css
+++ b/bda.css
@@ -937,6 +937,18 @@ table.table {
   padding-top: 2px;
 }
 
+.dash_screen_line{
+  font-size: 14px;
+}
+
+.dash_help_line {
+  display: none;
+}
+
+.alert-danger .dash_help_line{
+  display: block;
+}
+
 kbd {
   padding: 2px 4px;
   font-size: 90%;

--- a/bda.css
+++ b/bda.css
@@ -26,6 +26,10 @@ a {
   margin-bottom: 10px;
 }
 
+#resultToolbar button{
+  margin-right: 3px;
+}
+
 .select2-container.bda-repository .select2-choices .select2-search-field input, .select2-container.bda-repository .select2-choice, .select2-container.bda-repository .select2-choices {
   font-family: "Arial";
   font-size: 13px;

--- a/bda.css
+++ b/bda.css
@@ -1022,6 +1022,10 @@ kbd {
   border: 1px solid transparent;
 }
 
+.dash_return_line{
+  margin-top: 0.5em;
+}
+
 /** CACHE STATS **/
 table.cache {
   border-spacing: 0;

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -403,30 +403,8 @@ jQuery(document).ready(function() {
               params.itemDesc,
               params.id,
               params.repo,
-              function($xmlDoc, head) {
-                try {
-                  var res = "";
-                  var items = []
-                  if (!isNull($xmlDoc)) {
-                    var $itemXml;
-                    $xmlDoc.find('add-item').each(function() {
-                      $itemXml = $(this);
-                      // items.push(convertAddItemToPlainObject($itemXml));
-                      items.push($itemXml.outerHTML());
-                    })
-                    callback({
-                      items: items,
-                      head: head
-                    });
-                  } else {
-                    throw {
-                      name: "Not Found",
-                      message: "No value"
-                    }
-                  }
-                } catch (e) {
-                  errCallback(e);
-                }
+              function(result) {
+                $().getBdaRepository().parseXhrResult(result, params.repo, callback);
               },
               function(jqXHR, textStatus, errorThrown) {
                 errCallback({
@@ -436,7 +414,7 @@ jQuery(document).ready(function() {
               }
             );
           },
-          responseToString: (params, retval, cb) => BDA_DASH.displayRqlResult(params.repo, retval, cb)
+          responseToString: (params, retval, cb) => BDA_DASH.displayRqlResult(retval, cb)
         },
 
         //print @OR order p92133231
@@ -463,29 +441,8 @@ jQuery(document).ready(function() {
               params.itemDesc,
               params.query,
               params.repo,
-              function($xmlDoc, head) {
-                try {
-                  var res = "";
-                  var items = []
-                  if (!isNull($xmlDoc)) {
-                    var $itemXml;
-                    $xmlDoc.find('add-item').each(function() {
-                      $itemXml = $(this);
-                      items.push($itemXml.outerHTML());
-                    })
-                    callback({
-                      items: items,
-                      head: head
-                    });
-                  } else {
-                    throw {
-                      name: "Not Found",
-                      message: "No value"
-                    }
-                  }
-                } catch (e) {
-                  errCallback(e);
-                }
+              function(result) {
+                $().getBdaRepository().parseXhrResult(result, params.repo, callback);
               },
               function(jqXHR, textStatus, errorThrown) {
                 errCallback({
@@ -495,7 +452,7 @@ jQuery(document).ready(function() {
               }
             );
           },
-          responseToString: (params, retval, cb) => BDA_DASH.displayRqlResult(params.repo, retval, cb)
+          responseToString: (params, retval, cb) => BDA_DASH.displayRqlResult(retval, cb)
         },
 
 
@@ -568,28 +525,8 @@ jQuery(document).ready(function() {
               BDA_DASH.settings.domain,
               xmlText,
               repo,
-              function($xmlDoc, head) {
-                try {
-                  if (!isNull($xmlDoc)) {
-                    var $itemXml;
-                    var items = [];
-                    $xmlDoc.find('add-item').each(function() {
-                      $itemXml = $(this);
-                      items.push($itemXml.outerHTML());
-                    })
-                    callback({
-                      items: items,
-                      head: head
-                    });
-                  } else {
-                    throw {
-                      name: "Not Found",
-                      message: "No value"
-                    }
-                  }
-                } catch (e) {
-                  errCallback(e);
-                }
+              function(result) {
+                $().getBdaRepository().parseXhrResult(result, params.repo, callback);
               },
               function(jqXHR, textStatus, errorThrown) {
                 errCallback({
@@ -600,15 +537,8 @@ jQuery(document).ready(function() {
             );
 
           },
-          responseToString: (params, retval, cb) => {
-            let repo;
-            if (_.isNil(params.componentProperty)) {
-              repo = params.repo
-            } else {
-              repo = params.componentProperty.path;
-            }
-            BDA_DASH.displayRqlResult(repo, retval, cb);
-          }
+          responseToString: (params, retval, cb) => BDA_DASH.displayRqlResult(retval, cb)
+
 
         },
 
@@ -1752,7 +1682,7 @@ jQuery(document).ready(function() {
       handleOutput: function(cmd, params, result, textResult, level, jqueryResult) {
 
         //save the result
-        logTrace('handleOutput ' + textResult);
+        logTrace('handleOutput ' + textResult, jqueryResult);
         logTrace(params);
         if (!isNull(result) && !isNull(params) && !isNull(params.output)) {
           BDA_DASH.saveOutput(result, params.output);
@@ -2288,30 +2218,11 @@ jQuery(document).ready(function() {
         }
       },
 
-      displayRqlResult: function(repo, retval, cb) {
-        processRepositoryXmlDef(
-          "definitionFiles",
-          ($xmlDef) => {
-            console.log('xmlDef: ', $xmlDef);
-            var $res = $('<div></div>');
 
-
-            BDA_REPOSITORY.showXMLAsTab(retval.items.join(''), $xmlDef, $res, false,
-              function() {
-                var $elm = $(this);
-                console.log('click on loadable', $elm);
-                var id = $elm.attr("data-id");
-                var itemDesc = $elm.attr("data-descriptor");
-                var query = "print {0} {1} {2}".format(repo, itemDesc, id);
-                console.log('query %s', query);
-                BDA_DASH.handleInput(query);
-              });
-            //  $res.prepend($('<div></div>').text(retval.head));
-            // res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
-            cb('', $res);
-          },
-          repo
-        );
+      displayRqlResult: function(result, cb) {
+        var $res = $('<div></div>');
+        $().getBdaRepository().renderResultSection(result.items, result.repository, $res);
+        cb(result.logs, $res);
       },
 
       updateProgress: function() {

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -5,6 +5,7 @@ jQuery(document).ready(function() {
 
     var BDA;
     var BDA_STORAGE;
+    var BDA_REPOSITORY;
     var BDA_DASH = {
 
       devMode: false,
@@ -432,13 +433,25 @@ jQuery(document).ready(function() {
               }
             );
           },
-          responseToString: function(params, retval) {
-            var res = "";
-            for (var i = 0; i < retval.length; i++) {
-              var item = retval[i];
-              res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
-            }
-            return res;
+          responseToString: function(params, retval, cb) {
+
+            processRepositoryXmlDef(
+              "definitionFiles",
+              ($xmlDef) => {
+
+                var $res = $('<div></div>');
+                for (var i = 0; i < retval.length; i++) {
+                  var item = retval[i];
+                  BDA_REPOSITORY.showXMLAsTab(item, $xmlDef, $res, false);
+                  // res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
+                }
+                cb($res.html());
+              },
+              params.repo
+            );
+
+
+            // return res;
           }
         },
 
@@ -610,6 +623,9 @@ jQuery(document).ready(function() {
             for (var i = 0; i < retval.length; i++) {
               var item = retval[i];
               res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
+
+
+              //                res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
             }
             return res;
           }
@@ -1717,10 +1733,14 @@ jQuery(document).ready(function() {
                 if (isNull(fct.responseToString)) {
                   textResult = JSON.stringify(result);
                 } else {
-                  textResult = fct.responseToString(parsedParams, result);
+                  textResult = fct.responseToString(parsedParams, result, (asyncRes) => {
+                    BDA_DASH.handleOutput(stringCmd, parsedParams, result, asyncRes, "success");
+                  });
                 }
               }
-              BDA_DASH.handleOutput(stringCmd, parsedParams, result, textResult, "success");
+              if (!_.isNil(textResult)) {
+                BDA_DASH.handleOutput(stringCmd, parsedParams, result, textResult, "success");
+              }
             },
             function(err) {
               BDA_DASH.handleError(stringCmd, err);
@@ -2333,6 +2353,7 @@ jQuery(document).ready(function() {
       logTrace('Init plugin {0}'.format('DASH'));
       BDA = pBDA;
       BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
+      BDA_REPOSITORY = $.fn.getBdaRepository();
 
 
       if ($().bdaAddMenuElem) {

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -23,7 +23,7 @@ jQuery(document).ready(function() {
       $footer: null,
 
       modalHeight: 200,
-      modalHeightRatio: 0.93,
+      modalHeightRatio: 0.98,
       //
       initialized: false,
 

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -412,7 +412,8 @@ jQuery(document).ready(function() {
                     var $itemXml;
                     $xmlDoc.find('add-item').each(function() {
                       $itemXml = $(this);
-                      items.push(convertAddItemToPlainObject($itemXml));
+                      // items.push(convertAddItemToPlainObject($itemXml));
+                      items.push($itemXml.outerHTML());
                     })
                     callback(items);
                   } else {
@@ -438,13 +439,11 @@ jQuery(document).ready(function() {
             processRepositoryXmlDef(
               "definitionFiles",
               ($xmlDef) => {
-
+                console.log('xmlDef: ', $xmlDef);
                 var $res = $('<div></div>');
-                for (var i = 0; i < retval.length; i++) {
-                  var item = retval[i];
-                  BDA_REPOSITORY.showXMLAsTab(item, $xmlDef, $res, false);
-                  // res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
-                }
+
+                BDA_REPOSITORY.showXMLAsTab(retval.join(''), $xmlDef, $res, false);
+                // res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
                 cb($res.html());
               },
               params.repo

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -1490,37 +1490,7 @@ jQuery(document).ready(function() {
           });
 
 
-          $('.dash-autocomplete').textcomplete([{ // tech companies
-            id: 'commands',
-            match: /\b(\w{1,})$/, //1 letter or more
-            search: function(term, callback) {
-              logTrace('search %s', term)
-              BDA_DASH.suggestionEngine.search(term, callback, callback);
-            },
-            index: 1,
-            cache: true,
-            replace: function(data) {
-              logTrace('replace %s', data.value);
-              return data.value + ' ';
-            },
-            template: function(data, term) {
-              var pattern = data.pattern;
-              if (isNull(pattern)) {
-                pattern = '';
-              }
-              return '<strong>{0}</strong>&nbsp{1}'.format(data.value, pattern);
-            },
-            context: function(text) {
-              if (!isNull(text)) {
-                var lines = text.split('\n');
-                if (lines.length > 0) {
-                  var ret = lines[lines.length - 1];
-                  return ret;
-                }
-              }
-              return "";
-            }
-          }, {
+          $('.dash-autocomplete').textcomplete([{
             id: 'comprefs',
             match: /@(t|th|thi|this|([A-Z][A-Z0-9#]*))?$/, //@ and 0 letter or more or 'this'
             search: function(term, callback) {
@@ -1555,6 +1525,36 @@ jQuery(document).ready(function() {
             },
             template: function(data, term) {
               return '<strong>${0}&nbsp</strong>:&nbsp{1}'.format(data.value, data.preview);
+            }
+          }, {
+            id: 'commands',
+            match: /\b([^@]{1,})$/, //1 letter or more
+            search: function(term, callback) {
+              logTrace('search %s', term)
+              BDA_DASH.suggestionEngine.search(term, callback, callback);
+            },
+            index: 1,
+            cache: true,
+            replace: function(data) {
+              logTrace('replace %s', data.value);
+              return data.value + ' ';
+            },
+            template: function(data, term) {
+              var pattern = data.pattern;
+              if (isNull(pattern)) {
+                pattern = '';
+              }
+              return '<strong>{0}</strong>&nbsp{1}'.format(data.value, pattern);
+            },
+            context: function(text) {
+              if (!isNull(text)) {
+                var lines = text.split('\n');
+                if (lines.length > 0) {
+                  var ret = lines[lines.length - 1];
+                  return ret;
+                }
+              }
+              return "";
             }
           }, {
             id: 'xml',

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -402,7 +402,7 @@ jQuery(document).ready(function() {
               params.itemDesc,
               params.id,
               params.repo,
-              function($xmlDoc) {
+              function($xmlDoc, head) {
                 try {
                   var res = "";
                   var items = []
@@ -413,7 +413,10 @@ jQuery(document).ready(function() {
                       // items.push(convertAddItemToPlainObject($itemXml));
                       items.push($itemXml.outerHTML());
                     })
-                    callback(items);
+                    callback({
+                      items: items,
+                      head: head
+                    });
                   } else {
                     throw {
                       name: "Not Found",
@@ -459,7 +462,7 @@ jQuery(document).ready(function() {
               params.itemDesc,
               params.query,
               params.repo,
-              function($xmlDoc) {
+              function($xmlDoc, head) {
                 try {
                   var res = "";
                   var items = []
@@ -469,7 +472,10 @@ jQuery(document).ready(function() {
                       $itemXml = $(this);
                       items.push($itemXml.outerHTML());
                     })
-                    callback(items);
+                    callback({
+                      items: items,
+                      head: head
+                    });
                   } else {
                     throw {
                       name: "Not Found",
@@ -563,7 +569,6 @@ jQuery(document).ready(function() {
               repo,
               function($xmlDoc, head) {
                 try {
-                  var res = head.join('') + "\n";
                   if (!isNull($xmlDoc)) {
                     var $itemXml;
                     var items = [];
@@ -571,7 +576,10 @@ jQuery(document).ready(function() {
                       $itemXml = $(this);
                       items.push($itemXml.outerHTML());
                     })
-                    callback(items);
+                    callback({
+                      items: items,
+                      head: head
+                    });
                   } else {
                     throw {
                       name: "Not Found",
@@ -2286,7 +2294,8 @@ jQuery(document).ready(function() {
             console.log('xmlDef: ', $xmlDef);
             var $res = $('<div></div>');
 
-            BDA_REPOSITORY.showXMLAsTab(retval.join(''), $xmlDef, $res, false,
+
+            BDA_REPOSITORY.showXMLAsTab(retval.items.join(''), $xmlDef, $res, false,
               function() {
                 var $elm = $(this);
                 console.log('click on loadable', $elm);
@@ -2296,6 +2305,7 @@ jQuery(document).ready(function() {
                 console.log('query %s', query);
                 BDA_DASH.handleInput(query);
               });
+            //  $res.prepend($('<div></div>').text(retval.head));
             // res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
             cb('', $res);
           },

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -1115,7 +1115,6 @@ jQuery(document).ready(function() {
           }
         });
 
-        // BDA_DASH.handleInput('help -k'); //skip history
         BDA_DASH.restoreScreenState();
 
         console.log('trigger dash build done')

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -435,33 +435,7 @@ jQuery(document).ready(function() {
               }
             );
           },
-          responseToString: function(params, retval, cb) {
-
-            processRepositoryXmlDef(
-              "definitionFiles",
-              ($xmlDef) => {
-                console.log('xmlDef: ', $xmlDef);
-                var $res = $('<div></div>');
-
-                BDA_REPOSITORY.showXMLAsTab(retval.join(''), $xmlDef, $res, false,
-                  function() {
-                    var $elm = $(this);
-                    console.log('click on loadable', $elm);
-                    var id = $elm.attr("data-id");
-                    var itemDesc = $elm.attr("data-descriptor");
-                    var query = "print {0} {1} {2}".format(params.repo, itemDesc, id);
-                    console.log('query %s', query);
-                    BDA_DASH.handleInput(query);
-                  });
-                // res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
-                cb('', $res);
-              },
-              params.repo
-            );
-
-
-            // return res;
-          }
+          responseToString: (params, retval, cb) => BDA_DASH.displayRqlResult(params.repo, retval, cb)
         },
 
         //print @OR order p92133231
@@ -517,29 +491,7 @@ jQuery(document).ready(function() {
               }
             );
           },
-          responseToString: function(params, retval, cb) {
-            processRepositoryXmlDef(
-              "definitionFiles",
-              ($xmlDef) => {
-                console.log('xmlDef: ', $xmlDef);
-                var $res = $('<div></div>');
-
-                BDA_REPOSITORY.showXMLAsTab(retval.join(''), $xmlDef, $res, false,
-                  function() {
-                    var $elm = $(this);
-                    console.log('click on loadable', $elm);
-                    var id = $elm.attr("data-id");
-                    var itemDesc = $elm.attr("data-descriptor");
-                    var query = "print {0} {1} {2}".format(params.repo, itemDesc, id);
-                    console.log('query %s', query);
-                    BDA_DASH.handleInput(query);
-                  });
-                // res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
-                cb('', $res);
-              },
-              params.repo
-            );
-          }
+          responseToString: (params, retval, cb) => BDA_DASH.displayRqlResult(params.repo, retval, cb)
         },
 
 
@@ -620,7 +572,7 @@ jQuery(document).ready(function() {
                     var items = [];
                     $xmlDoc.find('add-item').each(function() {
                       $itemXml = $(this);
-                      items.push(convertAddItemToPlainObject($itemXml));
+                      items.push($itemXml.outerHTML());
                     })
                     callback(items);
                   } else {
@@ -642,16 +594,14 @@ jQuery(document).ready(function() {
             );
 
           },
-          responseToString: function(params, retval) {
-            var res = "";
-            for (var i = 0; i < retval.length; i++) {
-              var item = retval[i];
-              res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
-
-
-              //                res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
+          responseToString: (params, retval, cb) => {
+            let repo;
+            if (_.isNil(params.componentProperty)) {
+              repo = params.repo
+            } else {
+              repo = params.componentProperty.path;
             }
-            return res;
+            BDA_DASH.displayRqlResult(repo, retval, cb);
           }
 
         },
@@ -2324,6 +2274,30 @@ jQuery(document).ready(function() {
         if (BDA_DASH.progress.total > 1) {
           $bar.parent().fadeIn();
         }
+      },
+
+      displayRqlResult: function(repo, retval, cb) {
+        processRepositoryXmlDef(
+          "definitionFiles",
+          ($xmlDef) => {
+            console.log('xmlDef: ', $xmlDef);
+            var $res = $('<div></div>');
+
+            BDA_REPOSITORY.showXMLAsTab(retval.join(''), $xmlDef, $res, false,
+              function() {
+                var $elm = $(this);
+                console.log('click on loadable', $elm);
+                var id = $elm.attr("data-id");
+                var itemDesc = $elm.attr("data-descriptor");
+                var query = "print {0} {1} {2}".format(repo, itemDesc, id);
+                console.log('query %s', query);
+                BDA_DASH.handleInput(query);
+              });
+            // res += BDA_DASH.templates.printItemTemplate.format(item.id, buildSimpleTable(item, BDA_DASH.templates.tableTemplate, BDA_DASH.templates.rowTemplate));
+            cb('', $res);
+          },
+          repo
+        );
       },
 
       updateProgress: function() {

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -2222,7 +2222,7 @@ jQuery(document).ready(function() {
       displayRqlResult: function(result, cb) {
         var $res = $('<div></div>');
         $().getBdaRepository().renderResultSection(result.items, result.repository, $res);
-        cb(result.logs, $res);
+        cb('<pre>{0}</pre>'.format(result.logs), $res);
       },
 
       updateProgress: function() {

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -2220,7 +2220,7 @@ jQuery(document).ready(function() {
 
 
       displayRqlResult: function(result, cb) {
-        var $res = $('<div></div>');
+        var $res = $('<div class="rqlResultContainer"></div>');
         $().getBdaRepository().renderResultSection(result.items, result.repository, $res);
         cb('<pre>{0}</pre>'.format(result.logs), $res);
       },

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -23,7 +23,7 @@ jQuery(document).ready(function() {
       $footer: null,
 
       modalHeight: 200,
-      modalHeightRatio: 0.9,
+      modalHeightRatio: 0.93,
       //
       initialized: false,
 
@@ -120,7 +120,7 @@ jQuery(document).ready(function() {
           '<li role="presentation" class="pull-right footer-right" ><a id="dashClearScreen" class="btn-default"   role="tab" aria-controls="clearScreen" >Clear Screen <i class="fa fa-ban" ></i></a></li>' +
 
           '</ul>' +
-          '<div id="dashTips" class="text-muted"></div>' +
+          '<div id="dashTips" class="tips text-muted"></div>' +
           '</div>' +
           '</div>' +
           '</div>' +

--- a/bda.dash.js
+++ b/bda.dash.js
@@ -139,6 +139,7 @@ jQuery(document).ready(function() {
           '<p class="dash_feeback_line">$&gt;&nbsp;<span class="cmd"></span></p>' +
           '<p class="dash_log_line">{2}</p>' +
           '<p class="dash_return_line">{0}</p>' +
+          '<p class="dash_help_line"><br/> Type <em>help</em> for more information.</p>' +
           '<div class="dash_return_line objectResult"></div>' +
           '</div>',
         systemResponse: '<div class="dash_screen_sys_res alert alert-{1} alert-dismissible" role="alert" >' +
@@ -173,7 +174,7 @@ jQuery(document).ready(function() {
           'All your base are belong to us.'
         ],
         menuElem: '<div id="bdaDashMenuElem" class="menu" title="ctrl+alt+T"><p>Dash</p><div class="menuArrow"><i class="fa fa-terminal" /></div></div>',
-        errMsg: '<strong>{0}</strong> : {1}<br/> Type <em>help</em> for more information.',
+        errMsg: '<strong>{0}</strong> : {1}',
         tableTemplate: '<table class="table"><tr><th>{0}</th><th>{1}</th></tr>{2}</table>',
         rowTemplate: '<tr><td>{0}</td><td>{1}</td></tr>',
         printItemTemplate: '<div class="panel panel-default printItem"><div class="panel-heading">Printing item with id: {0}</div>{1}</div>',

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -185,16 +185,13 @@ try {
 
             $('.clear-button').on('click', function(event) {
               let target = $(this).attr('data-target');
-              BDA_REEX.fields[target].val('');
-              BDA_REEX.savePanelStatus();
+              BDA_REEX.fields[target].val('').change();
             });
 
             $('.current-component-button').on('click', function() {
               console.log('current-component-button')
               let target = $(this).attr('data-target');
-              BDA_REEX.fields[target].val(getCurrentComponentPath());
-              BDA_REEX.reloadRepositoryDefinition();
-              BDA_REEX.savePanelStatus();
+              BDA_REEX.fields[target].val(getCurrentComponentPath()).change();
             })
 
           },

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -1,109 +1,115 @@
 // Extension for DASH
 try {
   jQuery(document).ready(function() {
-      (function($) {
-          try {
+    (function($) {
+      try {
 
-            var BDA_REEX = {
+        var BDA_REEX = {
 
-              templates: {
-                rql: {
+          templates: {
 
-                },
-                menuPill: '<li role="presentation"><a id="repoExplorerButton"  href="#repo-explorer-tab" aria-controls="editor" role="tab" data-toggle="tab" data-cols="1" data-fs-mode="true">Repo Explorer</a></li>',
-                panel: '<div role="tabpanel" class="tab-pane fade bottom-panel" id="repo-explorer-tab">' +
-                  '<form id="dashEditorForm" class="form-horizontal">' +
-                  '<div class="form-group top-row">' +
-                  '<div class="col-sm-3">' +
-                  '<select id="reexQueryType" class="form-control">' +
-                  '<option data-queryable="false">print</option>' +
-                  '<option data-queryable="true">query</option>' +
-                  '<option data-queryable="true">add</option>' +
-                  '<option data-queryable="false">remove</option>' +
-                  '<option data-queryable="true">custom</option>' +
-                  '</select>' +
-                  '</div>' +
-                  '<div class="col-sm-5">' +
-                  '<input type-"text" id="reexRepo" class="form-control">' +
-                  '</input>' +
-                  '</div>' +
-                  '<div class="col-sm-4">' +
-                  '<div class="btn-group" role="group" >' +
-                  '<button type="button" id="reexClear" class="btn btn-primary" title="clear">' +
-                  '<i class="fa fa-eraser" />&nbsp;' +
-                  '</i>' +
-                  '</button>' +
-                  '<button type="button" id="reexRun" class="btn btn-primary" title="run">' +
-                  '<i class="fa fa-play" />&nbsp;' +
-                  '</i>' +
-                  '</button>' +
-                  '</div>' +
-                  '</div>' +
-                  '</div>' +
-                  '<div class="form-group middle-row">' +
-                  '<div class="col-sm-6">' +
-                  '<textarea id="reexEditor" class="form-control dash-input main-input reex-autocomplete" rows="4" placeholder=""></textarea>' +
-                  '</div>' +
-                  '<div class="col-sm-6">' +
-                  '<div>preview</div>' +
-                  '</div>' +
-                  '</div>' +
-                  '</form>' +
-                  '</div>',
-              },
+            menuPill: '<li role="presentation"><a id="repoExplorerButton"  href="#repo-explorer-tab" aria-controls="editor" role="tab" data-toggle="tab" data-cols="1" data-fs-mode="true">Repo Explorer</a></li>',
+            panel: '<div role="tabpanel" class="tab-pane fade bottom-panel" id="repo-explorer-tab">' +
+              '<form id="dashEditorForm" class="form-horizontal">' +
+              '<div class="form-group top-row">' +
+              '<div class="col-sm-1">' +
+              '<select id="reexQueryType" class="form-control">' +
+              '<option data-queryable="false">print</option>' +
+              '<option data-queryable="true">query</option>' +
+              '<option data-queryable="true">add</option>' +
+              '<option data-queryable="false">remove</option>' +
+              '<option data-queryable="true">custom</option>' +
+              '</select>' +
+              '</div>' +
+              '<div class="col-sm-3">' +
+              '<input type="text" id="reexRepo" class="form-control">' +
+              '</input>' +
+              '</div>' +
+              '<div class="col-sm-2">' +
+              '<input type="text" id="reexItemDesc" class="form-control">' +
+              '</input>' +
+              '</div>' +
+              '<div class="col-sm-2">' +
+              '<input type="text" id="reexId" class="form-control">' +
+              '</input>' +
+              '</div>' +
+              '<div class="col-sm-4">' +
+              '<div class="btn-group" role="group" >' +
+              '<button type="button" id="reexClear" class="btn btn-primary" title="clear">' +
+              '<i class="fa fa-eraser" />&nbsp;' +
+              '</i>' +
+              '</button>' +
+              '<button type="button" id="reexRun" class="btn btn-primary" title="run">' +
+              '<i class="fa fa-play" />&nbsp;' +
+              '</i>' +
+              '</button>' +
+              '</div>' +
+              '</div>' +
+              '</div>' +
+              '<div class="form-group middle-row">' +
+              '<div class="col-sm-6">' +
+              '<textarea id="reexEditor" class="form-control dash-input main-input reex-autocomplete" rows="4" placeholder=""></textarea>' +
+              '</div>' +
+              '<div class="col-sm-6">' +
+              '<div>preview</div>' +
+              '</div>' +
+              '</div>' +
+              '</form>' +
+              '</div>',
+          },
 
-              build: function() {
-                $('body').on('bda.dash.build.done', () => {
-                  console.log('init Repo Explorer')
-                  let navPill = $(BDA_REEX.templates.menuPill);
-                  BDA_DASH.$footer.find('#dashNav').append(navPill);
-                  BDA_REEX.$panel = $(BDA_REEX.templates.panel);
-                  BDA_DASH.$control.append(BDA_REEX.$panel);
-                  BDA_REEX.$querySelect = BDA_REEX.$panel.find('#reexQueryType');
-                  BDA_REEX.$editor = BDA_REEX.$panel.find('#reexEditor');
-                  BDA_DASH.bindTabChangeResize(navPill.find('a[data-toggle="tab"]'));
-                  BDA_REEX.initQueryTypeSelect();
-                })
-              },
+          build: function() {
+            $('body').on('bda.dash.build.done', () => {
+              console.log('init Repo Explorer')
+              let navPill = $(BDA_REEX.templates.menuPill);
+              BDA_DASH.$footer.find('#dashNav').append(navPill);
+              BDA_REEX.$panel = $(BDA_REEX.templates.panel);
+              BDA_DASH.$control.append(BDA_REEX.$panel);
+              BDA_REEX.$querySelect = BDA_REEX.$panel.find('#reexQueryType');
+              BDA_REEX.$editor = BDA_REEX.$panel.find('#reexEditor');
+              BDA_DASH.bindTabChangeResize(navPill.find('a[data-toggle="tab"]'));
+              BDA_REEX.initQueryTypeSelect();
+            })
+          },
 
-              initQueryTypeSelect: function() {
-                BDA_REEX.$querySelect.on('change', BDA_REEX.updateEditorState);
-                BDA_REEX.updateEditorState(BDA_REEX.$querySelect); //init
-              },
-              updateEditorState: function() {
-                let $option = $(this).find(':selected');
-                let writable = $option.attr('data-queryable');
-                console.log('writable %s', writable);
-                if (writable === 'true') {
-                  BDA_REEX.$editor.attr('disabled', false);
-                } else {
-                  BDA_REEX.$editor.attr('disabled', true);
-                }
-              }
+          initQueryTypeSelect: function() {
+            BDA_REEX.$querySelect.on('change', BDA_REEX.updateEditorState);
+            BDA_REEX.updateEditorState(BDA_REEX.$querySelect); //init
+          },
+          updateEditorState: function() {
+            let $option = $(this).find(':selected');
+            let writable = $option.attr('data-queryable');
+            console.log('writable %s', writable);
+            if (writable === 'true') {
+              BDA_REEX.$editor.attr('disabled', false);
+            } else {
+              BDA_REEX.$editor.attr('disabled', true);
             }
-          };
-
-          var defaults = {};
-          // Reference to BDA_STORAGE
-          var BDA_STORAGE, BDA_REPOSITORY;
-
-          $.fn.initRepositoryExplorer = function(pBDA, options) {
-            console.log('Init plugin {0}'.format('repoExplorer'));
-
-            BDA = pBDA;
-            BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
-            BDA_REPOSITORY = $.fn.getBdaRepository();
-            BDA_DASH = $.fn.getDash();
-            BDA_REEX.build();
-            return this;
-          };
-
-
-
-        } catch (e) {
-          console.log(e);
+          }
         }
-      })(jQuery);
+
+
+        var defaults = {};
+        // Reference to BDA_STORAGE
+        var BDA_STORAGE, BDA_REPOSITORY;
+
+        $.fn.initRepositoryExplorer = function(pBDA, options) {
+          console.log('Init plugin {0}'.format('repoExplorer'));
+
+          BDA = pBDA;
+          BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
+          BDA_REPOSITORY = $.fn.getBdaRepository();
+          BDA_DASH = $.fn.getDash();
+          BDA_REEX.build();
+          return this;
+        };
+
+
+
+      } catch (e) {
+        console.log(e);
+      }
+    })(jQuery);
   });
 
 } catch (e) {

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -95,7 +95,7 @@ try {
               '</div>' +
               '<div class="col-sm-2">' +
               '<div class="btn-group" role="group" >' +
-              '<button type="button" id="reexClear" class="btn btn-primary" title="clear">' +
+              '<button type="button" id="reexClear" class="btn btn-primary clear-all" title="clear">' +
               '<i class="fa fa-eraser" />&nbsp;' +
               '</i>' +
               '</button>' +
@@ -108,7 +108,7 @@ try {
               '</div>' +
               '<div class="form-group middle-row">' +
               '<div class="col-sm-6">' +
-              '<textarea id="reexEditor" class="form-control dash-input main-input reex-input reex-autocomplete" rows="4" placeholder=""></textarea>' +
+              '<textarea id="reexEditor" class="form-control dash-input main-input reex-input reex-autocomplete" rows="5" placeholder=""></textarea>' +
               '</div>' +
               '<div class="col-sm-6">' +
               '<div id="reexPreview">preview</div><br/>' +
@@ -187,6 +187,12 @@ try {
               let target = $(this).attr('data-target');
               BDA_REEX.fields[target].val('').change();
             });
+
+            $('.clear-all').on('click', () => {
+              _.forEach(BDA_REEX.fields, (f) => {
+                f.val('').change();
+              })
+            })
 
             $('.current-component-button').on('click', function() {
               console.log('current-component-button')

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -10,7 +10,8 @@ try {
             queries: {
               print: {
                 writable: false,
-                requireId: true
+                requireId: true,
+                template: 'print {0} {1} {2}'
               },
               query: {
                 writable: true,
@@ -92,15 +93,56 @@ try {
               BDA_DASH.$control.append(BDA_REEX.$panel);
               BDA_REEX.$querySelect = BDA_REEX.$panel.find('#reexQueryType');
               BDA_REEX.$editor = BDA_REEX.$panel.find('#reexEditor');
+              BDA_REEX.$idInput = BDA_REEX.$panel.find('#reexId');
+              BDA_REEX.$itemDescInput = BDA_REEX.$panel.find('#reexItemDesc');
+              BDA_REEX.$repoInput = BDA_REEX.$panel.find('#reexRepo');
               BDA_DASH.bindTabChangeResize(navPill.find('a[data-toggle="tab"]'));
               BDA_REEX.initQueryTypeSelect();
+
               var defaultTab = BDA_STORAGE.getConfigurationValue('dashDefaultTab');
               if (!isNull(defaultTab)) {
                 $('#' + defaultTab).tab('show');
               }
 
-              BDA_REEX.$submit = BDA_REEX.$panel.find('')
+              BDA_REEX.$submit = BDA_REEX.$panel.find('#reexRun');
+              BDA_REEX.$submit.on('click', BDA_REEX.submit)
+
             })
+          },
+
+          submit: function() {
+
+            try {
+
+              console.log('submit')
+              let queryType = BDA_REEX.$querySelect.val();
+              console.log(queryType);
+              switch (queryType) {
+                case 'print':
+                  BDA_REEX.submitPrint();
+                  break;
+                default:
+
+              }
+            } catch (e) {
+              console.error(e);
+            }
+          },
+
+          submitPrint: function() {
+            let dashQuery = BDA_REEX.config.queries.print.template.format(BDA_REEX.getRepoInput(), BDA_REEX.getItemDescInput(), BDA_REEX.getIdInput());
+            BDA_DASH.handleInput(dashQuery);
+          },
+
+          getIdInput: function() {
+            return BDA_REEX.$idInput.val();
+          },
+
+          getItemDescInput: function() {
+            return BDA_REEX.$itemDescInput.val();
+          },
+          getRepoInput: function() {
+            return BDA_REEX.$repoInput.val();
           },
 
           initQueryTypeSelect: function() {

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -6,13 +6,38 @@ try {
 
         var BDA_REEX = {
 
+          config: {
+            queries: {
+              print: {
+                writable: false,
+                requireId: true
+              },
+              query: {
+                writable: true,
+                requireId: false
+              },
+              add: {
+                writable: true,
+                requireId: true
+              },
+              remove: {
+                writable: false,
+                requireId: true
+              },
+              custom: {
+                writable: true,
+                requireId: false
+              }
+            }
+          },
+
           templates: {
 
             menuPill: '<li role="presentation"><a id="repoExplorerButton"  href="#repo-explorer-tab" aria-controls="editor" role="tab" data-toggle="tab" data-cols="1" data-fs-mode="true">Repo Explorer</a></li>',
             panel: '<div role="tabpanel" class="tab-pane fade bottom-panel" id="repo-explorer-tab">' +
               '<form id="dashEditorForm" class="form-horizontal">' +
               '<div class="form-group top-row">' +
-              '<div class="col-sm-1">' +
+              '<div class="col-sm-2">' +
               '<select id="reexQueryType" class="form-control">' +
               '<option data-queryable="false">print</option>' +
               '<option data-queryable="true">query</option>' +
@@ -21,19 +46,19 @@ try {
               '<option data-queryable="true">custom</option>' +
               '</select>' +
               '</div>' +
-              '<div class="col-sm-3">' +
-              '<input type="text" id="reexRepo" class="form-control">' +
-              '</input>' +
-              '</div>' +
-              '<div class="col-sm-2">' +
-              '<input type="text" id="reexItemDesc" class="form-control">' +
-              '</input>' +
-              '</div>' +
-              '<div class="col-sm-2">' +
-              '<input type="text" id="reexId" class="form-control">' +
-              '</input>' +
-              '</div>' +
               '<div class="col-sm-4">' +
+              '<input type="text" id="reexRepo" class="form-control" placeholder="repository">' +
+              '</input>' +
+              '</div>' +
+              '<div class="col-sm-2">' +
+              '<input type="text" id="reexItemDesc" class="form-control" placeholder="item descriptor">' +
+              '</input>' +
+              '</div>' +
+              '<div class="col-sm-2">' +
+              '<input type="text" id="reexId" class="form-control" placeholder="id">' +
+              '</input>' +
+              '</div>' +
+              '<div class="col-sm-2">' +
               '<div class="btn-group" role="group" >' +
               '<button type="button" id="reexClear" class="btn btn-primary" title="clear">' +
               '<i class="fa fa-eraser" />&nbsp;' +
@@ -69,22 +94,30 @@ try {
               BDA_REEX.$editor = BDA_REEX.$panel.find('#reexEditor');
               BDA_DASH.bindTabChangeResize(navPill.find('a[data-toggle="tab"]'));
               BDA_REEX.initQueryTypeSelect();
+              var defaultTab = BDA_STORAGE.getConfigurationValue('dashDefaultTab');
+              if (!isNull(defaultTab)) {
+                $('#' + defaultTab).tab('show');
+              }
+
+              BDA_REEX.$submit = BDA_REEX.$panel.find('')
             })
           },
 
           initQueryTypeSelect: function() {
             BDA_REEX.$querySelect.on('change', BDA_REEX.updateEditorState);
-            BDA_REEX.updateEditorState(BDA_REEX.$querySelect); //init
+            BDA_REEX.updateEditorState(); //init
           },
           updateEditorState: function() {
-            let $option = $(this).find(':selected');
-            let writable = $option.attr('data-queryable');
-            console.log('writable %s', writable);
-            if (writable === 'true') {
-              BDA_REEX.$editor.attr('disabled', false);
-            } else {
-              BDA_REEX.$editor.attr('disabled', true);
+            let $option = BDA_REEX.$querySelect.find(':selected');
+            let opt = $option.val();
+            let writable = true;
+            try {
+              writable = BDA_REEX.config.queries[opt].writable;
+            } catch (e) {
+
             }
+            console.log('writable %s', writable);
+            BDA_REEX.$editor.attr('disabled', !writable);
           }
         }
 

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -168,18 +168,75 @@ try {
 
               // bind preview
               BDA_REEX.$panel.find('.reex-input')
-
-              .on('keyup', BDA_REEX.updatePreview)
+                .on('keyup', BDA_REEX.updatePreview)
                 .on('change', BDA_REEX.updatePreview)
                 .on('keyup', autosaveFc)
                 .on('change', autosaveFc)
+
+              BDA_REEX.fields.repository.on('change', BDA_REEX.reloadRepositoryDefinition)
+
               BDA_REEX.updatePreview(); // init on build
 
 
 
+              BDA_REEX.reloadRepositoryDefinition();
+              BDA_REEX.initFieldsAutocomplete();
             })
           },
 
+          initFieldsAutocomplete: function() {
+            BDA_REEX.initRepositoryAutocomplete()
+          },
+
+          initRepositoryAutocomplete: function() {
+            let settings = $().getBdaSearchSuggestionEngineOptions();
+            var comps = BDA_STORAGE.getStoredComponents();
+            // settings.local = _.map(comps, (fav) => {
+            //   return {
+            //     path: fav.componentPath.replace(/\/dyn\/admin\/nucleus/g, '').replace(/\/$/g, ''),
+            //     value: fav.componentName
+            //   }
+            // });
+            //  settings.remote = null;
+            console.log(settings.local)
+
+            let completionEngine = new Bloodhound(settings);
+            //init typeahead
+            BDA_REEX.fields.repository.typeahead({
+              highlight: true,
+              hint: false,
+              minLength: 3,
+            }, {
+              name: 'reexRepository',
+              source: completionEngine,
+              displayKey: 'value',
+              limit: 5,
+            });
+
+          },
+
+
+          reloadRepositoryDefinition: function() {
+            processRepositoryXmlDef('definitionFiles', ($xmlDef) => {
+              try {
+
+                if (!_.isNil($xmlDef) && $xmlDef.length > 0) {
+
+                  //BDA_REEX.fields.descriptors.
+                  let itemDescriptors = [];
+                  var $descriptors = $xmlDef.find("item-descriptor");
+                  $descriptors.each((index, desc) => {
+                    itemDescriptors.push(desc.getAttribute('name'));
+                  })
+                  itemDescriptors = sort(itemDescriptors);
+                }
+
+              } catch (e) {
+                console.error(e);
+              }
+            }, BDA_REEX.fields.repository.val())
+
+          },
 
 
           updatePreview: function() {

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -138,7 +138,7 @@ try {
               }
 
               BDA_DASH.bindTabChangeResize(navPill.find('a[data-toggle="tab"]'));
-              BDA_REEX.initQueryTypeSelect();
+
 
               var defaultTab = BDA_STORAGE.getConfigurationValue('dashDefaultTab');
               if (!isNull(defaultTab)) {
@@ -159,6 +159,7 @@ try {
                 BDA_REEX.fields.repository.val(inputs.repository);
               }
 
+
               var autosaveFc = debounce(BDA_REEX.savePanelStatus,
                 300);
 
@@ -169,10 +170,8 @@ try {
                 .on('keyup', autosaveFc)
                 .on('change', autosaveFc)
 
-
+              BDA_REEX.initQueryTypeSelect();
               BDA_REEX.updatePreview(); // init on build
-
-
 
               BDA_REEX.reloadRepositoryDefinition();
               BDA_REEX.initFields();

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -221,21 +221,26 @@ try {
 
             //autocomplete
             let settings = $().getBdaSearchSuggestionEngineOptions();
+            let dynamoSearch = new Bloodhound(settings);
 
-            console.log(settings.local)
 
-            let completionEngine = new Bloodhound(settings);
+
             //init typeahead
             BDA_REEX.fields.repository.typeahead({
               highlight: true,
               hint: false,
               minLength: 3,
-            }, {
-              name: 'reexRepository',
-              source: completionEngine,
+            }, [{
+              name: 'reexRepositorySearch',
+              source: dynamoSearch,
               displayKey: 'value',
               limit: 5,
-            });
+              // }, {
+              //   name: 'favs',
+              //   source: favSearchEngine,
+              //   //   displayKey: 'path',
+              //   limit: 5
+            }]);
 
 
             BDA_REEX.fields.repository

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -73,7 +73,12 @@ try {
               '<div class="col-sm-4">' +
               '<div class="input-group">' +
               '<input type="text" id="reexRepo" class="form-control reex-input" placeholder="repository"/>' +
-              '<span class="input-group-btn"><button type="button"  class="btn btn-default clear-button" data-target="repository">×</button></span>' +
+              '<div class="input-group-btn">' +
+              '<button type="button"  class="btn btn-default current-component-button" data-target="repository">' +
+              '<i class="fa fa-location-arrow" ></i>&nbsp;' +
+              '</button>' +
+              '<button type="button"  class="btn btn-default clear-button" data-target="repository">×</button>' +
+              '</div>' +
               '</div>' +
               '</div>' +
               '<div class="col-sm-2">' +
@@ -83,7 +88,9 @@ try {
               '<div class="col-sm-2">' +
               '<div class="input-group">' +
               '<input type="text" id="reexId" class="form-control reex-input" placeholder="id"/>' +
-              '<span class="input-group-btn"><button type="button"  class="btn btn-default clear-button" data-target="id">×</button></span>' +
+              '<div class="input-group-btn">' +
+              '<button type="button"  class="btn btn-default clear-button" data-target="id">×</button>' +
+              '</div>' +
               '</div>' +
               '</div>' +
               '<div class="col-sm-2">' +
@@ -181,6 +188,14 @@ try {
               BDA_REEX.fields[target].val('');
               BDA_REEX.savePanelStatus();
             });
+
+            $('.current-component-button').on('click', function() {
+              console.log('current-component-button')
+              let target = $(this).attr('data-target');
+              BDA_REEX.fields[target].val(getCurrentComponentPath());
+              BDA_REEX.reloadRepositoryDefinition();
+              BDA_REEX.savePanelStatus();
+            })
 
           },
 

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -1,0 +1,50 @@
+// Extension for DASH
+try {
+  jQuery(document).ready(function() {
+    (function($) {
+      try {
+
+        var BDA_REEX = {
+
+          templates: {
+            menuPill: '<li role="presentation"><a id="repoExplorerButton"  href="#repo-explorer-tab" aria-controls="editor" role="tab" data-toggle="tab" data-cols="1" data-fs-mode="true">Repo Explorer</a></li>',
+            panel: '<div role="tabpanel" class="tab-pane fade" id="repo-explorer-tab">Repo Explorer</div>',
+          },
+
+          build: function() {
+            $('body').on('bda.dash.build.done', () => {
+              console.log('init Repo Explorer')
+              let navPill = $(BDA_REEX.templates.menuPill);
+              BDA_DASH.$footer.find('#dashNav').append(navPill);
+              BDA_DASH.$control.append($(BDA_REEX.templates.panel));
+              BDA_DASH.bindTabChangeResize(navPill.find('a[data-toggle="tab"]'));
+            })
+          },
+        };
+
+        var defaults = {};
+        // Reference to BDA_STORAGE
+        var BDA_STORAGE, BDA_REPOSITORY;
+
+        $.fn.initRepositoryExplorer = function(pBDA, options) {
+          console.log('Init plugin {0}'.format('repoExplorer'));
+
+          BDA = pBDA;
+          BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
+          BDA_REPOSITORY = $.fn.getBdaRepository();
+          BDA_DASH = $.fn.getDash();
+          BDA_REEX.build();
+          return this;
+        };
+
+
+
+      } catch (e) {
+        console.log(e);
+      }
+    })(jQuery);
+  });
+
+} catch (e) {
+  console.log(e);
+}

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -1,48 +1,109 @@
 // Extension for DASH
 try {
   jQuery(document).ready(function() {
-    (function($) {
-      try {
+      (function($) {
+          try {
 
-        var BDA_REEX = {
+            var BDA_REEX = {
 
-          templates: {
-            menuPill: '<li role="presentation"><a id="repoExplorerButton"  href="#repo-explorer-tab" aria-controls="editor" role="tab" data-toggle="tab" data-cols="1" data-fs-mode="true">Repo Explorer</a></li>',
-            panel: '<div role="tabpanel" class="tab-pane fade" id="repo-explorer-tab">Repo Explorer</div>',
-          },
+              templates: {
+                rql: {
 
-          build: function() {
-            $('body').on('bda.dash.build.done', () => {
-              console.log('init Repo Explorer')
-              let navPill = $(BDA_REEX.templates.menuPill);
-              BDA_DASH.$footer.find('#dashNav').append(navPill);
-              BDA_DASH.$control.append($(BDA_REEX.templates.panel));
-              BDA_DASH.bindTabChangeResize(navPill.find('a[data-toggle="tab"]'));
-            })
-          },
-        };
+                },
+                menuPill: '<li role="presentation"><a id="repoExplorerButton"  href="#repo-explorer-tab" aria-controls="editor" role="tab" data-toggle="tab" data-cols="1" data-fs-mode="true">Repo Explorer</a></li>',
+                panel: '<div role="tabpanel" class="tab-pane fade bottom-panel" id="repo-explorer-tab">' +
+                  '<form id="dashEditorForm" class="form-horizontal">' +
+                  '<div class="form-group top-row">' +
+                  '<div class="col-sm-3">' +
+                  '<select id="reexQueryType" class="form-control">' +
+                  '<option data-queryable="false">print</option>' +
+                  '<option data-queryable="true">query</option>' +
+                  '<option data-queryable="true">add</option>' +
+                  '<option data-queryable="false">remove</option>' +
+                  '<option data-queryable="true">custom</option>' +
+                  '</select>' +
+                  '</div>' +
+                  '<div class="col-sm-5">' +
+                  '<input type-"text" id="reexRepo" class="form-control">' +
+                  '</input>' +
+                  '</div>' +
+                  '<div class="col-sm-4">' +
+                  '<div class="btn-group" role="group" >' +
+                  '<button type="button" id="reexClear" class="btn btn-primary" title="clear">' +
+                  '<i class="fa fa-eraser" />&nbsp;' +
+                  '</i>' +
+                  '</button>' +
+                  '<button type="button" id="reexRun" class="btn btn-primary" title="run">' +
+                  '<i class="fa fa-play" />&nbsp;' +
+                  '</i>' +
+                  '</button>' +
+                  '</div>' +
+                  '</div>' +
+                  '</div>' +
+                  '<div class="form-group middle-row">' +
+                  '<div class="col-sm-6">' +
+                  '<textarea id="reexEditor" class="form-control dash-input main-input reex-autocomplete" rows="4" placeholder=""></textarea>' +
+                  '</div>' +
+                  '<div class="col-sm-6">' +
+                  '<div>preview</div>' +
+                  '</div>' +
+                  '</div>' +
+                  '</form>' +
+                  '</div>',
+              },
 
-        var defaults = {};
-        // Reference to BDA_STORAGE
-        var BDA_STORAGE, BDA_REPOSITORY;
+              build: function() {
+                $('body').on('bda.dash.build.done', () => {
+                  console.log('init Repo Explorer')
+                  let navPill = $(BDA_REEX.templates.menuPill);
+                  BDA_DASH.$footer.find('#dashNav').append(navPill);
+                  BDA_REEX.$panel = $(BDA_REEX.templates.panel);
+                  BDA_DASH.$control.append(BDA_REEX.$panel);
+                  BDA_REEX.$querySelect = BDA_REEX.$panel.find('#reexQueryType');
+                  BDA_REEX.$editor = BDA_REEX.$panel.find('#reexEditor');
+                  BDA_DASH.bindTabChangeResize(navPill.find('a[data-toggle="tab"]'));
+                  BDA_REEX.initQueryTypeSelect();
+                })
+              },
 
-        $.fn.initRepositoryExplorer = function(pBDA, options) {
-          console.log('Init plugin {0}'.format('repoExplorer'));
+              initQueryTypeSelect: function() {
+                BDA_REEX.$querySelect.on('change', BDA_REEX.updateEditorState);
+                BDA_REEX.updateEditorState(BDA_REEX.$querySelect); //init
+              },
+              updateEditorState: function() {
+                let $option = $(this).find(':selected');
+                let writable = $option.attr('data-queryable');
+                console.log('writable %s', writable);
+                if (writable === 'true') {
+                  BDA_REEX.$editor.attr('disabled', false);
+                } else {
+                  BDA_REEX.$editor.attr('disabled', true);
+                }
+              }
+            }
+          };
 
-          BDA = pBDA;
-          BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
-          BDA_REPOSITORY = $.fn.getBdaRepository();
-          BDA_DASH = $.fn.getDash();
-          BDA_REEX.build();
-          return this;
-        };
+          var defaults = {};
+          // Reference to BDA_STORAGE
+          var BDA_STORAGE, BDA_REPOSITORY;
+
+          $.fn.initRepositoryExplorer = function(pBDA, options) {
+            console.log('Init plugin {0}'.format('repoExplorer'));
+
+            BDA = pBDA;
+            BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
+            BDA_REPOSITORY = $.fn.getBdaRepository();
+            BDA_DASH = $.fn.getDash();
+            BDA_REEX.build();
+            return this;
+          };
 
 
 
-      } catch (e) {
-        console.log(e);
-      }
-    })(jQuery);
+        } catch (e) {
+          console.log(e);
+        }
+      })(jQuery);
   });
 
 } catch (e) {

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -200,6 +200,19 @@ try {
               BDA_REEX.fields[target].val(getCurrentComponentPath()).change();
             })
 
+            //bind enter on text & id inputs
+            _.forEach([BDA_REEX.fields.id, BDA_REEX.fields.text], (field) => {
+              field.on('keydown', (e) => {
+
+
+                if (e.which == 13 && !e.altKey && !e.shiftKey) {
+                  e.preventDefault();
+                  BDA_REEX.submit();
+                  return false;
+                }
+              })
+            })
+
           },
 
           initItemDescriptorField: function() {

--- a/bda.repo-explorer.js
+++ b/bda.repo-explorer.js
@@ -71,16 +71,20 @@ try {
               '</select>' +
               '</div>' +
               '<div class="col-sm-4">' +
-              '<input type="text" id="reexRepo" class="form-control reex-input" placeholder="repository">' +
-              '</input>' +
+              '<div class="input-group">' +
+              '<input type="text" id="reexRepo" class="form-control reex-input" placeholder="repository"/>' +
+              '<span class="input-group-btn"><button type="button"  class="btn btn-default clear-button" data-target="repository">×</button></span>' +
+              '</div>' +
               '</div>' +
               '<div class="col-sm-2">' +
-              '<select  id="reexItemDesc" class="reex-input" placeholder="item descriptor">' +
+              '<select  id="reexItemDesc" class=" reex-input" placeholder="item descriptor">' +
               '</select>' +
               '</div>' +
               '<div class="col-sm-2">' +
-              '<input type="text" id="reexId" class="form-control reex-input" placeholder="id">' +
-              '</input>' +
+              '<div class="input-group">' +
+              '<input type="text" id="reexId" class="form-control reex-input" placeholder="id"/>' +
+              '<span class="input-group-btn"><button type="button"  class="btn btn-default clear-button" data-target="id">×</button></span>' +
+              '</div>' +
               '</div>' +
               '<div class="col-sm-2">' +
               '<div class="btn-group" role="group" >' +
@@ -148,16 +152,7 @@ try {
                 BDA_REEX.fields.repository.val(inputs.repository);
               }
 
-              var autosaveFc = debounce(function() {
-                  try {
-
-                    var inputs = BDA_REEX.getInputs()
-                    let inputAsString = JSON.stringify(inputs);
-                    BDA_STORAGE.storeConfiguration('reexCurrentInputs', inputAsString);
-                  } catch (e) {
-                    console.error(e);
-                  }
-                },
+              var autosaveFc = debounce(BDA_REEX.savePanelStatus,
                 300);
 
               // bind preview
@@ -179,7 +174,14 @@ try {
 
           initFields: function() {
             BDA_REEX.initItemDescriptorField();
-            BDA_REEX.initRepositoryField()
+            BDA_REEX.initRepositoryField();
+
+            $('.clear-button').on('click', function(event) {
+              let target = $(this).attr('data-target');
+              BDA_REEX.fields[target].val('');
+              BDA_REEX.savePanelStatus();
+            });
+
           },
 
           initItemDescriptorField: function() {
@@ -226,10 +228,20 @@ try {
 
             BDA_REEX.fields.repository
               .on('typeahead:select', BDA_REEX.reloadRepositoryDefinition)
-              .on('change', BDA_REEX.reloadRepositoryDefinition)
+              .on('change', BDA_REEX.reloadRepositoryDefinition);
+
 
           },
+          savePanelStatus: function() {
+            try {
 
+              var inputs = BDA_REEX.getInputs()
+              let inputAsString = JSON.stringify(inputs);
+              BDA_STORAGE.storeConfiguration('reexCurrentInputs', inputAsString);
+            } catch (e) {
+              console.error(e);
+            }
+          },
 
           reloadRepositoryDefinition: function() {
             processRepositoryXmlDef('definitionFiles', ($xmlDef) => {

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -162,7 +162,8 @@
       resultTable: '<table class="dataTable" data-descriptor="{0}"><tbody></tbody></table>',
       idCell: '<td id="id_{0}">{0}</td>',
       descriptorCell: '<td>{0}</td>',
-      propertyCell: '<td data-property="{1}" data-item-id="{2}">{0}</td>'
+      propertyCell: '<td data-property="{1}" data-item-id="{2}">{0}</td>',
+      longPropertyCell: '<td class="property show-short" data-property="{2}" data-item-id="{3}"><span class="long">{0}</span><span class="short">{1}</span></td>',
 
     },
     cmAutocomplete: {
@@ -1321,8 +1322,14 @@
       } catch (e) {
         val = '';
       }
+      let res;
+      if (val.length <= 20) {
+        res = BDA_REPOSITORY.templates.propertyCell.format(val, item.id, property.name);
+      } else {
+        let short = val.substr(0, 20) + '...';
+        res = BDA_REPOSITORY.templates.longPropertyCell.format(val, short, item.id, property.name);
+      }
 
-      let res = BDA_REPOSITORY.templates.propertyCell.format(val, item.id, property.name);
 
       return $(res);
     },

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1438,33 +1438,7 @@ console.timeEnd('formatTabResult');
           .each((elem) => {
             elem.appendTo(idLine)
           });
-        idLine.find('.reload-item').on('click', function() {
-          let $this = $(this);
-          let property = $this.closest('.property');
-          let id = property.attr('data-id');
-          let item = property.attr('data-item');
-          let repoPath = property.attr('data-repository');
-          let parentTab = $this.closest('.dataTable');
-          $this.addClass('fa-spin');
-          BDA_REPOSITORY.reloadTab(id, item, repoPath, parentTab, () => {
-            $this.removeClass('fa-spin');
-            $.notify(
-              "Success: Reloaded {0} {1}".format(item, id), {
-                className: "success",
-                position: "top center",
-                autoHideDelay: 3000
-              }
-            );
-
-          });
-        });
-        idLine.find('.copy-xml').on('click', function() {
-          copyToClipboard($(this).closest('.property').data('repositoryItem').rawXml);
-        })
-        idLine.find('.close-elem').on('click', function() {
-          logTrace('close-elem', $(this));
-          BDA_REPOSITORY.closeTab($(this).closest('.property'));
-        })
+       
 
         // let descLineElems = _(items).map((item) => BDA_REPOSITORY.templates.descriptorCell.format(itemDescriptorName, item.id)).join('');
         // let descLine = $('<tr class="descriptor odd"><th>descriptor</th>{0}</tr>'.format(descLineElems)).appendTo(tableHead);
@@ -1479,7 +1453,7 @@ console.timeEnd('formatTabResult');
             // hiden lines that have all null values
             let lineIsVisible = !!renderContext[itemDescriptor.name][property.name]
 
-            let line = $('<tr class="item-line {0} {1}" data-property="{2}"></tr>'.format(getEvenOddClass(index), lineIsVisible ? '' : 'hidden', property.name));
+            let line = $('<tr class="item-line {0} {1}" data-property="{2}"></tr>'.format('', lineIsVisible ? '' : 'hidden', property.name));
 
             //build property name cell
             // the following flags have been set on the repoItem level :
@@ -1523,16 +1497,44 @@ console.timeEnd('formatTabResult');
 
         //enable local collapse/expand
         console.time('bind actions');
-        tbody.find('.actions')
-        .on('click', '.collapse', function() {
+        table
+        .on('click', '.actions .collapse', function() {
           $(this).closest('.property').addClass('show-short').removeClass('show-long');
         })
-        .on('click', '.expand', function() {
+        .on('click', '.actions .expand', function() {
           $(this).closest('.property').removeClass('show-short').addClass('show-long');
         })
-        .on('click', '.start-edit', function() {
+        .on('click', '.actions .start-edit', function() {
           $(this).closest('.property').addClass('show-edit').find('.inline-input').focus();
 
+        })
+          .on('click','.id .reload-item', function() {
+            console.log('reloadItem')
+          let $this = $(this);
+          let property = $this.closest('.property');
+          let id = property.attr('data-id');
+          let item = property.attr('data-item');
+          let repoPath = property.attr('data-repository');
+          let parentTab = $this.closest('.dataTable');
+          $this.addClass('fa-spin');
+          BDA_REPOSITORY.reloadTab(id, item, repoPath, parentTab, () => {
+            $this.removeClass('fa-spin');
+            $.notify(
+              "Success: Reloaded {0} {1}".format(item, id), {
+                className: "success",
+                position: "top center",
+                autoHideDelay: 3000
+              }
+            );
+
+          });
+        })
+         .on('click','.id .copy-xml', function() {
+          copyToClipboard($(this).closest('.property').data('repositoryItem').rawXml);
+        })
+         .on('click', '.id .close-elem',function() {
+          logTrace('close-elem', $(this));
+          BDA_REPOSITORY.closeTab($(this).closest('.property'));
         })
         console.timeEnd('bind actions');
 
@@ -1586,7 +1588,7 @@ console.timeEnd('formatTabResult');
       }
 
       if (!_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
-        BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
+       BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
       }
       // console.timeEnd('buildPropertyValueCell ' + property.name);
       return res;

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1613,8 +1613,8 @@
     addInlineEditForm: function(output, val, property, item, repository) {
       try {
 
-        let form = $('<form class="edit"><input type="text"></input></form>');
-        let input = form.find('input').val(val);
+        let form = $('<form class="edit"><textarea class="inline-input"></input></form>');
+        let input = form.find('.inline-input').val(val);
         input.on('blur', function() {
 
           try {

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1521,6 +1521,9 @@ console.timeEnd('formatTabResult');
           $(this).closest('.property').removeClass('show-short').addClass('show-long');
         })
         .on('click', '.actions .start-edit', function() {
+
+          // addInlineEditForm(output, val, property, item, repository) 
+
           $(this).closest('.property').addClass('show-edit').find('.inline-input').focus();
 
         })
@@ -1604,9 +1607,9 @@ console.timeEnd('formatTabResult');
         longCell.append(val);
       }
 
-      if (lineIsVisible && !_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
-        BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
-      }
+      // if (lineIsVisible && !_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
+      //   BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
+      // }
        BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell');
       // console.timeEnd('buildPropertyValueCell ' + property.name);
       return res;
@@ -1703,10 +1706,12 @@ console.timeEnd('formatTabResult');
     },
 
     addInlineEditForm: function(output, val, property, item, repository) {
+      BDA_REPOSITORY.PERF_MONITOR.start('addInlineEditForm');
       try {
 
-        let form = $('<form class="edit"><textarea class="inline-input" rows="1"></input></form>');
-        let input = form.find('.inline-input').val(val);
+        let form = $('<form class="edit"></form>');
+        let input = $('<textarea class="inline-input" rows="1"></input>').val(val);
+        input.appendTo(form);
         input.on('blur', function() {
 
           try {
@@ -1776,7 +1781,7 @@ console.timeEnd('formatTabResult');
       } catch (e) {
         console.error(e);
       }
-
+      BDA_REPOSITORY.PERF_MONITOR.cumul('addInlineEditForm');
 
     },
     closeTab: function(idCell, container) {

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1461,7 +1461,7 @@
             }
 
             // add all cells
-            let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem));
+            let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem, repo));
             _.each(cells, cell => cell.appendTo(line));
             line.appendTo(tbody);
             index++;
@@ -1473,7 +1473,7 @@
       return res;
     },
 
-    buildPropertyValueCell: function(item, property, referencePropertyValue) {
+    buildPropertyValueCell: function(item, property, referencePropertyValue, repository) {
       let propertyValue = item.values[property.name];
       let val;
       try {
@@ -1520,7 +1520,7 @@
       }
 
       if (!_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
-        BDA_REPOSITORY.addInlineEditForm(res, val, property, item);
+        BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
       }
 
       return res;
@@ -1590,7 +1590,7 @@
         });
     },
 
-    addInlineEditForm: function(output, val, property, item) {
+    addInlineEditForm: function(output, val, property, item, repository) {
       try {
 
         let form = $('<form class="edit"><input type="text"></input></form>');
@@ -1616,14 +1616,14 @@
               options: [{
                 label: 'Confirm',
                 _callback: function() {
-                  BDA_REPOSITORY.executeQuery('', xmlText, getCurrentComponentPath(),
+                  BDA_REPOSITORY.executeQuery('', xmlText, repository.path,
                     (result) => {
                       try {
                         var xmlContent = $('<div>' + result + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
                         let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
 
                         let parentTab = input.closest('.dataTable');
-                        BDA_REPOSITORY.reloadTab(item.id, item.itemDescriptor.name, getCurrentComponentPath(), parentTab, () => {
+                        BDA_REPOSITORY.reloadTab(item.id, item.itemDescriptor.name, repository.path, parentTab, () => {
 
                           $.notify(
                             "Success: \n{0}".format(logs), {

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -950,7 +950,7 @@
       return html;
     },
 
-    showXMLAsTab: function(xmlContent, $xmlDef, $outputDiv, isItemTree) {
+    showXMLAsTab: function(xmlContent, $xmlDef, $outputDiv, isItemTree, loadSubItemCb) {
       console.time("renderTab");
       var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
       var $xml = $(xmlDoc);
@@ -1085,40 +1085,46 @@
         });
       }
 
-      $(".loadable_property").click(function() {
-        console.log('click on loadable');
-        var $elm = $(this);
-        var id = $elm.attr("data-id");
-        var itemDesc = $elm.attr("data-descriptor");
-        var query = "<print-item id='" + id + "' item-descriptor='" + itemDesc + "' />\n";
+      if (_.isNil(loadSubItemCb)) {
+        $outputDiv.find(".loadable_property").click(BDA_REPOSITORY.showLoadSubItemAlert);
 
-
-
-        $('body').bdaAlert({
-          msg: 'You are about to add this query and reload the page: \n' + query,
-          options: [{
-            label: 'Add & Reload',
-            _callback: function() {
-              BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
-              $("#RQLForm").submit();
-            }
-          }, {
-            label: 'Just Add',
-            _callback: function() {
-              BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
-            }
-          }, {
-            label: 'Cancel'
-          }]
-        });
-
-      });
+      } else {
+        $outputDiv.find(".loadable_property").click(loadSubItemCb);
+      }
 
       if (isItemTree)
         BDA_REPOSITORY.createSpeedbar();
 
       console.timeEnd("renderTab");
       return log;
+    },
+
+    showLoadSubItemAlert: function() {
+      console.log('click on loadable');
+      var $elm = $(this);
+      var id = $elm.attr("data-id");
+      var itemDesc = $elm.attr("data-descriptor");
+      var query = "<print-item id='" + id + "' item-descriptor='" + itemDesc + "' />\n";
+
+
+
+      $('body').bdaAlert({
+        msg: 'You are about to add this query and reload the page: \n' + query,
+        options: [{
+          label: 'Add & Reload',
+          _callback: function() {
+            BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
+            $("#RQLForm").submit();
+          }
+        }, {
+          label: 'Just Add',
+          _callback: function() {
+            BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
+          }
+        }, {
+          label: 'Cancel'
+        }]
+      });
     },
 
     showRQLLog: function(log, error) {

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1,3367 +1,3376 @@
 (function($) {
 
-    var tags = {
+  var tags = {
+    '!top': ['add-item', 'query-items', 'print-item', 'remove-item'],
+    '!attrs': {},
+    'toto': {
+
+    },
+    'add-item': {
+      attrs: {
+        'id': null,
+        'item-descriptor': null
+      },
+      children: ['set-property']
+    },
+    'print-item': {
+      attrs: {
+        'id': null,
+        'item-descriptor': null
+      },
+      children: []
+    },
+    'remove-item': {
+      attrs: {
+        'id': null,
+        'item-descriptor': null
+      },
+      children: ['set-property']
+    },
+    'query-items': {
+      attrs: {
+        'item-descriptor': null,
+        'id-only': ['true', 'false']
+      },
+      children: []
+    },
+    'set-property': {
+      attrs: {
+        name: null
+      },
+      children: []
+    }
+  };
+
+  var Repository = function(data) {
+    this.path;
+    this.xmlDefinition;
+    this.descriptors = {}
+    _.merge(this, data);
+  }
+  Repository.prototype.getItemDescriptor = function(itemDescriptorName) {
+    let desc = this.descriptors[itemDescriptorName]
+    if (_.isNil(desc) && !_.isNil(this.xmlDefinition)) {
+      desc = BDA_REPOSITORY.buildItemDescriptor(itemDescriptorName, this.xmlDefinition, this);
+      this.descriptors[itemDescriptorName] = desc;
+    }
+    return desc;
+  }
+
+  var ItemDescriptor = function(data) {
+    this.properties = {}; //PropertyDescriptor
+    this.name;
+    this.xmlDefinition;
+    _.merge(this, data);
+
+  }
+  var PropertyDescriptor = function($xmlDefinition, repository) {
+    this.xmlDefinition = $xmlDefinition;
+    if (this.xmlDefinition) {
+      this.name = this.xmlDefinition.attr('name');
+      this.type = this.xmlDefinition.attr('type');
+      this.itemType = this.xmlDefinition.attr('item-type');
+      this.otherRepositoryPath = this.xmlDefinition.attr('repository');
+      this.componentItemType = this.xmlDefinition.attr('component-item-type');
+
+      if (!!this.itemType || !!this.componentItemType) {
+        this.isItem = true;
+        this.isItemOfSameRepository = _.isNil(this.otherRepositoryPath);
+        if (this.isItemOfSameRepository) {
+          this.itemRepository = repository.path;
+        } else {
+          this.itemRepository = this.otherRepositoryPath;
+        }
+        this.isMulti = !!this.componentItemType;
+        if (!!this.componentItemType) {
+          this.itemType = this.componentItemType; //simplify by using one property
+        }
+      }
+    }
+  }
+
+  var RepositoryItem = function(data) {
+    this.itemDescriptor;
+    this.id;
+    this.repository;
+    this.values = {}; // PropertyValue
+    _.merge(this, data);
+
+    // init default values
+    if (!_.isNil(this.itemDescriptor)) {
+      _(this.itemDescriptor.properties)
+        .filter(propDesc => !_.isEmpty(propDesc.defaultValue))
+        .each(propDesc => {
+          this.values[propDesc.name] = new PropertyValue(propDesc);
+        });
+    }
+
+  }
+  RepositoryItem.prototype.hasValueFor = function(propertyName) {
+    return !_.isNil(this.values[propertyName]) && !_.isEmpty(this.values[propertyName].value)
+  }
+
+  var PropertyValue = function(descriptor, xmlValue) {
+    this.descriptor = descriptor;
+    this.xmlValue = xmlValue;
+    if (!_.isNil(xmlValue)) {
+      this.setValueFromXml(xmlValue)
+    } else if (!_.isNil(descriptor)) {
+      this.value = descriptor.defaultValue;
+      this.isDefault = true;
+    }
+    this.isDefault;
+    // get attribues from the xml result, not the descriptor
+    if (!_.isNil(this.xmlValue)) {
+      this.rdonly = this.xmlValue.attr('rdonly');
+      this.derived = this.xmlValue.attr('derived');
+      this.exportable = this.xmlValue.attr('exportable');
+    }
+  }
+  PropertyValue.prototype.setValueFromXml = function(xmlValue) {
+    this.value = xmlValue.text();
+    this.isDefault = false;
+  }
+  "use scrict";
+  var BDA_REPOSITORY = {
+
+    repositories: {},
+
+    CELL_MAX_LENGTH: 23,
+
+    PERF_MONITOR: null,
+
+    MAP_SEPARATOR: "=",
+    LIST_SEPARATOR: ",",
+    descriptorTableSelector: "table:eq(0)",
+    repositoryViewSelector: "h2:contains('Examine the Repository, Control Debugging')",
+    cacheUsageSelector: "h2:contains('Cache usage statistics')",
+    propertiesSelector: "h1:contains('Properties')",
+    eventSetsSelector: "h1:contains('Event Sets')",
+    methodsSelector: "h1:contains('Methods')",
+    resultsSelector: "h2:contains('Results:')",
+    errorsSelector1: "p:contains('Errors:')",
+    errorsSelector2: "code:contains('*** Query:')",
+    defaultItemByTab: "10",
+    nbItemReceived: 0,
+    itemTree: new Map(),
+    defaultDescriptor: {
+      "OrderRepository": "order",
+      "CsrRepository": "returnRequest",
+      "ProfileAdapterRepository": "user",
+      "ProductCatalog": "sku",
+      "InventoryRepository": "inventory",
+      "PriceLists": "price"
+    },
+    xmlDefinitionMaxSize: 150000, // 150 Ko
+    queryEditor: null,
+    descriptorList: null,
+    isRepositoryPage: false,
+    hasErrors: false,
+    hasResults: false,
+    templates: {
+      printItem: '<print-item item-descriptor="{0}" id="{1}"/>',
+      queryItems: '<query-items item-descriptor="{0}">\n{1}\n</query-items>',
+      resultHeader: '<p class="nbResults"> {0} items in {1} descriptor(s)</p>',
+      resultTable: '<table class="dataTable" data-descriptor="{0}" data-repository="{1}"></table>',
+      idCell: '<td class="property idCell" data-identifier="id_{0}_{1}" data-id="{0}" data-item="{1}" data-repository="{2}" >' +
+        '<div class="flex-wrapper">' +
+        '<div class="value-elem">{0}</div>' +
+        '<span class="actions">' +
+        '<i class="fa fa-refresh action reload-item" aria-hidden="true"></i>' +
+        '<i class="fa fa-code action copy-xml" aria-hidden="true"></i>' +
+        '<i class="fa fa-close action close-elem" aria-hidden="true"></i>' +
+        '</div>' +
+        '</span>' +
+        '</div>' +
+        '</td>',
+      descriptorCell: '<td data-id="{1}">{0}</td>',
+      propertyCell: '<td data-property="{2}" data-id="{1}" class="property show-short {3} {4}"><div class="flex-wrapper">' +
+        '{0}' +
+        '<span class="actions">' +
+        '<i class="fa fa-edit action start-edit" aria-hidden="true"></i>' +
+        '<i class="fa fa-compress action collapse" aria-hidden="true"></i>' +
+        '<i class="fa fa-expand action expand" aria-hidden="true"></i>' +
+        '<i class="fa fa-spinner fa-spin passive-loading-icon" aria-hidden="true"></i>' +
+        '</span>' +
+        '</div></td>',
+      shortPropertyCell: '<div class="value-elem propertyValue" data-raw="{0}">{1}</div>',
+      longPropertyCell: '<span class="value-elem long propertyValue" data-raw="{1}">{2}</span><span class="value-elem short">{0}</span>',
+      editProperty: '<update-item item-descriptor="{0}" id="{1}">\n    <set-property name="{2}"><![CDATA[{3}]]></set-property>\n</update-item>'
+
+
+    },
+    cmAutocomplete: {
+      tags: {
         '!top': ['add-item', 'query-items', 'print-item', 'remove-item'],
         '!attrs': {},
         'toto': {
 
         },
         'add-item': {
-            attrs: {
-                'id': null,
-                'item-descriptor': null
-            },
-            children: ['set-property']
+          attrs: {
+            'id': null,
+            'item-descriptor': null
+          },
+          children: ['set-property']
         },
         'print-item': {
-            attrs: {
-                'id': null,
-                'item-descriptor': null
-            },
-            children: []
+          attrs: {
+            'id': null,
+            'item-descriptor': null
+          },
+          children: []
         },
         'remove-item': {
-            attrs: {
-                'id': null,
-                'item-descriptor': null
-            },
-            children: ['set-property']
+          attrs: {
+            'id': null,
+            'item-descriptor': null
+          },
+          children: ['set-property']
         },
         'query-items': {
-            attrs: {
-                'item-descriptor': null,
-                'id-only': ['true', 'false']
-            },
-            children: []
+          attrs: {
+            'item-descriptor': null,
+            'id-only': ['true', 'false']
+          },
+          children: []
         },
         'set-property': {
-            attrs: {
-                name: null
-            },
-            children: []
+          attrs: {
+            name: null
+          },
+          children: []
         }
-    };
+      },
+    },
+    CACHE_STAT_TITLE_REGEXP: /item-descriptor=(.*) cache-mode=(.*)( cache-locality=(.*))?/,
+    edgesToIgnore: ["order", "relationships", "orderRef"],
 
-    var Repository = function(data) {
-        this.path;
-        this.xmlDefinition;
-        this.descriptors = {}
-        _.merge(this, data);
-    }
-    Repository.prototype.getItemDescriptor = function(itemDescriptorName) {
-        let desc = this.descriptors[itemDescriptorName]
-        if (_.isNil(desc) && !_.isNil(this.xmlDefinition)) {
-            desc = BDA_REPOSITORY.buildItemDescriptor(itemDescriptorName, this.xmlDefinition, this);
-            this.descriptors[itemDescriptorName] = desc;
+    build: function() {
+      console.time("bdaRepository");
+      BDA_REPOSITORY.isRepositoryPage = BDA_REPOSITORY.isRepositoryPageFct();
+      BDA_REPOSITORY.hasErrors = BDA_REPOSITORY.hasErrorsFct();
+      BDA_REPOSITORY.hasResults = BDA_REPOSITORY.hasResultsFct(BDA_REPOSITORY.hasErrors);
+      logTrace("isRepositoryPage : " + BDA_REPOSITORY.isRepositoryPage + " Page has results : " + BDA_REPOSITORY.hasResults + ". Page has errors : " + BDA_REPOSITORY.hasErrors);
+      // Setup repository page
+      if (BDA_REPOSITORY.isRepositoryPage)
+        BDA_REPOSITORY.setupRepositoryPage();
+      console.timeEnd("bdaRepository");
+    },
+
+    isRepositoryPageFct: function() {
+      return $("h2:contains('Run XML Operation Tags on the Repository')").length > 0;
+    },
+
+    setupRepositoryPage: function() {
+      // Move RQL editor to the top of the page
+
+      console.time('preparePage');
+
+      BDA_REPOSITORY.PERF_MONITOR = new PerformanceMonitor(true);
+      BDA_REPOSITORY.PERF_MONITOR.reset();
+
+      $(BDA_REPOSITORY.descriptorTableSelector).attr("id", "descriptorTable");
+
+      //save the native form in variable before adding more forms with the showRQLResults methods (inline forms)
+      BDA_REPOSITORY.initialForm = $("form:eq(1)");
+
+      $("<div id='RQLEditor'></div>").insertBefore("h2:first");
+      $("<div id='RQLResults'></div>").insertBefore("#RQLEditor");
+      if (BDA_REPOSITORY.hasErrors)
+        BDA_REPOSITORY.showRqlErrors();
+      if (BDA_REPOSITORY.hasResults && !BDA_REPOSITORY.hasErrors) {
+        setTimeout(function() {
+
+          BDA_REPOSITORY.showRQLResults();
+        }, 300);
+      }
+
+      BDA_REPOSITORY.initialForm
+        .appendTo("#RQLEditor")
+        .attr("id", "RQLForm");
+      var $children = $("#RQLForm").children();
+      $("#RQLForm").empty().append($children);
+      $("textarea[name=xmltext]").attr("id", "xmltext");
+
+      var actionSelect = "<select id='RQLAction' class='js-example-basic-single' style='width:170px'>" + " <optgroup label='Empty queries'>" + "<option value='print-item'>print-item</option>" + "<option value='query-items'>query-items</option>" + "<option value='remove-item'>remove-item</option>" + "<option value='add-item'>add-item</option>" + "<option value='update-item'>update-item</option>" + "</optgroup>" + " <optgroup label='Predefined queries'>" + "<option value='all'>query-items ALL</option>" + "<option value='last_10_ordered'>query-items last 10 order by id</option>" + "<option value='last_10'>query-items last 10</option>" + "</optgroup>" + "</select>";
+
+      $("<div id='RQLToolbar'></div>").append("<div> Action : " + actionSelect + " <span id='editor'>" + "<span id='itemIdField' >ids : <input type='text' id='itemId' placeholder='Id1,Id2,Id3' /></span>" + "<span id='itemDescriptorField' > descriptor :  <select id='itemDescriptor' class='itemDescriptor' >" + BDA_REPOSITORY.getDescriptorOptions() + "</select></span>" + "<span id='idOnlyField' style='display: none;'><label for='idOnly'>&nbsp;id only : </label><input type='checkbox' id='idOnly'></input></span>" + "</span>" + BDA_REPOSITORY.getsubmitButton() + "</div>")
+        .insertBefore("#RQLEditor textarea")
+        .after("<div id='RQLText'></div>");
+
+      $("#xmltext").appendTo("#RQLText");
+      $("#RQLText").after("<div id='tabs'>" + "<ul id='navbar'>" + "<li id='propertiesTab' class='selected'>Properties</li>" + "<li id='queriesTab'>Stored Queries</li>" + "</ul>" + "<div id='storedQueries'><i>No stored query for this repository</i></div>" + "<div id='descProperties'><i>Select a descriptor to see his properties</i></i></div>" + "</div>");
+
+      $("#RQLForm input[type=submit]").remove();
+
+      var splitObj = BDA_STORAGE.getStoredSplitObj();
+      var itemByTab = BDA_REPOSITORY.defaultItemByTab;
+      var isChecked = false;
+      if (splitObj) {
+        itemByTab = splitObj.splitValue;
+        isChecked = splitObj.activeSplit;
+      }
+      var checkboxSplit = "<input type='checkbox' id='noSplit' ";
+      if (isChecked)
+        checkboxSplit += " checked ";
+      checkboxSplit += "/> don't split.";
+
+      $("#tabs").after("<div id='RQLSave'>" + "<div style='display:inline-block;width:200px'><button id='clearQuery' type='button'>Clear <i class='fa fa-ban fa-x'></i></button></div>" + "<div style='display:inline-block;width:530px'>Split tab every :  <input type='text' value='" + itemByTab + "' id='splitValue'> items. " + checkboxSplit + "</div>" + "<button type='submit' id='RQLSubmit'>Enter <i class='fa fa-play fa-x'></i></button>" + "</div>" + "<div><input placeholder='Name this query' type='text' id='queryLabel'>&nbsp;<button type='button' id='saveQuery'>Save <i class='fa fa-save fa-x'></i></button></div>");
+      console.timeEnd('preparePage');
+
+      console.time('showQueryList');
+      BDA_REPOSITORY.showQueryList();
+      console.timeEnd('showQueryList');
+
+      console.time('setupItemTreeForm');
+      BDA_REPOSITORY.setupItemTreeForm();
+      console.timeEnd('setupItemTreeForm');
+
+      console.time('setupItemDescriptorTable');
+      BDA_REPOSITORY.setupItemDescriptorTable();
+      console.timeEnd('setupItemDescriptorTable');
+
+      console.time('setupPropertiesTables');
+      BDA_REPOSITORY.setupPropertiesTables();
+      console.timeEnd('setupPropertiesTables');
+
+      var defaultDescriptor = BDA_REPOSITORY.defaultDescriptor[getComponentNameFromPath(getCurrentComponentPath())];
+      if (defaultDescriptor !== undefined)
+        BDA_REPOSITORY.showItemPropertyList(defaultDescriptor);
+
+      // Default tab position
+      $("#descProperties").css("display", "inline-block");
+      $("#storedQueries").css("display", "none");
+
+      $("#queriesTab").click(function() {
+        logTrace("show stored queries");
+        $("#descProperties").css("display", "none");
+        $("#storedQueries").css("display", "inline-block");
+        $(this).addClass("selected");
+        $("#propertiesTab").removeClass("selected");
+      });
+
+      $("#propertiesTab").click(function() {
+        logTrace("show properties");
+        $("#descProperties").css("display", "inline-block");
+        $("#storedQueries").css("display", "none");
+        $(this).addClass("selected");
+        $("#queriesTab").removeClass("selected");
+
+      });
+
+      $("#RQLAction").change(function() {
+        var action = $(this).val();
+        logTrace("Action change : " + action);
+        if (action == "print-item")
+          BDA_REPOSITORY.getPrintItemEditor();
+        else if (action == "query-items")
+          BDA_REPOSITORY.getQueryItemsEditor();
+        else if (action == "remove-item")
+          BDA_REPOSITORY.getRemoveItemEditor();
+        else if (action == "add-item")
+          BDA_REPOSITORY.getAddItemEditor();
+        else if (action == "update-item")
+          BDA_REPOSITORY.getUpdateItemEditor();
+        else
+          BDA_REPOSITORY.getQueryItemsEditor();
+      });
+
+      $("#RQLSubmit").click(function() {
+        BDA_REPOSITORY.submitRQLQuery(false);
+      });
+
+      $("#RQLGo").click(function() {
+        BDA_REPOSITORY.submitRQLQuery(true);
+      });
+
+      $("#RQLAdd").click(function() {
+        var query = BDA_REPOSITORY.getRQLQuery();
+        BDA_REPOSITORY.addToQueryEditor(query);
+      });
+
+      $("#saveQuery").click(function() {
+        if (BDA_REPOSITORY.getQueryEditorValue().trim().length > 0 && $("#queryLabel").val().trim().length > 0) {
+          BDA_STORAGE.storeRQLQuery($("#queryLabel").val().trim(), BDA_REPOSITORY.getQueryEditorValue().trim());
+          BDA_REPOSITORY.showQueryList();
         }
-        return desc;
-    }
+      });
 
-    var ItemDescriptor = function(data) {
-        this.properties = {}; //PropertyDescriptor
-        this.name;
-        this.xmlDefinition;
-        _.merge(this, data);
+      $("#clearQuery").click(function() {
+        BDA_REPOSITORY.setQueryEditorValue("");
+      });
 
-    }
-    var PropertyDescriptor = function($xmlDefinition, repository) {
-        this.xmlDefinition = $xmlDefinition;
-        if (this.xmlDefinition) {
-            this.name = this.xmlDefinition.attr('name');
-            this.type = this.xmlDefinition.attr('type');
-            this.itemType = this.xmlDefinition.attr('item-type');
-            this.otherRepositoryPath = this.xmlDefinition.attr('repository');
-            this.componentItemType = this.xmlDefinition.attr('component-item-type');
+      // Hide other sections
+      var toggleObj = BDA_STORAGE.getToggleObj();
 
-            if (!!this.itemType || !!this.componentItemType) {
-                this.isItem = true;
-                this.isItemOfSameRepository = _.isNil(this.otherRepositoryPath);
-                if (this.isItemOfSameRepository) {
-                    this.itemRepository = repository.path;
-                } else {
-                    this.itemRepository = this.otherRepositoryPath;
-                }
-                this.isMulti = !!this.componentItemType;
-                if (!!this.componentItemType) {
-                    this.itemType = this.componentItemType; //simplify by using one property
-                }
-            }
+      var repositoryView = "<a href='javascript:void(0)' id='showMoreRepositoryView' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreRepositoryView) + "</a>";
+      var cacheUsage = "&nbsp;<a href='javascript:void(0)' id='showMoreCacheUsage' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreCacheUsage) + "</a>";
+      var properties = "&nbsp;<a href='javascript:void(0)' id='showMoreProperties' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreProperties) + "</a>";
+      var eventSets = "&nbsp;<a href='javascript:void(0)' id='showMoreEventsSets' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreEventsSets) + "</a>";
+      var methods = "&nbsp;<a href='javascript:void(0)' id='showMoreMethods' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreMethods) + "</a>";
+
+      // Auto hide Repository View
+      $(BDA_REPOSITORY.repositoryViewSelector).append(repositoryView);
+
+      if (toggleObj.hasOwnProperty("showMoreRepositoryView") && toggleObj.showMoreRepositoryView == 0)
+        BDA_REPOSITORY.toggleRepositoryView();
+      $("#showMoreRepositoryView").click(function() {
+        BDA_REPOSITORY.toggleRepositoryView();
+      });
+
+      //setup cache section before hidding it
+      BDA_REPOSITORY.setupRepositoryCacheSection();
+
+      // Auto hide Cache usage
+      $(BDA_REPOSITORY.cacheUsageSelector).append(cacheUsage);
+      if (toggleObj.showMoreCacheUsage != 1)
+        BDA_REPOSITORY.toggleCacheUsage();
+      $("#showMoreCacheUsage").click(function() {
+        BDA_REPOSITORY.toggleCacheUsage();
+      });
+      // Auto hide Properties
+      $(BDA_REPOSITORY.propertiesSelector).append(properties);
+      if (toggleObj.showMoreProperties != 1)
+        BDA_REPOSITORY.toggleProperties();
+      $("#showMoreProperties").click(function() {
+        BDA_REPOSITORY.toggleProperties();
+      });
+      // Auto hide Events Sets
+      $(BDA_REPOSITORY.eventSetsSelector).append(eventSets);
+      if (toggleObj.showMoreEventsSets != 1)
+        BDA_REPOSITORY.toggleEventSets();
+      $("#showMoreEventsSets").click(function() {
+        BDA_REPOSITORY.toggleEventSets();
+      });
+      // Auto hide Methods
+      $(BDA_REPOSITORY.methodsSelector).append(methods);
+      if (toggleObj.showMoreMethods != 1)
+        BDA_REPOSITORY.toggleMethods();
+      $("#showMoreMethods").click(function() {
+        BDA_REPOSITORY.toggleMethods();
+      });
+
+      // console.time('setupEditableTable');
+      // BDA_REPOSITORY.setupEditableTable();
+      // console.timeEnd('setupEditableTable');
+      console.time('initCodeMirror');
+      BDA_REPOSITORY.queryEditor = BDA_REPOSITORY.initCodeMirror(true);
+      console.timeEnd('initCodeMirror');
+
+      console.time('initSelect2');
+
+      // Init select2 plugin
+      $("#RQLAction").select2({
+        width: "style",
+        containerCssClass: 'bda-repository',
+        dropdownCssClass: 'bda-repository',
+        minimumResultsForSearch: -1
+      });
+
+      $(".itemDescriptor").select2({
+        placeholder: "Select a descriptor",
+        allowClear: false,
+        width: "element",
+        containerCssClass: 'bda-repository',
+        dropdownCssClass: 'bda-repository',
+        matcher: function(params, data) {
+          // If there are no search terms, return all of the data
+          if ($.trim(params) === '') {
+            return data;
+          }
+          data = data.toUpperCase();
+          params = params.toUpperCase();
+          // `params.term` should be the term that is used for searching
+          // `data.text` is the text that is displayed for the data object
+          if (data.indexOf(params) != -1)
+            return true;
+          return false;
         }
-    }
+      });
 
-    var RepositoryItem = function(data) {
-        this.itemDescriptor;
-        this.id;
-        this.repository;
-        this.values = {}; // PropertyValue
-        _.merge(this, data);
+      $("#itemDescriptor").on("select2-selecting", function(e) {
+        BDA_REPOSITORY.showItemPropertyList(e.val);
+      });
 
-        // init default values
-        if (!_.isNil(this.itemDescriptor)) {
-            _(this.itemDescriptor.properties)
-                .filter(propDesc => !_.isEmpty(propDesc.defaultValue))
-                .each(propDesc => {
-                    this.values[propDesc.name] = new PropertyValue(propDesc);
-                });
+      console.timeEnd('initSelect2');
+
+
+    },
+
+    initCodeMirror: function(autocomplete) {
+
+      var editor;
+      if (autocomplete) {
+
+        //inner functions for auto-complete
+        //taken from CM XML hint demo
+        //tryed to define them elsewhere but it broke the completion...
+        function completeAfter(cm, pred) {
+          var cur = cm.getCursor();
+          if (!pred || pred()) setTimeout(function() {
+            if (!cm.state.completionActive)
+              cm.showHint({
+                completeSingle: false
+              });
+          }, 100);
+          return CodeMirror.Pass;
         }
 
-    }
-    RepositoryItem.prototype.hasValueFor = function(propertyName) {
-        return !_.isNil(this.values[propertyName]) && !_.isEmpty(this.values[propertyName].value)
-    }
-
-    var PropertyValue = function(descriptor, xmlValue) {
-        this.descriptor = descriptor;
-        this.xmlValue = xmlValue;
-        if (!_.isNil(xmlValue)) {
-            this.setValueFromXml(xmlValue)
-        } else if (!_.isNil(descriptor)) {
-            this.value = descriptor.defaultValue;
-            this.isDefault = true;
+        function completeIfAfterLt(cm) {
+          return completeAfter(cm, function() {
+            var cur = cm.getCursor();
+            return cm.getRange(CodeMirror.Pos(cur.line, cur.ch - 1), cur) == "<";
+          });
         }
-        this.isDefault;
-        // get attribues from the xml result, not the descriptor
-        if (!_.isNil(this.xmlValue)) {
-            this.rdonly = this.xmlValue.attr('rdonly');
-            this.derived = this.xmlValue.attr('derived');
-            this.exportable = this.xmlValue.attr('exportable');
+
+        function completeIfInTag(cm) {
+          return completeAfter(cm, function() {
+            var tok = cm.getTokenAt(cm.getCursor());
+            if (tok.type == "string" && (!/['"]/.test(tok.string.charAt(tok.string.length - 1)) || tok.string.length == 1)) return false;
+            var inner = CodeMirror.innerMode(cm.getMode(), tok.state).state;
+            return inner.tagName;
+          });
         }
-    }
-    PropertyValue.prototype.setValueFromXml = function(xmlValue) {
-        this.value = xmlValue.text();
-        this.isDefault = false;
-    }
-    "use scrict";
-    var BDA_REPOSITORY = {
-
-        repositories: {},
-
-        CELL_MAX_LENGTH: 23,
-
-        PERF_MONITOR: null,
-
-        MAP_SEPARATOR: "=",
-        LIST_SEPARATOR: ",",
-        descriptorTableSelector: "table:eq(0)",
-        repositoryViewSelector: "h2:contains('Examine the Repository, Control Debugging')",
-        cacheUsageSelector: "h2:contains('Cache usage statistics')",
-        propertiesSelector: "h1:contains('Properties')",
-        eventSetsSelector: "h1:contains('Event Sets')",
-        methodsSelector: "h1:contains('Methods')",
-        resultsSelector: "h2:contains('Results:')",
-        errorsSelector1: "p:contains('Errors:')",
-        errorsSelector2: "code:contains('*** Query:')",
-        defaultItemByTab: "10",
-        nbItemReceived: 0,
-        itemTree: new Map(),
-        defaultDescriptor: {
-            "OrderRepository": "order",
-            "CsrRepository": "returnRequest",
-            "ProfileAdapterRepository": "user",
-            "ProductCatalog": "sku",
-            "InventoryRepository": "inventory",
-            "PriceLists": "price"
-        },
-        xmlDefinitionMaxSize: 150000, // 150 Ko
-        queryEditor: null,
-        descriptorList: null,
-        isRepositoryPage: false,
-        hasErrors: false,
-        hasResults: false,
-        templates: {
-            printItem: '<print-item item-descriptor="{0}" id="{1}"/>',
-            queryItems: '<query-items item-descriptor="{0}">\n{1}\n</query-items>',
-            resultHeader: '<p class="nbResults"> {0} items in {1} descriptor(s)</p>',
-            resultTable: '<table class="dataTable" data-descriptor="{0}" data-repository="{1}"></table>',
-            idCell: '<td class="property idCell" data-identifier="id_{0}_{1}" data-id="{0}" data-item="{1}" data-repository="{2}" >' +
-                '<div class="flex-wrapper">' +
-                '<div class="value-elem">{0}</div>' +
-                '<span class="actions">' +
-                '<i class="fa fa-refresh action reload-item" aria-hidden="true"></i>' +
-                '<i class="fa fa-code action copy-xml" aria-hidden="true"></i>' +
-                '<i class="fa fa-close action close-elem" aria-hidden="true"></i>' +
-                '</div>' +
-                '</span>' +
-                '</div>' +
-                '</td>',
-            descriptorCell: '<td data-id="{1}">{0}</td>',
-            propertyCell: '<td data-property="{2}" data-id="{1}" class="property show-short {3} {4}"><div class="flex-wrapper">' +
-                '{0}' +
-                '<span class="actions">' +
-                '<i class="fa fa-edit action start-edit" aria-hidden="true"></i>' +
-                '<i class="fa fa-compress action collapse" aria-hidden="true"></i>' +
-                '<i class="fa fa-expand action expand" aria-hidden="true"></i>' +
-                '<i class="fa fa-spinner fa-spin passive-loading-icon" aria-hidden="true"></i>' +
-                '</span>' +
-                '</div></td>',
-            shortPropertyCell: '<div class="value-elem propertyValue" data-raw="{0}">{1}</div>',
-            longPropertyCell: '<span class="value-elem long propertyValue" data-raw="{1}">{2}</span><span class="value-elem short">{0}</span>',
-            editProperty: '<update-item item-descriptor="{0}" id="{1}">\n    <set-property name="{2}"><![CDATA[{3}]]></set-property>\n</update-item>'
 
 
-        },
-        cmAutocomplete: {
-            tags: {
-                '!top': ['add-item', 'query-items', 'print-item', 'remove-item'],
-                '!attrs': {},
-                'toto': {
+        // Init code mirror
+        editor = CodeMirror.fromTextArea(document.getElementById("xmltext"), {
+          lineNumbers: false,
+          mode: 'xml',
+          extraKeys: {
+            "'<'": completeAfter,
+            "'/'": completeIfAfterLt,
+            "' '": completeIfInTag,
+            "'='": completeIfInTag,
+            "Ctrl-Space": "autocomplete"
+          },
+          hintOptions: {
+            schemaInfo: tags
+          }
+        });
 
-                },
-                'add-item': {
-                    attrs: {
-                        'id': null,
-                        'item-descriptor': null
-                    },
-                    children: ['set-property']
-                },
-                'print-item': {
-                    attrs: {
-                        'id': null,
-                        'item-descriptor': null
-                    },
-                    children: []
-                },
-                'remove-item': {
-                    attrs: {
-                        'id': null,
-                        'item-descriptor': null
-                    },
-                    children: ['set-property']
-                },
-                'query-items': {
-                    attrs: {
-                        'item-descriptor': null,
-                        'id-only': ['true', 'false']
-                    },
-                    children: []
-                },
-                'set-property': {
-                    attrs: {
-                        name: null
-                    },
-                    children: []
-                }
-            },
-        },
-        CACHE_STAT_TITLE_REGEXP: /item-descriptor=(.*) cache-mode=(.*)( cache-locality=(.*))?/,
-        edgesToIgnore: ["order", "relationships", "orderRef"],
-
-        build: function() {
-            console.time("bdaRepository");
-            BDA_REPOSITORY.isRepositoryPage = BDA_REPOSITORY.isRepositoryPageFct();
-            BDA_REPOSITORY.hasErrors = BDA_REPOSITORY.hasErrorsFct();
-            BDA_REPOSITORY.hasResults = BDA_REPOSITORY.hasResultsFct(BDA_REPOSITORY.hasErrors);
-            logTrace("isRepositoryPage : " + BDA_REPOSITORY.isRepositoryPage + " Page has results : " + BDA_REPOSITORY.hasResults + ". Page has errors : " + BDA_REPOSITORY.hasErrors);
-            // Setup repository page
-            if (BDA_REPOSITORY.isRepositoryPage)
-                BDA_REPOSITORY.setupRepositoryPage();
-            console.timeEnd("bdaRepository");
-        },
-
-        isRepositoryPageFct: function() {
-            return $("h2:contains('Run XML Operation Tags on the Repository')").length > 0;
-        },
-
-        setupRepositoryPage: function() {
-            // Move RQL editor to the top of the page
-
-            console.time('preparePage');
-
-            BDA_REPOSITORY.PERF_MONITOR = new PerformanceMonitor(true);
-            BDA_REPOSITORY.PERF_MONITOR.reset();
-
-            $(BDA_REPOSITORY.descriptorTableSelector).attr("id", "descriptorTable");
-
-            //save the native form in variable before adding more forms with the showRQLResults methods (inline forms)
-            BDA_REPOSITORY.initialForm = $("form:eq(1)");
-
-            $("<div id='RQLEditor'></div>").insertBefore("h2:first");
-            $("<div id='RQLResults'></div>").insertBefore("#RQLEditor");
-            if (BDA_REPOSITORY.hasErrors)
-                BDA_REPOSITORY.showRqlErrors();
-            if (BDA_REPOSITORY.hasResults && !BDA_REPOSITORY.hasErrors){
-              setTimeout(function() {
-                
-                BDA_REPOSITORY.showRQLResults();
-              }, 300);
+        // HACK
+        // on FF + greasemonkey, the hint is not updated when it's already open
+        // mostly working, yet a bit clunky
+        if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+          CodeMirror.on(editor, "cursorActivity", function(cm, object) {
+            if (cm.state.completionActive) {
+              cm.showHint({
+                completeSingle: false
+              });
             }
-
-            BDA_REPOSITORY.initialForm
-                .appendTo("#RQLEditor")
-                .attr("id", "RQLForm");
-            var $children = $("#RQLForm").children();
-            $("#RQLForm").empty().append($children);
-            $("textarea[name=xmltext]").attr("id", "xmltext");
-
-            var actionSelect = "<select id='RQLAction' class='js-example-basic-single' style='width:170px'>" + " <optgroup label='Empty queries'>" + "<option value='print-item'>print-item</option>" + "<option value='query-items'>query-items</option>" + "<option value='remove-item'>remove-item</option>" + "<option value='add-item'>add-item</option>" + "<option value='update-item'>update-item</option>" + "</optgroup>" + " <optgroup label='Predefined queries'>" + "<option value='all'>query-items ALL</option>" + "<option value='last_10_ordered'>query-items last 10 order by id</option>" + "<option value='last_10'>query-items last 10</option>" + "</optgroup>" + "</select>";
-
-            $("<div id='RQLToolbar'></div>").append("<div> Action : " + actionSelect + " <span id='editor'>" + "<span id='itemIdField' >ids : <input type='text' id='itemId' placeholder='Id1,Id2,Id3' /></span>" + "<span id='itemDescriptorField' > descriptor :  <select id='itemDescriptor' class='itemDescriptor' >" + BDA_REPOSITORY.getDescriptorOptions() + "</select></span>" + "<span id='idOnlyField' style='display: none;'><label for='idOnly'>&nbsp;id only : </label><input type='checkbox' id='idOnly'></input></span>" + "</span>" + BDA_REPOSITORY.getsubmitButton() + "</div>")
-                .insertBefore("#RQLEditor textarea")
-                .after("<div id='RQLText'></div>");
-
-            $("#xmltext").appendTo("#RQLText");
-            $("#RQLText").after("<div id='tabs'>" + "<ul id='navbar'>" + "<li id='propertiesTab' class='selected'>Properties</li>" + "<li id='queriesTab'>Stored Queries</li>" + "</ul>" + "<div id='storedQueries'><i>No stored query for this repository</i></div>" + "<div id='descProperties'><i>Select a descriptor to see his properties</i></i></div>" + "</div>");
-
-            $("#RQLForm input[type=submit]").remove();
-
-            var splitObj = BDA_STORAGE.getStoredSplitObj();
-            var itemByTab = BDA_REPOSITORY.defaultItemByTab;
-            var isChecked = false;
-            if (splitObj) {
-                itemByTab = splitObj.splitValue;
-                isChecked = splitObj.activeSplit;
-            }
-            var checkboxSplit = "<input type='checkbox' id='noSplit' ";
-            if (isChecked)
-                checkboxSplit += " checked ";
-            checkboxSplit += "/> don't split.";
-
-            $("#tabs").after("<div id='RQLSave'>" + "<div style='display:inline-block;width:200px'><button id='clearQuery' type='button'>Clear <i class='fa fa-ban fa-x'></i></button></div>" + "<div style='display:inline-block;width:530px'>Split tab every :  <input type='text' value='" + itemByTab + "' id='splitValue'> items. " + checkboxSplit + "</div>" + "<button type='submit' id='RQLSubmit'>Enter <i class='fa fa-play fa-x'></i></button>" + "</div>" + "<div><input placeholder='Name this query' type='text' id='queryLabel'>&nbsp;<button type='button' id='saveQuery'>Save <i class='fa fa-save fa-x'></i></button></div>");
-            console.timeEnd('preparePage');
-
-            console.time('showQueryList');
-            BDA_REPOSITORY.showQueryList();
-            console.timeEnd('showQueryList');
-
-            console.time('setupItemTreeForm');
-            BDA_REPOSITORY.setupItemTreeForm();
-            console.timeEnd('setupItemTreeForm');
-
-            console.time('setupItemDescriptorTable');
-            BDA_REPOSITORY.setupItemDescriptorTable();
-            console.timeEnd('setupItemDescriptorTable');
-
-            console.time('setupPropertiesTables');
-            BDA_REPOSITORY.setupPropertiesTables();
-            console.timeEnd('setupPropertiesTables');
-
-            var defaultDescriptor = BDA_REPOSITORY.defaultDescriptor[getComponentNameFromPath(getCurrentComponentPath())];
-            if (defaultDescriptor !== undefined)
-                BDA_REPOSITORY.showItemPropertyList(defaultDescriptor);
-
-            // Default tab position
-            $("#descProperties").css("display", "inline-block");
-            $("#storedQueries").css("display", "none");
-
-            $("#queriesTab").click(function() {
-                logTrace("show stored queries");
-                $("#descProperties").css("display", "none");
-                $("#storedQueries").css("display", "inline-block");
-                $(this).addClass("selected");
-                $("#propertiesTab").removeClass("selected");
-            });
-
-            $("#propertiesTab").click(function() {
-                logTrace("show properties");
-                $("#descProperties").css("display", "inline-block");
-                $("#storedQueries").css("display", "none");
-                $(this).addClass("selected");
-                $("#queriesTab").removeClass("selected");
-
-            });
-
-            $("#RQLAction").change(function() {
-                var action = $(this).val();
-                logTrace("Action change : " + action);
-                if (action == "print-item")
-                    BDA_REPOSITORY.getPrintItemEditor();
-                else if (action == "query-items")
-                    BDA_REPOSITORY.getQueryItemsEditor();
-                else if (action == "remove-item")
-                    BDA_REPOSITORY.getRemoveItemEditor();
-                else if (action == "add-item")
-                    BDA_REPOSITORY.getAddItemEditor();
-                else if (action == "update-item")
-                    BDA_REPOSITORY.getUpdateItemEditor();
-                else
-                    BDA_REPOSITORY.getQueryItemsEditor();
-            });
-
-            $("#RQLSubmit").click(function() {
-                BDA_REPOSITORY.submitRQLQuery(false);
-            });
-
-            $("#RQLGo").click(function() {
-                BDA_REPOSITORY.submitRQLQuery(true);
-            });
-
-            $("#RQLAdd").click(function() {
-                var query = BDA_REPOSITORY.getRQLQuery();
-                BDA_REPOSITORY.addToQueryEditor(query);
-            });
-
-            $("#saveQuery").click(function() {
-                if (BDA_REPOSITORY.getQueryEditorValue().trim().length > 0 && $("#queryLabel").val().trim().length > 0) {
-                    BDA_STORAGE.storeRQLQuery($("#queryLabel").val().trim(), BDA_REPOSITORY.getQueryEditorValue().trim());
-                    BDA_REPOSITORY.showQueryList();
-                }
-            });
-
-            $("#clearQuery").click(function() {
-                BDA_REPOSITORY.setQueryEditorValue("");
-            });
-
-            // Hide other sections
-            var toggleObj = BDA_STORAGE.getToggleObj();
-
-            var repositoryView = "<a href='javascript:void(0)' id='showMoreRepositoryView' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreRepositoryView) + "</a>";
-            var cacheUsage = "&nbsp;<a href='javascript:void(0)' id='showMoreCacheUsage' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreCacheUsage) + "</a>";
-            var properties = "&nbsp;<a href='javascript:void(0)' id='showMoreProperties' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreProperties) + "</a>";
-            var eventSets = "&nbsp;<a href='javascript:void(0)' id='showMoreEventsSets' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreEventsSets) + "</a>";
-            var methods = "&nbsp;<a href='javascript:void(0)' id='showMoreMethods' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreMethods) + "</a>";
-
-            // Auto hide Repository View
-            $(BDA_REPOSITORY.repositoryViewSelector).append(repositoryView);
-
-            if (toggleObj.hasOwnProperty("showMoreRepositoryView") && toggleObj.showMoreRepositoryView == 0)
-                BDA_REPOSITORY.toggleRepositoryView();
-            $("#showMoreRepositoryView").click(function() {
-                BDA_REPOSITORY.toggleRepositoryView();
-            });
-
-            //setup cache section before hidding it
-            BDA_REPOSITORY.setupRepositoryCacheSection();
-
-            // Auto hide Cache usage
-            $(BDA_REPOSITORY.cacheUsageSelector).append(cacheUsage);
-            if (toggleObj.showMoreCacheUsage != 1)
-                BDA_REPOSITORY.toggleCacheUsage();
-            $("#showMoreCacheUsage").click(function() {
-                BDA_REPOSITORY.toggleCacheUsage();
-            });
-            // Auto hide Properties
-            $(BDA_REPOSITORY.propertiesSelector).append(properties);
-            if (toggleObj.showMoreProperties != 1)
-                BDA_REPOSITORY.toggleProperties();
-            $("#showMoreProperties").click(function() {
-                BDA_REPOSITORY.toggleProperties();
-            });
-            // Auto hide Events Sets
-            $(BDA_REPOSITORY.eventSetsSelector).append(eventSets);
-            if (toggleObj.showMoreEventsSets != 1)
-                BDA_REPOSITORY.toggleEventSets();
-            $("#showMoreEventsSets").click(function() {
-                BDA_REPOSITORY.toggleEventSets();
-            });
-            // Auto hide Methods
-            $(BDA_REPOSITORY.methodsSelector).append(methods);
-            if (toggleObj.showMoreMethods != 1)
-                BDA_REPOSITORY.toggleMethods();
-            $("#showMoreMethods").click(function() {
-                BDA_REPOSITORY.toggleMethods();
-            });
-
-            // console.time('setupEditableTable');
-            // BDA_REPOSITORY.setupEditableTable();
-            // console.timeEnd('setupEditableTable');
-            console.time('initCodeMirror');
-            BDA_REPOSITORY.queryEditor = BDA_REPOSITORY.initCodeMirror(true);
-            console.timeEnd('initCodeMirror');
-
-            console.time('initSelect2');
-
-            // Init select2 plugin
-            $("#RQLAction").select2({
-                width: "style",
-                containerCssClass: 'bda-repository',
-                dropdownCssClass: 'bda-repository',
-                minimumResultsForSearch: -1
-            });
-
-            $(".itemDescriptor").select2({
-                placeholder: "Select a descriptor",
-                allowClear: false,
-                width: "element",
-                containerCssClass: 'bda-repository',
-                dropdownCssClass: 'bda-repository',
-                matcher: function(params, data) {
-                    // If there are no search terms, return all of the data
-                    if ($.trim(params) === '') {
-                        return data;
-                    }
-                    data = data.toUpperCase();
-                    params = params.toUpperCase();
-                    // `params.term` should be the term that is used for searching
-                    // `data.text` is the text that is displayed for the data object
-                    if (data.indexOf(params) != -1)
-                        return true;
-                    return false;
-                }
-            });
-
-            $("#itemDescriptor").on("select2-selecting", function(e) {
-                BDA_REPOSITORY.showItemPropertyList(e.val);
-            });
-
-            console.timeEnd('initSelect2');
-
-
-        },
-
-        initCodeMirror: function(autocomplete) {
-
-            var editor;
-            if (autocomplete) {
-
-                //inner functions for auto-complete
-                //taken from CM XML hint demo
-                //tryed to define them elsewhere but it broke the completion...
-                function completeAfter(cm, pred) {
-                    var cur = cm.getCursor();
-                    if (!pred || pred()) setTimeout(function() {
-                        if (!cm.state.completionActive)
-                            cm.showHint({
-                                completeSingle: false
-                            });
-                    }, 100);
-                    return CodeMirror.Pass;
-                }
-
-                function completeIfAfterLt(cm) {
-                    return completeAfter(cm, function() {
-                        var cur = cm.getCursor();
-                        return cm.getRange(CodeMirror.Pos(cur.line, cur.ch - 1), cur) == "<";
-                    });
-                }
-
-                function completeIfInTag(cm) {
-                    return completeAfter(cm, function() {
-                        var tok = cm.getTokenAt(cm.getCursor());
-                        if (tok.type == "string" && (!/['"]/.test(tok.string.charAt(tok.string.length - 1)) || tok.string.length == 1)) return false;
-                        var inner = CodeMirror.innerMode(cm.getMode(), tok.state).state;
-                        return inner.tagName;
-                    });
-                }
-
-
-                // Init code mirror
-                editor = CodeMirror.fromTextArea(document.getElementById("xmltext"), {
-                    lineNumbers: false,
-                    mode: 'xml',
-                    extraKeys: {
-                        "'<'": completeAfter,
-                        "'/'": completeIfAfterLt,
-                        "' '": completeIfInTag,
-                        "'='": completeIfInTag,
-                        "Ctrl-Space": "autocomplete"
-                    },
-                    hintOptions: {
-                        schemaInfo: tags
-                    }
-                });
-
-                // HACK
-                // on FF + greasemonkey, the hint is not updated when it's already open
-                // mostly working, yet a bit clunky
-                if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-                    CodeMirror.on(editor, "cursorActivity", function(cm, object) {
-                        if (cm.state.completionActive) {
-                            cm.showHint({
-                                completeSingle: false
-                            });
-                        }
-                    })
-                }
-            } else {
-
-                // Init code mirror
-                editor = CodeMirror.fromTextArea(document.getElementById("xmltext"), {
-                    lineNumbers: false,
-                });
-
-            }
-            return editor;
-        },
-
-        setupEditableTable: function() {
-            $('body').on('click', '.dataTable .fa-pencil-square-o', function(item) {
-                var $target = $(item.target).parent();
-                $target.html('<input type="text" value="' + $target.text().replace(/●/g, ' ') + '"/>');
-                var $input = $($target.children()[0]);
-                $input.focus().blur(function(item) {
-                    var $target = $(item.target);
-                    var $table = $target.parents(".dataTable");
-                    var descriptor = $table.attr("data-descriptor");
-                    var itemId = $target.parent().attr("data-id");
-                    var propertyName = $target.parent().attr("data-property");
-                    if (propertyName == "id" || propertyName == "descriptor") {
-                        $input.parent().html($input.val());
-                        $.notify(
-                            "You can't change value of id or descriptor this way.", {
-                                position: "top center",
-                                className: "error"
-                            }
-                        );
-                        return;
-                    }
-                    logTrace(itemId + " " + descriptor + " " + $target.val() + " " + propertyName);
-                    var query = '<update-item id="' + itemId + '" item-descriptor="' + descriptor + '">\n' + '  <set-property name="' + propertyName + '"><![CDATA[' + $target.val() + ']]>' + '</set-property>\n</update-item>';
-                    var initialValue = $input.attr("value");
-                    if (confirm('You are about to execute this query : \n' + query)) {
-                        jQuery.post(document.location.href, 'xmltext=' + query, function(res) {
-                            var $res = $(res);
-                            var errorsSelector1 = "Errors:";
-                            if ($res.text().indexOf(errorsSelector1) != -1) {
-                                var errorMsg = $res.find("code").text().trim();
-                                $.notify(
-                                    "Error : " + errorMsg, {
-                                        position: "top left",
-                                        className: "error",
-                                        autoHide: true,
-                                        autoHideDelay: 15000
-                                    }
-                                );
-                                $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + initialValue); // reset inital value
-                            } else {
-                                $.notify(
-                                    "Value succesfully changed", {
-                                        position: "top center",
-                                        className: "success"
-                                    }
-                                );
-                            }
-                            $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + $input.val());
-                        });
-                    } else
-                        $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + initialValue); // reset inital value
-                });
-            });
-
-        },
-
-        addToQueryEditor: function(query) {
-            var editor = BDA_REPOSITORY.queryEditor;
-            var editorCursor = editor.getCursor();
-            if (editorCursor.ch !== 0)
-                editor.setCursor(editor.getCursor().line + 1, 0);
-
-            BDA_REPOSITORY.queryEditor.replaceSelection(query);
-        },
-
-        setupPropertiesTables: function() {
-            if ($("a[name=showProperties]").length > 0) {
-                $("a[name=showProperties]").next().attr("id", "propertiesTable");
-                $("#propertiesTable").find("tr:nth-child(odd)").addClass("odd");
-            }
-        },
-
-        setupItemDescriptorTable: function() {
-            var descriptors = BDA_REPOSITORY.getDescriptorList();
-            var componentURI = window.location.pathname;
-            var splitValue = 20;
-            var html = "<p>" + descriptors.length + " descriptors available.</p>";
-            html += "<div>";
-            for (var i = 0; i != descriptors.length; i++) {
-                if (i === 0 || i % splitValue === 0) {
-                    html += "<table class='descriptorTable'>";
-                    html += "<th>Descriptor</th>";
-                    html += "<th>View</th>";
-                    html += "<th>Debug</th>";
-                }
-                if (i % 2 === 0)
-                    html += "<tr class='even'>";
-                else
-                    html += "<tr class='odd'>";
-                var isDebugEnable = false;
-                if ($("a[href='" + componentURI + "?action=clriddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors']").length > 0)
-                    isDebugEnable = true;
-                html += "<td class='descriptor'>" + descriptors[i] + "</td>";
-                html += "<td><a class='btn-desc' href='" + componentURI + "?action=seetmpl&itemdesc=" + descriptors[i] + "#showProperties'>Properties</a>";
-                html += "&nbsp;<a class='btn-desc' class='btn-desc' href='" + componentURI + "?action=seenamed&itemdesc=" + descriptors[i] + "#namedQuery'>Named queries</a></td>";
-
-                html += "<td>";
-                if (isDebugEnable)
-                    html += "<a class='btn-desc red' href='" + componentURI + "?action=clriddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors'>Disable</a>";
-                else {
-                    html += "<a class='btn-desc' href='" + componentURI + "?action=setiddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors'>Enable</a>";
-                    html += "&nbsp;<a class='btn-desc' href='" + componentURI + "?action=dbgprops&itemdesc=" + descriptors[i] + "#debugProperties'>Edit</a>";
-                }
-                html += "</td>";
-                html += "</tr>";
-                if (i !== 0 && ((i + 1) % splitValue === 0 || i + 1 === descriptors.length))
-                    html += "</table>";
-            }
-            html += "</div>";
-            html += "<div style='clear:both' />";
-
-            $("#descriptorTable").remove();
-            $(html).insertAfter("a[name='listItemDescriptors']");
-        },
-
-
-        showItemPropertyList: function(item) {
-            logTrace("showItemPropertyList");
-            var componentURI = window.location.pathname;
-            var url = componentURI + "?action=seetmpl&itemdesc=" + item + "#showProperties";
-            $.get(url, function(data) {
-                logTrace("Enter showItemPropertyList callback");
-                var $pTable = $(data).find("a[name='showProperties']").next();
-                $pTable.find('th:nth-child(2), td:nth-child(2),th:nth-child(4), td:nth-child(4),th:nth-child(5), td:nth-child(5),th:nth-child(6), td:nth-child(6)').remove();
-                $pTable.find("tr").each(function(index) {
-                    var $tr = $(this);
-                    $tr.find("td").each(function(i) {
-                        var $td = $(this);
-                        if (i === 0) {
-                            var content = $td.html();
-                            var req = /[\w\s']+\((\w+)\)$/i;
-                            content = content.replace(req, "<a class='itemPropertyBtn' href='javascript:void(0)'> $1 </a>");
-                            $td.html(content);
-                        } else if (i === 1)
-                            $td.text($td.text().replace("Class", ""));
-
-                    });
-                });
-                logTrace($pTable);
-                $("#descProperties")
-                    .empty()
-                    .append($pTable);
-
-                $('.itemPropertyBtn').click(function(item) {
-                    BDA_REPOSITORY.addToQueryEditor('<set-property name="' + $(this).text().trim() + '"><![CDATA[]]></set-property>\n');
-                });
-            });
-        },
-
-        hasResultsFct: function(hasErrors) {
-            return $(BDA_REPOSITORY.resultsSelector).length > 0;
-        },
-
-        hasErrorsFct: function() {
-            return $(BDA_REPOSITORY.errorsSelector1).length > 0 || $(BDA_REPOSITORY.errorsSelector2).length > 0;
-        },
-
-
-        getDescriptorList: function() {
-            if (BDA_REPOSITORY.descriptorList)
-                return BDA_REPOSITORY.descriptorList;
-            var descriptors = [];
-            $("#descriptorTable tr th:first-child:not([colspan])")
-                .sort(function(a, b) {
-                    return $(a).text().toLowerCase() > $(b).text().toLowerCase() ? 1 : -1;
-                }).each(function() {
-
-                    descriptors.push($(this).html().trim());
-                });
-            BDA_REPOSITORY.descriptorList = descriptors;
-            return descriptors;
-        },
-
-        getDescriptorOptions: function() {
-            var descriptorOptions = "";
-            var descriptors = BDA_REPOSITORY.getDescriptorList();
-            descriptorOptions = "";
-            var defaultDesc = BDA_REPOSITORY.defaultDescriptor[getComponentNameFromPath(getCurrentComponentPath())];
-            if (defaultDesc === undefined)
-                descriptorOptions = "<option></option>";
-            for (var i = 0; i != descriptors.length; i++) {
-                descriptorOptions += "<option value='" + descriptors[i] + "'";
-                if (defaultDesc === descriptors[i])
-                    descriptorOptions += "selected='selected'";
-                descriptorOptions += ">" + descriptors[i] + "</option>\n";
-            }
-            return descriptorOptions;
-        },
-
-        getsubmitButton: function() {
-            return "<button type='button' id='RQLAdd'>Add</button>" + "<button type='button' id='RQLGo'>Add & Enter <i class='fa fa-play fa-x'></i></button>";
-        },
-
-        getPrintItemEditor: function() {
-            $("#itemIdField").show();
-            $("#itemDescriptorField").show();
-            $("#idOnlyField").hide();
-        },
-
-        getAddItemEditor: function() {
-            $("#itemIdField").hide();
-            $("#itemDescriptorField").show();
-            $("#idOnlyField").hide();
-        },
-
-        getRemoveItemEditor: function() {
-            BDA_REPOSITORY.getPrintItemEditor();
-        },
-
-        getRemoveItemsEditor: function() {
-            BDA_REPOSITORY.getPrintItemEditor();
-        },
-
-        getUpdateItemEditor: function() {
-            BDA_REPOSITORY.getPrintItemEditor();
-        },
-
-        getQueryItemsEditor: function() {
-            $("#itemIdField").hide();
-            $("#itemDescriptorField").show();
-            $("#idOnlyField").show();
-        },
-
-        getMultiId: function() {
-            var ids = $("#itemId").val().trim();
-            if (ids.indexOf(",") != -1)
-                return ids.split(",");
-            return [ids];
-        },
-
-        getPrintItemQuery: function() {
-            var ids = BDA_REPOSITORY.getMultiId();
-            var descriptor = $("#itemDescriptor").val();
-            var query = "";
-            for (var i = 0; i != ids.length; i++)
-                query += "<print-item id=\"" + ids[i].trim() + "\" item-descriptor=\"" + descriptor + "\" />\n";
-            return query;
-        },
-
-        getRemoveItemQuery: function() {
-            var ids = BDA_REPOSITORY.getMultiId();
-            var descriptor = $("#itemDescriptor").val();
-            var query = "";
-            for (var i = 0; i != ids.length; i++)
-                query += "<remove-item id=\"" + ids[i].trim() + "\" item-descriptor=\"" + descriptor + "\" />\n";
-            return query;
-        },
-
-        getAddItemQuery: function() {
-            var descriptor = $("#itemDescriptor").val();
-            var query = "<add-item item-descriptor=\"" + descriptor + "\" >\n";
-            query += "  <set-property name=\"\"><![CDATA\[]]></set-property>\n";
-            query += "</add-item>\n";
-            return query;
-        },
-
-        getUpdateItemQuery: function() {
-            var descriptor = $("#itemDescriptor").val();
-            var ids = BDA_REPOSITORY.getMultiId();
-            var query = "";
-            for (var i = 0; i != ids.length; i++) {
-                query += "<update-item id=\"" + ids[i] + "\" item-descriptor=\"" + descriptor + "\" >\n";
-                query += "  <set-property name=\"\"><![CDATA\[]]></set-property>\n";
-                query += "</update-item>\n";
-            }
-            return query;
-        },
-
-        getQueryItemsQuery: function() {
-            var descriptor = $("#itemDescriptor").val();
-            var idOnly = $("#idOnly").prop('checked');
-            var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n\n";
-            query += "</query-items>\n";
-            return query;
-        },
-
-        getAllItemQuery: function() {
-            var descriptor = $("#itemDescriptor").val();
-            var idOnly = $("#idOnly").prop('checked');
-            var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
-            query += "ALL\n";
-            query += "</query-items>\n";
-            return query;
-        },
-
-        getLast10ItemQueryOrdered: function() {
-            var descriptor = $("#itemDescriptor").val();
-            var idOnly = $("#idOnly").prop('checked');
-            var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
-            query += "ALL ORDER BY ID DESC RANGE 0+10\n";
-            query += "</query-items>\n";
-            return query;
-        },
-
-
-        getLast10ItemQuery: function() {
-            var descriptor = $("#itemDescriptor").val();
-            var idOnly = $("#idOnly").prop('checked');
-            var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
-            query += "ALL RANGE 0+10\n";
-            query += "</query-items>\n";
-            return query;
-        },
-
-        getRQLQuery: function() {
-            var query = "";
-            var action = $("#RQLAction").val();
-            logTrace("getRQLQuery : " + action);
-            if (action == "print-item")
-                query = BDA_REPOSITORY.getPrintItemQuery();
-            else if (action == "query-items")
-                query = BDA_REPOSITORY.getQueryItemsQuery();
-            else if (action == "remove-item")
-                query = BDA_REPOSITORY.getRemoveItemQuery();
-            else if (action == "add-item")
-                query = BDA_REPOSITORY.getAddItemQuery();
-            else if (action == "update-item")
-                query = BDA_REPOSITORY.getUpdateItemQuery();
-            else if (action == "all")
-                query = BDA_REPOSITORY.getAllItemQuery();
-            else if (action == "last_10_ordered")
-                query = BDA_REPOSITORY.getLast10ItemQueryOrdered();
-            else if (action == "last_10")
-                query = BDA_REPOSITORY.getLast10ItemQuery();
-            return query;
-        },
-        submitRQLQuery: function(addText) {
-            if (addText) {
-                var query = BDA_REPOSITORY.getRQLQuery();
-                BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
-            }
-            BDA_REPOSITORY.sanitizeQuery();
-            BDA_STORAGE.storeSplitValue();
-            // set anchor to the result div
-            location.hash = '#RQLResults';
-            $("#RQLForm").submit();
-        },
-
-        sanitizeQuery: function() {
-            var query = BDA_REPOSITORY.getQueryEditorValue();
-            BDA_REPOSITORY.setQueryEditorValue(query.replace(/repository\=\".+\"/gi, ""));
-        },
-
-        setQueryEditorValue: function(value) {
-            BDA_REPOSITORY.queryEditor.getDoc().setValue(value);
-        },
-
-        getQueryEditorValue: function() {
-            return BDA_REPOSITORY.queryEditor.getDoc().getValue();
-        },
-
-        showTextField: function(baseId) {
-            baseId = BDA_REPOSITORY.sanitizeSelector(baseId);
-            $("#" + baseId).toggle();
-            $("#text_" + baseId).toggle();
-        },
-
-        // Escape '.', ':' in a jquery selector
-        sanitizeSelector: function(id) {
-            return id.replace(/(:|\.|\[|\]|,)/g, "\\$1");
-        },
-
-        purgeXml: function(xmlContent) {
-            var xmlStr = "";
-            var lines = xmlContent.split("\n");
-            for (var i = 0; i != lines.length; i++) {
-                var line = lines[i].trim();
-                if (!(line.substr(0, 1) == "<" && endsWith(line, ">")))
-                    xmlStr += line + "\n";
-            }
-            return xmlStr;
-        },
-
-
-        // Check if the given property contains id(s) with the given item descriptor
-        // Return an item descriptor name if the property is an ID,
-        // Return null if the property is not found,
-        // Return "FOUND_NOT_ID" is the property is found but is not an ID
-        isPropertyId: function(propertyName, $itemDesc) {
-            var isId = null;
-            var propertyFound = false;
-            $itemDesc.find("property[name=" + propertyName + "]").each(function() {
-                propertyFound = true;
-                var $property = $(this);
-                if ($property.attr("item-type") !== undefined && $property.attr("repository") === undefined)
-                    isId = $property.attr("item-type");
-                else if ($property.attr("component-item-type") !== undefined && $property.attr("repository") === undefined)
-                    isId = $property.attr("component-item-type");
-            });
-            if (propertyFound && isId === null)
-                return "FOUND_NOT_ID";
-            return isId;
-        },
-        // Check if the given property contains id(s) with the given repository definition
-        // Only ID from the current repository are take in account
-        // Return the item descriptor name if the type if an ID, null otherwise
-        isTypeId: function(propertyName, itemDesc, $xmlDef) {
-            var isId = null;
-            if ($xmlDef !== null) {
-                var $itemDesc = $xmlDef.find("item-descriptor[name='" + itemDesc + "']");
-                // First check in current item desc
-                isId = BDA_REPOSITORY.isPropertyId(propertyName, $itemDesc);
-                // In case we found the property but it's not an ID, we don't want to search in super-type
-                if (isId == "FOUND_NOT_ID")
-                    return null;
-                // In case we found the property and it's an ID
-                if (isId !== null)
-                    return isId;
-                // Now we check in each super-type item desc
-                var superType = $itemDesc.attr("super-type");
-                while (superType !== undefined && isId === null) {
-                    var $parentDesc = $xmlDef.find("item-descriptor[name='" + superType + "']");
-                    isId = BDA_REPOSITORY.isPropertyId(propertyName, $parentDesc);
-                    superType = $parentDesc.attr("super-type");
-                }
-                if (isId == "FOUND_NOT_ID")
-                    return null;
-            }
-            return isId;
-        },
-
-        // Parse the given repository ID into a tab, each index will contains an ID or a separator : "," or "="
-        parseRepositoryId: function(id) {
-            var idAsTab = [];
-            var tab = [];
-            // Case of simple ID
-            if (id.indexOf(BDA_REPOSITORY.MAP_SEPARATOR) == -1 && id.indexOf(BDA_REPOSITORY.LIST_SEPARATOR) === -1)
-                idAsTab.push(id);
-            // Case of a list of ID
-            else if (id.indexOf(BDA_REPOSITORY.MAP_SEPARATOR) == -1 && id.indexOf(BDA_REPOSITORY.LIST_SEPARATOR) !== -1) {
-                tab = id.split(BDA_REPOSITORY.LIST_SEPARATOR);
-                for (var i = 0; i != tab.length; i++) {
-                    if (i !== 0)
-                        idAsTab.push(BDA_REPOSITORY.LIST_SEPARATOR);
-                    idAsTab.push(tab[i]);
-                }
-            }
-            // Case of a Map of ID
-            else {
-                var mapEntries = id.split(BDA_REPOSITORY.LIST_SEPARATOR);
-                for (var a = 0; a != mapEntries.length; a++) {
-                    if (a !== 0)
-                        idAsTab.push(BDA_REPOSITORY.LIST_SEPARATOR);
-                    var mapValues = mapEntries[a].split(BDA_REPOSITORY.MAP_SEPARATOR);
-                    for (var b = 0; b != mapValues.length; b++) {
-                        if (b !== 0)
-                            idAsTab.push(BDA_REPOSITORY.MAP_SEPARATOR);
-                        idAsTab.push(mapValues[b]);
-                    }
-                }
-            }
-            return idAsTab;
-        },
-
-        renderProperty: function(curProp, propValue, itemId, isItemTree) {
-            var html = "";
-            var td = "<td data-property='" + curProp.name + "' data-id='" + itemId + "'>";
-            if (propValue !== null && propValue !== undefined) {
-                propValue = propValue.replace(/ /g, '●');
-                // Remove "_"
-                if (curProp.name == "descriptor")
-                    propValue = propValue.substr(1);
-                // propertyName_id
-                var base_id = curProp.name + "_" + itemId;
-
-                if (curProp.name == "id")
-                    html += "<td id='" + base_id + "'>" + propValue + "</td>";
-                // Hide long value
-                else if (propValue.length > 25) {
-                    var link_id = "link_" + base_id;
-                    var field_id = "text_" + base_id;
-                    propValue = "<a class='copyLink' href='javascript:void(0)' title='Show all' id='" + link_id + "' >" + "<span id='" + base_id + "'>" + BDA_REPOSITORY.escapeHTML(propValue.substr(0, 25)) + "..." + "</span></a><textarea class='copyField' id='" + field_id + "' readonly>" + propValue + "</textarea>";
-                    html += td + propValue + "</td>";
-                }
-                // Make IDs clickable
-                else if (curProp.isId === true) {
-                    propValue = BDA_REPOSITORY.parseRepositoryId(propValue);
-                    html += td;
-                    for (var b = 0; b != propValue.length; b++) {
-                        if (propValue[b] != BDA_REPOSITORY.MAP_SEPARATOR && propValue[b] != BDA_REPOSITORY.LIST_SEPARATOR) {
-                            if (isItemTree) // for item tree we create an anchor link
-                                html += "<a class='clickable_property' href='#id_" + propValue[b] + "'>" + propValue[b] + "</a>";
-                            else
-                                html += "<a class='clickable_property loadable_property' data-id='" + propValue[b] + "' data-descriptor='" + curProp.itemDesc + "'>" + propValue[b] + "</a>";
-                        } else
-                            html += propValue[b];
-                    }
-                    html += "</td>";
-                }
-                // descriptor, Read only and derived porperty are not editable
-                else if (curProp.name == "descriptor" || curProp.rdonly == "true" || curProp.derived == "true")
-                    html += "<td>" + propValue + "</td>";
-                else
-                    html += td + '<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + propValue + "</td>";
-            } else
-                html += td + '<i class="fa fa-pencil-square-o" aria-hidden="true"></i></td>';
-
-            return html;
-        },
-
-        renderTab: function(itemDesc, types, datas, tabId, isItemTree) {
-            var html = "";
-            html += "<table class='dataTable' data-descriptor='" + itemDesc.substr(1) + "' ";
-            if (isItemTree)
-                html += "id='" + tabId + "'";
-            html += ">";
-            for (var i = 0; i != types.length; i++) {
-                var curProp = types[i];
-                if (i % 2 === 0)
-                    html += "<tr class='even";
-                else
-                    html += "<tr class='odd";
-
-                if (curProp.name == "id")
-                    html += " id";
-                else if (curProp.name == "descriptor")
-                    html += " descriptor";
-
-                html += "'>";
-                html += "<th>" + curProp.name + "<span class='prop_name'>";
-                if (curProp.rdonly == "true")
-                    html += "<div class='prop_attr prop_attr_red'>R</div>";
-                if (curProp.derived == "true")
-                    html += "<div class='prop_attr prop_attr_green'>D</div>";
-                if (curProp.exportable == "true")
-                    html += "<div class='prop_attr prop_attr_blue'>E</div>";
-                html += "</span></th>";
-
-                for (var a = 0; a < datas.length; a++) {
-                    var propValue = datas[a][curProp.name];
-                    html += BDA_REPOSITORY.renderProperty(curProp, propValue, datas[a].id, isItemTree);
-                }
-                html += "</tr>";
-            }
-            html += "</table>";
-            return html;
-        },
-
-        getDescriptorAndDefaultValues: function(itemDescriptor, $xmlDef, descriptorAndDefaultValues) {
-            descriptorAndDefaultValues[itemDescriptor] = {};
-            var itemDefinition = $xmlDef.find("item-descriptor[name=" + itemDescriptor + "]");
-            var defaultProperties = $xmlDef.find("item-descriptor[name=" + itemDescriptor + "] property[default]");
-            if (itemDefinition !== undefined && itemDefinition.length > 0) {
-                var superType = itemDefinition[0].getAttribute("super-type");
-                defaultProperties = defaultProperties.toArray().concat($xmlDef.find("item-descriptor[name=" + superType + "] property[default]").toArray());
-            }
-            for (var defaultPropertiesIndex = 0; defaultPropertiesIndex < defaultProperties.length; defaultPropertiesIndex++) {
-                var defaultProperty = defaultProperties[defaultPropertiesIndex];
-                var defaultPropertyName = defaultProperty.getAttribute("name");
-                var defaultPropertyValue = defaultProperty.getAttribute("default");
-                descriptorAndDefaultValues[itemDescriptor][defaultPropertyName] = defaultPropertyValue;
-            }
-        },
-
-        //same as getDescriptorAndDefaultValues but using Objects
-        buildItemDescriptor: function(itemDescriptorName, $xmlDef, repository) {
-            BDA_REPOSITORY.PERF_MONITOR.start('buildItemDescriptor');
-            //  console.time(itemDescriptorName);
-            var $itemDefinition = $xmlDef.find('item-descriptor[name={0}]'.format(itemDescriptorName));
-
-            // first get properties from the parent, if it exists
-            var superType = $itemDefinition.attr("super-type");
-            let parent = null;
-            if (!_.isNil(superType)) {
-                parent = repository.getItemDescriptor(superType); //this will build parents by recursion if necessary
-            }
-            let propertyDescriptors = {};
-            if (!_.isNil(parent)) {
-                propertyDescriptors = parent.properties;
-            }
-
-            // then add current properties
-            var $properties = $itemDefinition.find('property');
-
-            var selfPropertyDescriptors = {};
-            $properties.each(function() {
-                let $prop = $(this);
-                let name = $prop.attr('name');
-                let propDesc = new PropertyDescriptor($prop, repository);
-                let defaultValue = $prop.attr('default');
-                if (!_.isNil(defaultValue)) {
-                    propDesc.defaultValue = defaultValue;
-                }
-                selfPropertyDescriptors[name] = propDesc;
-            });
-
-            propertyDescriptors = _.merge(propertyDescriptors, selfPropertyDescriptors);
-            propertyDescriptors = _.sortKeysBy(propertyDescriptors);
-
-            let desc = new ItemDescriptor({
-                name: itemDescriptorName,
-                xmlDefinition: $itemDefinition,
-                properties: propertyDescriptors
-            });
-            //  console.timeEnd(itemDescriptorName);
-            BDA_REPOSITORY.PERF_MONITOR.cumul('buildItemDescriptor');
-            return desc;
-        },
-
-        getRepositoryAsync: function(path, callback) {
-            logTrace('getRepositoryAsync', path);
-            let repository = BDA_REPOSITORY.repositories[path];
-            if (_.isNil(repository)) {
-                processRepositoryXmlDef("definitionFiles",
-                    ($xmlDef) => {
-
-                        repository = BDA_REPOSITORY.getRepository($xmlDef, path);
-                        callback(repository);
-                    }, path)
-
-            } else {
-                callback(repository)
-            }
-        },
-
-        getRepository: function($xmlDef, repositoryPath) {
-            logTrace('getRepository', repositoryPath);
-            let repository = BDA_REPOSITORY.repositories[repositoryPath];
-            if (_.isNil(repository)) {
-                repository = new Repository({
-                    path: repositoryPath,
-                    xmlDefinition: $xmlDef
-                })
-                BDA_REPOSITORY.repositories[repositoryPath] = repository;
-            }
-            return repository;
-        },
-
-
-        showXMLAsTab: function(rawXml, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
-            let xmlContent = sanitizeXml(rawXml);
-
-            console.time('showXMLAsTab_new');
-            if (_.isEmpty(repositoryPath)) {
-                repositoryPath = getCurrentComponentPath();
-            }
-            let repository = BDA_REPOSITORY.getRepository($xmlDef, repositoryPath);
-            let parsedResult = BDA_REPOSITORY.parseXmlResult(xmlContent, repository, rawXml);
-
-            let items = parsedResult.items;
-            let logs = parsedResult.logs;
-
-            BDA_REPOSITORY.renderResultSection(items, repository, $outputDiv, isItemTree);
-
-            //  if (isItemTree) {
-            BDA_REPOSITORY.createSpeedbar_new($outputDiv);
-            //}
-
-            BDA_REPOSITORY.PERF_MONITOR.log();
-            console.timeEnd('showXMLAsTab_new');
-            return logs;
-        },
-
-        renderResultSection: function(items, repository, $outputDiv, isItemTree) {
-            console.time('renderResultSection');
-            // now render the result section
-            $outputDiv.append("<div class='prop_attr prop_attr_red'>R</div> : read-only " +
-                "<div class='prop_attr prop_attr_green'>D</div> : derived " +
-                "<div class='prop_attr prop_attr_blue'>E</div> : export is false," +
-                '&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i> : Link to other Repository,' +
-                '&nbsp;<span class="default">grey</span> : default value');
-
-            // show all button
-            let showAll = $('<button>Show All <i class="fa fa-expand" aria-hidden="true"></i></button>');
-            let hideAll = $('<button>Collapse All <i class="fa fa-compress" aria-hidden="true"></i></button>');
-
-            showAll.on('click', function() {
-                $('.property')
-                    .removeClass('show-short')
-                    .addClass('show-long');
-                $(this).hide();
-                hideAll.show();
-            })
-
-            hideAll.on('click', function() {
-                $('.property')
-                    .addClass('show-short')
-                    .removeClass('show-long');
-                $(this).hide();
-                showAll.show();
-            }).hide();
-
-
-            $outputDiv.append($('<p></p>').append(showAll).append(hideAll));
-
-            if (isItemTree) {
-                $('<button>Show speedbar</button></p>')
-                    .on('click', () => $('#speedbar').fadeIn(200))
-                    .appendTo($outputDiv);
-            }
-
-
-            BDA_REPOSITORY.formatTabResult(repository, items, $outputDiv);
-            console.timeEnd('renderResultSection');
-
-        },
-
-        parseXhrResult: function(xhrResult, repositoryPath, callback) {
-
-            BDA_REPOSITORY.getRepositoryAsync(repositoryPath, (repository) => {
-                try {
-                    logTrace('parseXhrResult', repositoryPath, xhrResult);
-                    var rawXml = $('<div>' + xhrResult + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
-                    let xmlContent = sanitizeXml(rawXml);
-                    let result = BDA_REPOSITORY.parseXmlResult(xmlContent, repository, rawXml);
-                    result.repository = repository;
-                    logTrace('parseXhrResult result:', result);
-                    callback(result);
-                } catch (e) {
-                    console.error(e);
-                }
-            })
-
-        },
-
-        parseXmlResult: function(xmlContent, repository, rawXml) {
-            console.time('parseXmlResult');
-            try {
-
-                var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
-                var $xml = $(xmlDoc);
-                var rawXmlDoc = $($.parseXML("<xml>" + rawXml + "</xml>"));
-                var $addItems = $xml.find("add-item");
-                let items = BDA_REPOSITORY.parseXmlAsObjects($addItems, repository, rawXmlDoc);
-                let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
-                console.timeEnd('parseXmlResult');
-                return {
-                    items: items,
-                    logs: logs
-                }
-            } catch (e) {
-                console.error(e);
-                console.timeEnd('parseXmlResult');
-            }
-
-        },
-        getExecutionLogs: function(xmlContent) {
-            var log = $("<xml>" + xmlContent + "</xml>")
-                .children()
-                .remove()
-                .end()
-                .text()
-                .trim();
-            return log;
-        },
-
-        getChunkSize: function() {
-            let chunkSize = 1;
-            var splitObj = BDA_STORAGE.getStoredSplitObj();
-            // activeSplit == don't split - don't ask me why this name...
-            if (_.isNil(splitObj) || !!splitObj.activeSplit) {
-                chunkSize = Number.MAX_SAFE_INTEGER;
-            } else {
-                chunkSize = parseInt(splitObj.splitValue);
-            }
-            if (chunkSize < 1) {
-                chunkSize = 1; // safety
-            }
-            return chunkSize;
-        },
-
-        formatTabResult: function(repository, repositoryItems, result) {
-            console.time('formatTabResult');
-            try {
-                let itemsByType = _.groupBy(repositoryItems, repoItem => !_.isNil(repoItem.itemDescriptor) ? repoItem.itemDescriptor.name : null);
-                let nbItemDescriptors = _.keys(itemsByType).length;
-                let res = $(BDA_REPOSITORY.templates.resultHeader.format(repositoryItems.length, nbItemDescriptors))
-
-                var chunkSize = BDA_REPOSITORY.getChunkSize();
-
-                // for each property, only display it if it'si not empty in one result
-                let renderContext = {}
-                _(itemsByType)
-                    .each((items, itemDescName) => {
-                        let desc = repository.getItemDescriptor(itemDescName);
-                        renderContext[itemDescName] = {};
-                        _.each(desc.properties, property => {
-                            try {
-                                renderContext[itemDescName][property.name] = _.some(items, item => item.hasValueFor(property.name));
-
-                            } catch (e) {
-                                console.err('error finding render context for: itemDescName,items, property', itemDescName, items, property);
-                            }
-                        })
-                    });
-
-
-                // for each group of item by descriptor, split in chunks of same descriptor and max size 'chunkSize'
-                let chunks = _(itemsByType)
-                    .map(group => _.chunk(group, chunkSize)) //split each group
-                    .flatMap() //flatten the array of arrays
-                    .value();
-
-
-                //now render each tab
-                let firstResult = _.chain(chunks)
-                    .map(chunk => BDA_REPOSITORY.buildResultTable(chunk, renderContext, repository))
-                    .filter(table => !_.isNil(table))
-                    .map(table => {
-                        table.appendTo(result)
-                        return table;
-                    })
-                    .head().value();
-
-                return firstResult;
-
-            } catch (e) {
-                console.error(e);
-            }
-            console.timeEnd('formatTabResult');
-        },
-
-        parseXmlAsObjects: function($addItems, repository, rawXmlDoc) {
-            BDA_REPOSITORY.PERF_MONITOR.start('parseXmlAsObjects');
-            let res = $addItems.map(function() {
-                var currentItem = $(this);
-                var descriptorName = currentItem.attr("item-descriptor");
-                var id = currentItem.attr("id");
-                let itemDescriptor = repository.getItemDescriptor(descriptorName);
-                let rawXml;
-                if (!_.isNil(rawXmlDoc)) {
-                    rawXml = rawXmlDoc.find('add-item[item-descriptor="{0}"][id="{1}"]'.format(descriptorName, id));
-                }
-                let repositoryItem = new RepositoryItem({
-                    itemDescriptor: itemDescriptor,
-                    id: id,
-                    xmlDefinition: currentItem,
-                    rawXml: rawXml.outerHTML()
-                })
-
-                currentItem.find('set-property').each(function() {
-                    let currentProperty = $(this);
-                    let propertyName = currentProperty.attr('name');
-                    let propertyDescriptor;
-                    if (!_.isNil(itemDescriptor)) {
-                        propertyDescriptor = itemDescriptor.properties[propertyName];
-                    }
-                    let val = repositoryItem.values[propertyName];
-                    if (_.isNil(val)) {
-                        val = new PropertyValue(propertyDescriptor, currentProperty);
-                        repositoryItem.values[propertyName] = val;
-                    } else {
-                        val.setValueFromXml(currentProperty);
-                    }
-                })
-                logTrace('repoItem', repositoryItem);
-                return repositoryItem;
-            });
-            BDA_REPOSITORY.PERF_MONITOR.cumul('parseXmlAsObjects');
-            return res;
-        },
-
-        showNonEmptyLines: function(resultTable) {
-            resultTable.find('.item-line.hidden').each(function() {
-                let line = $(this);
-                let mustShow = _.some(line.find('.propertyValue').get(),
-                    (elem) => !_.isEmpty($(elem).attr('data-raw'))
-                );
-                if (mustShow) {
-                    line.removeClass('hidden');
-                }
-            })
-        },
-
-        buildResultTable: function(items, renderContext, repo) {
-            console.time('buildResultTable')
-            let res;
-            if (!_.isNil(items) && items.length > 0) {
-                let itemDescriptor = items[0].itemDescriptor;
-                let itemDescriptorName = itemDescriptor ? itemDescriptor.name : '';
-                let table = $(BDA_REPOSITORY.templates.resultTable.format(itemDescriptorName, repo.path));
-                let tableHead = $('<thead></thead>').appendTo(table);
-
-                let idLine = $('<tr class="id even"><th>{0}</th></tr>'.format(itemDescriptorName)).appendTo(tableHead);
-                _(items)
-                    .map(item => $(BDA_REPOSITORY.templates.idCell.format(item.id, itemDescriptorName, repo.path)).data('repositoryItem', item))
-                    .each((elem) => {
-                        elem.appendTo(idLine)
-                    });
-
-
-                // let descLineElems = _(items).map((item) => BDA_REPOSITORY.templates.descriptorCell.format(itemDescriptorName, item.id)).join('');
-                // let descLine = $('<tr class="descriptor odd"><th>descriptor</th>{0}</tr>'.format(descLineElems)).appendTo(tableHead);
-
-                let tbody = $('<tbody></tbody>').appendTo(table);
-                //for each property, get 
-                let index = 1;
-                console.time('build all items');
-                _(itemDescriptor.properties)
-                    .each((property) => {
-
-                        // hiden lines that have all null values
-                        let lineIsVisible = !!renderContext[itemDescriptor.name][property.name]
-
-                        let line = $('<tr class="item-line {0} {1}" data-property="{2}"></tr>'.format(getEvenOddClass(index), lineIsVisible ? '' : 'hidden', property.name));
-
-                        //build property name cell
-                        // the following flags have been set on the repoItem level :
-
-                        let propertyNameCell = $('<th>{0}<span class="prop_name"></span></th>'.format(property.name)).appendTo(line);
-
-                        let sampleItem = null
-
-                        if (lineIsVisible) {
-                            sampleItem = _.find(items, item => !_.isNil(item.values[property.name]));
-                            index++;
-                        }
-
-
-                        if (lineIsVisible && !_.isNil(sampleItem)) {
-                            let sampleValue = sampleItem.values[property.name];
-                            if (!!sampleValue.derived) {
-                                propertyNameCell.append('<div class="prop_attr prop_attr_green">D</div>');
-                                line.addClass('derived');
-                            }
-                            if (!!sampleValue.rdonly) {
-                                propertyNameCell.append('<div class="prop_attr prop_attr_red">R</div>');
-                                line.addClass('rdonly');
-                            }
-                            if (!!sampleValue.exportable) {
-                                propertyNameCell.append('<div class="prop_attr prop_attr_blue">E</div>');
-                                line.addClass('exportable');
-                            }
-                            if (property.isItem && !property.isItemOfSameRepository) {
-                                propertyNameCell.append('&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i>');
-                                line.addClass('other-repository');
-                            }
-                        }
-
-                        // add all cells
-                        //   console.time('build all cells');
-                        let cellsAsString = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem, repo, lineIsVisible));
-                        // console.timeEnd('build all cells');
-                        //console.time('append all cells');
-
-                        $(cellsAsString.join()).appendTo(line);
-                       // _.each(cells, cell => cell.appendTo(line));
-
-                        //   console.timeEnd('append all cells');
-                        line.appendTo(tbody);
-
-                    });
-
-                //enable local collapse/expand
-                console.time('bind actions');
-                table
-                    .on('click', '.actions .collapse', function() {
-                        $(this).closest('.property').addClass('show-short').removeClass('show-long');
-                    })
-                    .on('click', '.actions .expand', function() {
-                        $(this).closest('.property').removeClass('show-short').addClass('show-long');
-                    })
-                    .on('click', '.actions .start-edit', function() {
-                        BDA_REPOSITORY.onEdit($(this));
-
-                    })
-                    .on('click', '.id .reload-item', function() {
-                        BDA_REPOSITORY.onReload(this);
-                    })
-                    .on('click', '.id .copy-xml', function() {
-                        copyToClipboard($(this).closest('.property').data('repositoryItem').rawXml);
-                    })
-                    .on('click', '.id .close-elem', function() {
-                        logTrace('close-elem', $(this));
-                        BDA_REPOSITORY.closeTab($(this).closest('.property'));
-                    })
-                console.timeEnd('bind actions');
-
-                console.timeEnd('build all items');
-                res = table;
-            }
-            console.timeEnd('buildResultTable')
-            return res;
-        },
-
-        buildPropertyValueCell: function(item, property, referencePropertyValue, repository, lineIsVisible) {
-            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell');
-
-
-            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.extractValue');
-            let propertyValue = item.values[property.name];
-            logTrace('buildPropertyValueCell : propertyValue', propertyValue);
-            let val;
-            try {
-                val = propertyValue.value;
-            } catch (e) {
-                val = '';
-            }
-            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.extractValue');
-
-            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.displayedVal');
-            let displayedVal;
-            if (lineIsVisible && property.isItem) {
-
-                displayedVal = BDA_REPOSITORY.buildLinkToOtherItem( val, property);
-
-            } else {
-                displayedVal = val;
-            }
-               BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.displayedVal');
-
-
-            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.innerVal');
-            let innerVal;
-            let long = false;
-            if (val.length <= BDA_REPOSITORY.CELL_MAX_LENGTH) {
-                innerVal = BDA_REPOSITORY.templates.shortPropertyCell.format(val,displayedVal);
-            } else {
-                long = true;
-                let short = val.substr(0, BDA_REPOSITORY.CELL_MAX_LENGTH) + ' ...';
-                innerVal = BDA_REPOSITORY.templates.longPropertyCell.format(short,val,displayedVal);
-            }
-            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.innerVal');
-
-
-            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.formatCell');
-            let resAsString = BDA_REPOSITORY.templates.propertyCell.format(
-              innerVal,
-              item.id, 
-              property.name,
-              long?'toggable':'',
-              (propertyValue && propertyValue.isDefault)?'default':'',
-              displayedVal);
-
-          //  res = $(resAsString);
-            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.formatCell');
-
-
-           
-
-
-         
-
-            // if (lineIsVisible && !_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
-            //   BDA_REPOSITORY.addInlineEditFormFromObjects(res, val, property, item, repository);
-            // }
-            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell');
-            // console.timeEnd('buildPropertyValueCell ' + property.name);
-            return resAsString;
-        },
-
-        onReload: function(elem) {
-            console.log('reloadItem')
-            let $this = $(elem);
-            let property = $this.closest('.property');
-            let id = property.attr('data-id');
-            let item = property.attr('data-item');
-            let repoPath = property.attr('data-repository');
-            let parentTab = $this.closest('.dataTable');
-            $this.addClass('fa-spin');
-            BDA_REPOSITORY.reloadTab(id, item, repoPath, parentTab, () => {
-                $this.removeClass('fa-spin');
+          })
+        }
+      } else {
+
+        // Init code mirror
+        editor = CodeMirror.fromTextArea(document.getElementById("xmltext"), {
+          lineNumbers: false,
+        });
+
+      }
+      return editor;
+    },
+
+    setupEditableTable: function() {
+      $('body').on('click', '.dataTable .fa-pencil-square-o', function(item) {
+        var $target = $(item.target).parent();
+        $target.html('<input type="text" value="' + $target.text().replace(/●/g, ' ') + '"/>');
+        var $input = $($target.children()[0]);
+        $input.focus().blur(function(item) {
+          var $target = $(item.target);
+          var $table = $target.parents(".dataTable");
+          var descriptor = $table.attr("data-descriptor");
+          var itemId = $target.parent().attr("data-id");
+          var propertyName = $target.parent().attr("data-property");
+          if (propertyName == "id" || propertyName == "descriptor") {
+            $input.parent().html($input.val());
+            $.notify(
+              "You can't change value of id or descriptor this way.", {
+                position: "top center",
+                className: "error"
+              }
+            );
+            return;
+          }
+          logTrace(itemId + " " + descriptor + " " + $target.val() + " " + propertyName);
+          var query = '<update-item id="' + itemId + '" item-descriptor="' + descriptor + '">\n' + '  <set-property name="' + propertyName + '"><![CDATA[' + $target.val() + ']]>' + '</set-property>\n</update-item>';
+          var initialValue = $input.attr("value");
+          if (confirm('You are about to execute this query : \n' + query)) {
+            jQuery.post(document.location.href, 'xmltext=' + query, function(res) {
+              var $res = $(res);
+              var errorsSelector1 = "Errors:";
+              if ($res.text().indexOf(errorsSelector1) != -1) {
+                var errorMsg = $res.find("code").text().trim();
                 $.notify(
-                    "Success: Reloaded {0} {1}".format(item, id), {
-                        className: "success",
-                        position: "top center",
-                        autoHideDelay: 3000
-                    }
+                  "Error : " + errorMsg, {
+                    position: "top left",
+                    className: "error",
+                    autoHide: true,
+                    autoHideDelay: 15000
+                  }
                 );
-
+                $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + initialValue); // reset inital value
+              } else {
+                $.notify(
+                  "Value succesfully changed", {
+                    position: "top center",
+                    className: "success"
+                  }
+                );
+              }
+              $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + $input.val());
             });
-        },
+          } else
+            $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + initialValue); // reset inital value
+        });
+      });
 
-        onEdit: function($this) {
-            logInfo('click on start edit');
+    },
 
-            let propertyElem = $this.closest('.property');
+    addToQueryEditor: function(query) {
+      var editor = BDA_REPOSITORY.queryEditor;
+      var editorCursor = editor.getCursor();
+      if (editorCursor.ch !== 0)
+        editor.setCursor(editor.getCursor().line + 1, 0);
+
+      BDA_REPOSITORY.queryEditor.replaceSelection(query);
+    },
+
+    setupPropertiesTables: function() {
+      if ($("a[name=showProperties]").length > 0) {
+        $("a[name=showProperties]").next().attr("id", "propertiesTable");
+        $("#propertiesTable").find("tr:nth-child(odd)").addClass("odd");
+      }
+    },
+
+    setupItemDescriptorTable: function() {
+      var descriptors = BDA_REPOSITORY.getDescriptorList();
+      var componentURI = window.location.pathname;
+      var splitValue = 20;
+      var html = "<p>" + descriptors.length + " descriptors available.</p>";
+      html += "<div>";
+      for (var i = 0; i != descriptors.length; i++) {
+        if (i === 0 || i % splitValue === 0) {
+          html += "<table class='descriptorTable'>";
+          html += "<th>Descriptor</th>";
+          html += "<th>View</th>";
+          html += "<th>Debug</th>";
+        }
+        if (i % 2 === 0)
+          html += "<tr class='even'>";
+        else
+          html += "<tr class='odd'>";
+        var isDebugEnable = false;
+        if ($("a[href='" + componentURI + "?action=clriddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors']").length > 0)
+          isDebugEnable = true;
+        html += "<td class='descriptor'>" + descriptors[i] + "</td>";
+        html += "<td><a class='btn-desc' href='" + componentURI + "?action=seetmpl&itemdesc=" + descriptors[i] + "#showProperties'>Properties</a>";
+        html += "&nbsp;<a class='btn-desc' class='btn-desc' href='" + componentURI + "?action=seenamed&itemdesc=" + descriptors[i] + "#namedQuery'>Named queries</a></td>";
+
+        html += "<td>";
+        if (isDebugEnable)
+          html += "<a class='btn-desc red' href='" + componentURI + "?action=clriddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors'>Disable</a>";
+        else {
+          html += "<a class='btn-desc' href='" + componentURI + "?action=setiddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors'>Enable</a>";
+          html += "&nbsp;<a class='btn-desc' href='" + componentURI + "?action=dbgprops&itemdesc=" + descriptors[i] + "#debugProperties'>Edit</a>";
+        }
+        html += "</td>";
+        html += "</tr>";
+        if (i !== 0 && ((i + 1) % splitValue === 0 || i + 1 === descriptors.length))
+          html += "</table>";
+      }
+      html += "</div>";
+      html += "<div style='clear:both' />";
+
+      $("#descriptorTable").remove();
+      $(html).insertAfter("a[name='listItemDescriptors']");
+    },
 
 
-            if (_.isNil(propertyElem.attr('data-form-generated'))) {
+    showItemPropertyList: function(item) {
+      logTrace("showItemPropertyList");
+      var componentURI = window.location.pathname;
+      var url = componentURI + "?action=seetmpl&itemdesc=" + item + "#showProperties";
+      $.get(url, function(data) {
+        logTrace("Enter showItemPropertyList callback");
+        var $pTable = $(data).find("a[name='showProperties']").next();
+        $pTable.find('th:nth-child(2), td:nth-child(2),th:nth-child(4), td:nth-child(4),th:nth-child(5), td:nth-child(5),th:nth-child(6), td:nth-child(6)').remove();
+        $pTable.find("tr").each(function(index) {
+          var $tr = $(this);
+          $tr.find("td").each(function(i) {
+            var $td = $(this);
+            if (i === 0) {
+              var content = $td.html();
+              var req = /[\w\s']+\((\w+)\)$/i;
+              content = content.replace(req, "<a class='itemPropertyBtn' href='javascript:void(0)'> $1 </a>");
+              $td.html(content);
+            } else if (i === 1)
+              $td.text($td.text().replace("Class", ""));
 
-                try {
+          });
+        });
+        logTrace($pTable);
+        $("#descProperties")
+          .empty()
+          .append($pTable);
 
-                    let dataTable = propertyElem.closest('.dataTable');
-                    let line = propertyElem.closest('.item-line')
+        $('.itemPropertyBtn').click(function(item) {
+          BDA_REPOSITORY.addToQueryEditor('<set-property name="' + $(this).text().trim() + '"><![CDATA[]]></set-property>\n');
+        });
+      });
+    },
 
-                    let itemName = dataTable.attr('data-descriptor');
-                    let repositoryPath = dataTable.attr('data-repository');
+    hasResultsFct: function(hasErrors) {
+      return $(BDA_REPOSITORY.resultsSelector).length > 0;
+    },
 
-                    let itemId = propertyElem.attr('data-id');
-                    let propertyName = propertyElem.attr('data-property');
-
-
-                    let val = propertyElem.find('.propertyValue').attr('data-raw');
-
-
-                    BDA_REPOSITORY.addInlineEditForm(propertyElem, val, propertyName, itemName, itemId, repositoryPath);
-                    propertyElem.attr('data-form-generated', true);
-
-                } catch (e) {
-                    console.error(e);
-                }
+    hasErrorsFct: function() {
+      return $(BDA_REPOSITORY.errorsSelector1).length > 0 || $(BDA_REPOSITORY.errorsSelector2).length > 0;
+    },
 
 
-            }
+    getDescriptorList: function() {
+      if (BDA_REPOSITORY.descriptorList)
+        return BDA_REPOSITORY.descriptorList;
+      var descriptors = [];
+      $("#descriptorTable tr th:first-child:not([colspan])")
+        .sort(function(a, b) {
+          return $(a).text().toLowerCase() > $(b).text().toLowerCase() ? 1 : -1;
+        }).each(function() {
 
-            propertyElem.addClass('show-edit').find('.inline-input').focus();
-        },
+          descriptors.push($(this).html().trim());
+        });
+      BDA_REPOSITORY.descriptorList = descriptors;
+      return descriptors;
+    },
 
-        buildLinkToOtherItem: function( val, property) {
-            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.buildLinkToOtherItem');
+    getDescriptorOptions: function() {
+      var descriptorOptions = "";
+      var descriptors = BDA_REPOSITORY.getDescriptorList();
+      descriptorOptions = "";
+      var defaultDesc = BDA_REPOSITORY.defaultDescriptor[getComponentNameFromPath(getCurrentComponentPath())];
+      if (defaultDesc === undefined)
+        descriptorOptions = "<option></option>";
+      for (var i = 0; i != descriptors.length; i++) {
+        descriptorOptions += "<option value='" + descriptors[i] + "'";
+        if (defaultDesc === descriptors[i])
+          descriptorOptions += "selected='selected'";
+        descriptorOptions += ">" + descriptors[i] + "</option>\n";
+      }
+      return descriptorOptions;
+    },
 
-            let res;
-            // handle map types
-            let ids = _(val)
-                .split(',')
-                .map(sPair => _.split(sPair, '='))
-                .map(pairArray => {
-                    if (pairArray.length >= 2) {
-                        return {
-                            id: pairArray[1].trim(),
-                            key: pairArray[0].trim()
-                        }
-                    } else if (pairArray.length == 1) {
-                        return {
-                            id: pairArray[0].trim()
-                        }
-                    } else {
-                        return null;
-                    }
+    getsubmitButton: function() {
+      return "<button type='button' id='RQLAdd'>Add</button>" + "<button type='button' id='RQLGo'>Add & Enter <i class='fa fa-play fa-x'></i></button>";
+    },
 
-                })
-                .filter(elem => !_.isNil(elem))
-                .value();
+    getPrintItemEditor: function() {
+      $("#itemIdField").show();
+      $("#itemDescriptorField").show();
+      $("#idOnlyField").hide();
+    },
 
-            _(ids)
-                .map(elem => {
-                    let cell = $('<span class="clickable_property loadable_property {1}">{0}</span>'.format(elem.id, property.isItemOfSameRepository ? '' : 'newpage'))
-                        .on('click', function() {
+    getAddItemEditor: function() {
+      $("#itemIdField").hide();
+      $("#itemDescriptorField").show();
+      $("#idOnlyField").hide();
+    },
 
-                            if (property.isItemOfSameRepository) {
-                                let $this = $(this);
-                                try {
-                                    //find the item if same id
-                                    // load the result in the parent section (repo/itemtree/dashscreen)
-                                    let outputDiv = $this.closest('.rqlResultContainer');
-                                    let selector = '.idCell[data-id="{0}"]'.format(elem.id);
-                                    let resultTable = outputDiv.find(selector);
-                                    // if the result already exists, just scroll to it
-                                    if (resultTable.length > 0) {
-                                        resultTable.scrollTo();
-                                        resultTable.find('[data-id="{0}"]'.format(elem.id)).flash(); //flash the whole tab
-                                    } else {
-                                        let $property = $this.parent().parent();
-                                        $property.addClass('loading');
-                                        let endLoadingFc = () => {
-                                            $property.removeClass('loading');
-                                        };
-                                        BDA_REPOSITORY.loadSubItem(elem.id, property.itemType, property.itemRepository, outputDiv, null, null, endLoadingFc);
-                                    }
-                                } catch (e) {
-                                    console.error(e)
-                                }
+    getRemoveItemEditor: function() {
+      BDA_REPOSITORY.getPrintItemEditor();
+    },
 
-                            } else {
-                                //create a form that will post to a new tab
-                                try {
+    getRemoveItemsEditor: function() {
+      BDA_REPOSITORY.getPrintItemEditor();
+    },
 
-                                    var xmlText = BDA_REPOSITORY.templates.printItem.format(property.itemType, elem.id);
-                                    let form = $('<form  action="/dyn/admin/nucleus{0}/" method="POST" target="_blank"><textarea name="xmltext" ></textarea><input value="Enter" type="submit"></form>'.format(property.itemRepository));
-                                    form
-                                        .appendTo('body')
-                                        .find('textarea')
-                                        .val(xmlText)
-                                        .end()
-                                        .submit()
-                                        .remove();
+    getUpdateItemEditor: function() {
+      BDA_REPOSITORY.getPrintItemEditor();
+    },
 
-                                } catch (e) {
-                                    console.error(e);
-                                }
-                            }
-                        });
-                    return {
-                        key: elem.key,
-                        cell: cell
-                    }
+    getQueryItemsEditor: function() {
+      $("#itemIdField").hide();
+      $("#itemDescriptorField").show();
+      $("#idOnlyField").show();
+    },
 
-                })
-                .each((elem, idx) => {
-                    if (!_.isNil(elem.key)) {
-                        res +='{0} = '.format(elem.key);
-                    }
-                    res +=(elem.cell).html()
-                    if (idx < ids.length - 1) {
-                        res += ' , ';
-                    }
-                });
-            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.buildLinkToOtherItem');
-        },
+    getMultiId: function() {
+      var ids = $("#itemId").val().trim();
+      if (ids.indexOf(",") != -1)
+        return ids.split(",");
+      return [ids];
+    },
 
-        addInlineEditFormFromObjects: function(output, val, property, item, repository) {
-            BDA_REPOSITORY.addInlineEditForm(output, val, property.name, item.id, repository.path);
-        },
+    getPrintItemQuery: function() {
+      var ids = BDA_REPOSITORY.getMultiId();
+      var descriptor = $("#itemDescriptor").val();
+      var query = "";
+      for (var i = 0; i != ids.length; i++)
+        query += "<print-item id=\"" + ids[i].trim() + "\" item-descriptor=\"" + descriptor + "\" />\n";
+      return query;
+    },
 
-        addInlineEditForm: function(output, val, propertyName, itemName, itemId, repositoryPath) {
-            BDA_REPOSITORY.PERF_MONITOR.start('addInlineEditForm');
-            logInfo('addInlineEditForm', arguments);
-            try {
+    getRemoveItemQuery: function() {
+      var ids = BDA_REPOSITORY.getMultiId();
+      var descriptor = $("#itemDescriptor").val();
+      var query = "";
+      for (var i = 0; i != ids.length; i++)
+        query += "<remove-item id=\"" + ids[i].trim() + "\" item-descriptor=\"" + descriptor + "\" />\n";
+      return query;
+    },
 
-                let form = $('<form class="edit"></form>');
-                let input = $('<textarea class="inline-input" rows="1"></input>').val(val);
-                input.appendTo(form);
-                input.on('blur', function() {
+    getAddItemQuery: function() {
+      var descriptor = $("#itemDescriptor").val();
+      var query = "<add-item item-descriptor=\"" + descriptor + "\" >\n";
+      query += "  <set-property name=\"\"><![CDATA\[]]></set-property>\n";
+      query += "</add-item>\n";
+      return query;
+    },
 
-                    try {
+    getUpdateItemQuery: function() {
+      var descriptor = $("#itemDescriptor").val();
+      var ids = BDA_REPOSITORY.getMultiId();
+      var query = "";
+      for (var i = 0; i != ids.length; i++) {
+        query += "<update-item id=\"" + ids[i] + "\" item-descriptor=\"" + descriptor + "\" >\n";
+        query += "  <set-property name=\"\"><![CDATA\[]]></set-property>\n";
+        query += "</update-item>\n";
+      }
+      return query;
+    },
 
-                        let newVal = input.val();
-                        if (newVal === val) {
-                            input.closest('.property').removeClass('show-edit');
-                            return; // exit if no change
-                        }
-                        var xmlText = BDA_REPOSITORY.templates.editProperty.format(itemName, itemId, propertyName, newVal);
-                        let highlighted = $('<div class="xml"><pre><code></code></pre></div>');
-                        highlighted.find('code').text(xmlText);
-                        highlighted.each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        })
+    getQueryItemsQuery: function() {
+      var descriptor = $("#itemDescriptor").val();
+      var idOnly = $("#idOnly").prop('checked');
+      var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n\n";
+      query += "</query-items>\n";
+      return query;
+    },
 
-                        $('body').bdaAlert({
-                            msg: 'You are about to execute this query : \n {0}'.format(highlighted.html()),
-                            options: [{
-                                label: 'Confirm',
-                                _callback: function() {
-                                    BDA_REPOSITORY.executeQuery('', xmlText, repositoryPath,
-                                        (result) => {
-                                            try {
-                                                var xmlContent = $('<div>' + result + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
-                                                let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
+    getAllItemQuery: function() {
+      var descriptor = $("#itemDescriptor").val();
+      var idOnly = $("#idOnly").prop('checked');
+      var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
+      query += "ALL\n";
+      query += "</query-items>\n";
+      return query;
+    },
 
-                                                let parentTab = input.closest('.dataTable');
-                                                BDA_REPOSITORY.reloadTab(itemId, itemName, repositoryPath, parentTab, () => {
+    getLast10ItemQueryOrdered: function() {
+      var descriptor = $("#itemDescriptor").val();
+      var idOnly = $("#idOnly").prop('checked');
+      var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
+      query += "ALL ORDER BY ID DESC RANGE 0+10\n";
+      query += "</query-items>\n";
+      return query;
+    },
 
-                                                    $.notify(
-                                                        "Success: \n{0}".format(logs), {
-                                                            className: "success",
-                                                            position: "top center",
-                                                            autoHideDelay: 5000
 
-                                                        }
-                                                    );
+    getLast10ItemQuery: function() {
+      var descriptor = $("#itemDescriptor").val();
+      var idOnly = $("#idOnly").prop('checked');
+      var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
+      query += "ALL RANGE 0+10\n";
+      query += "</query-items>\n";
+      return query;
+    },
 
-                                                });
+    getRQLQuery: function() {
+      var query = "";
+      var action = $("#RQLAction").val();
+      logTrace("getRQLQuery : " + action);
+      if (action == "print-item")
+        query = BDA_REPOSITORY.getPrintItemQuery();
+      else if (action == "query-items")
+        query = BDA_REPOSITORY.getQueryItemsQuery();
+      else if (action == "remove-item")
+        query = BDA_REPOSITORY.getRemoveItemQuery();
+      else if (action == "add-item")
+        query = BDA_REPOSITORY.getAddItemQuery();
+      else if (action == "update-item")
+        query = BDA_REPOSITORY.getUpdateItemQuery();
+      else if (action == "all")
+        query = BDA_REPOSITORY.getAllItemQuery();
+      else if (action == "last_10_ordered")
+        query = BDA_REPOSITORY.getLast10ItemQueryOrdered();
+      else if (action == "last_10")
+        query = BDA_REPOSITORY.getLast10ItemQuery();
+      return query;
+    },
+    submitRQLQuery: function(addText) {
+      if (addText) {
+        var query = BDA_REPOSITORY.getRQLQuery();
+        BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
+      }
+      BDA_REPOSITORY.sanitizeQuery();
+      BDA_STORAGE.storeSplitValue();
+      // set anchor to the result div
+      location.hash = '#RQLResults';
+      $("#RQLForm").submit();
+    },
 
-                                            } catch (e) {
-                                                console.error(e);
-                                            }
+    sanitizeQuery: function() {
+      var query = BDA_REPOSITORY.getQueryEditorValue();
+      BDA_REPOSITORY.setQueryEditorValue(query.replace(/repository\=\".+\"/gi, ""));
+    },
 
-                                        },
-                                        (jqXHR, textStatus, errorThrown) => {
-                                            $.notify(
-                                                "Error during call: {0}.".format(errorThrown), {
-                                                    className: "error",
-                                                    position: "top center",
-                                                    autoHide: false
-                                                }
-                                            );
-                                        });
-                                }
-                            }, {
-                                label: 'Cancel'
-                            }]
-                        });
-                    } catch (e) {
-                        console.error(e);
-                    }
+    setQueryEditorValue: function(value) {
+      BDA_REPOSITORY.queryEditor.getDoc().setValue(value);
+    },
 
-                })
-                output.append(form);
-            } catch (e) {
-                console.error(e);
-            }
-            BDA_REPOSITORY.PERF_MONITOR.cumul('addInlineEditForm');
+    getQueryEditorValue: function() {
+      return BDA_REPOSITORY.queryEditor.getDoc().getValue();
+    },
 
-        },
-        closeTab: function(idCell, container) {
-            try {
-                logTrace('closetab', idCell);
-                let tab = idCell.closest('.dataTable');
-                tab.find('[data-id="{0}"]'.format(idCell.attr('data-id'))).remove();
-                //if last item remove tab
-                let tabSize = tab.find('.idCell').length;
-                let container = tab.closest('.rqlResultContainer');
-                BDA_REPOSITORY.reloadSpeedBar(container);
-                if (tabSize == 0) {
-                    tab.remove();
-                }
-            } catch (e) {
-                console.error(e);
-            }
+    showTextField: function(baseId) {
+      baseId = BDA_REPOSITORY.sanitizeSelector(baseId);
+      $("#" + baseId).toggle();
+      $("#text_" + baseId).toggle();
+    },
 
-        },
+    // Escape '.', ':' in a jquery selector
+    sanitizeSelector: function(id) {
+      return id.replace(/(:|\.|\[|\]|,)/g, "\\$1");
+    },
 
-        findTabToAppendTo: function(itemDescriptorName, outputDiv) {
-            let dataTables = outputDiv.find('.dataTable[data-descriptor="{0}"]'.format(itemDescriptorName));
-            var max = BDA_REPOSITORY.getChunkSize();
-            let res;
-            logTrace('dataTables', dataTables);
-            dataTables.each(function(idx, table) {
-                let $table = $(table);
-                logTrace('table', $table);
-                if ($table.find('.idCell').length < max) {
-                    res = $table;
-                }
+    purgeXml: function(xmlContent) {
+      var xmlStr = "";
+      var lines = xmlContent.split("\n");
+      for (var i = 0; i != lines.length; i++) {
+        var line = lines[i].trim();
+        if (!(line.substr(0, 1) == "<" && endsWith(line, ">")))
+          xmlStr += line + "\n";
+      }
+      return xmlStr;
+    },
+
+
+    // Check if the given property contains id(s) with the given item descriptor
+    // Return an item descriptor name if the property is an ID,
+    // Return null if the property is not found,
+    // Return "FOUND_NOT_ID" is the property is found but is not an ID
+    isPropertyId: function(propertyName, $itemDesc) {
+      var isId = null;
+      var propertyFound = false;
+      $itemDesc.find("property[name=" + propertyName + "]").each(function() {
+        propertyFound = true;
+        var $property = $(this);
+        if ($property.attr("item-type") !== undefined && $property.attr("repository") === undefined)
+          isId = $property.attr("item-type");
+        else if ($property.attr("component-item-type") !== undefined && $property.attr("repository") === undefined)
+          isId = $property.attr("component-item-type");
+      });
+      if (propertyFound && isId === null)
+        return "FOUND_NOT_ID";
+      return isId;
+    },
+    // Check if the given property contains id(s) with the given repository definition
+    // Only ID from the current repository are take in account
+    // Return the item descriptor name if the type if an ID, null otherwise
+    isTypeId: function(propertyName, itemDesc, $xmlDef) {
+      var isId = null;
+      if ($xmlDef !== null) {
+        var $itemDesc = $xmlDef.find("item-descriptor[name='" + itemDesc + "']");
+        // First check in current item desc
+        isId = BDA_REPOSITORY.isPropertyId(propertyName, $itemDesc);
+        // In case we found the property but it's not an ID, we don't want to search in super-type
+        if (isId == "FOUND_NOT_ID")
+          return null;
+        // In case we found the property and it's an ID
+        if (isId !== null)
+          return isId;
+        // Now we check in each super-type item desc
+        var superType = $itemDesc.attr("super-type");
+        while (superType !== undefined && isId === null) {
+          var $parentDesc = $xmlDef.find("item-descriptor[name='" + superType + "']");
+          isId = BDA_REPOSITORY.isPropertyId(propertyName, $parentDesc);
+          superType = $parentDesc.attr("super-type");
+        }
+        if (isId == "FOUND_NOT_ID")
+          return null;
+      }
+      return isId;
+    },
+
+    // Parse the given repository ID into a tab, each index will contains an ID or a separator : "," or "="
+    parseRepositoryId: function(id) {
+      var idAsTab = [];
+      var tab = [];
+      // Case of simple ID
+      if (id.indexOf(BDA_REPOSITORY.MAP_SEPARATOR) == -1 && id.indexOf(BDA_REPOSITORY.LIST_SEPARATOR) === -1)
+        idAsTab.push(id);
+      // Case of a list of ID
+      else if (id.indexOf(BDA_REPOSITORY.MAP_SEPARATOR) == -1 && id.indexOf(BDA_REPOSITORY.LIST_SEPARATOR) !== -1) {
+        tab = id.split(BDA_REPOSITORY.LIST_SEPARATOR);
+        for (var i = 0; i != tab.length; i++) {
+          if (i !== 0)
+            idAsTab.push(BDA_REPOSITORY.LIST_SEPARATOR);
+          idAsTab.push(tab[i]);
+        }
+      }
+      // Case of a Map of ID
+      else {
+        var mapEntries = id.split(BDA_REPOSITORY.LIST_SEPARATOR);
+        for (var a = 0; a != mapEntries.length; a++) {
+          if (a !== 0)
+            idAsTab.push(BDA_REPOSITORY.LIST_SEPARATOR);
+          var mapValues = mapEntries[a].split(BDA_REPOSITORY.MAP_SEPARATOR);
+          for (var b = 0; b != mapValues.length; b++) {
+            if (b !== 0)
+              idAsTab.push(BDA_REPOSITORY.MAP_SEPARATOR);
+            idAsTab.push(mapValues[b]);
+          }
+        }
+      }
+      return idAsTab;
+    },
+
+    renderProperty: function(curProp, propValue, itemId, isItemTree) {
+      var html = "";
+      var td = "<td data-property='" + curProp.name + "' data-id='" + itemId + "'>";
+      if (propValue !== null && propValue !== undefined) {
+        propValue = propValue.replace(/ /g, '●');
+        // Remove "_"
+        if (curProp.name == "descriptor")
+          propValue = propValue.substr(1);
+        // propertyName_id
+        var base_id = curProp.name + "_" + itemId;
+
+        if (curProp.name == "id")
+          html += "<td id='" + base_id + "'>" + propValue + "</td>";
+        // Hide long value
+        else if (propValue.length > 25) {
+          var link_id = "link_" + base_id;
+          var field_id = "text_" + base_id;
+          propValue = "<a class='copyLink' href='javascript:void(0)' title='Show all' id='" + link_id + "' >" + "<span id='" + base_id + "'>" + BDA_REPOSITORY.escapeHTML(propValue.substr(0, 25)) + "..." + "</span></a><textarea class='copyField' id='" + field_id + "' readonly>" + propValue + "</textarea>";
+          html += td + propValue + "</td>";
+        }
+        // Make IDs clickable
+        else if (curProp.isId === true) {
+          propValue = BDA_REPOSITORY.parseRepositoryId(propValue);
+          html += td;
+          for (var b = 0; b != propValue.length; b++) {
+            if (propValue[b] != BDA_REPOSITORY.MAP_SEPARATOR && propValue[b] != BDA_REPOSITORY.LIST_SEPARATOR) {
+              if (isItemTree) // for item tree we create an anchor link
+                html += "<a class='clickable_property' href='#id_" + propValue[b] + "'>" + propValue[b] + "</a>";
+              else
+                html += "<a class='clickable_property loadable_property' data-id='" + propValue[b] + "' data-descriptor='" + curProp.itemDesc + "'>" + propValue[b] + "</a>";
+            } else
+              html += propValue[b];
+          }
+          html += "</td>";
+        }
+        // descriptor, Read only and derived porperty are not editable
+        else if (curProp.name == "descriptor" || curProp.rdonly == "true" || curProp.derived == "true")
+          html += "<td>" + propValue + "</td>";
+        else
+          html += td + '<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + propValue + "</td>";
+      } else
+        html += td + '<i class="fa fa-pencil-square-o" aria-hidden="true"></i></td>';
+
+      return html;
+    },
+
+    renderTab: function(itemDesc, types, datas, tabId, isItemTree) {
+      var html = "";
+      html += "<table class='dataTable' data-descriptor='" + itemDesc.substr(1) + "' ";
+      if (isItemTree)
+        html += "id='" + tabId + "'";
+      html += ">";
+      for (var i = 0; i != types.length; i++) {
+        var curProp = types[i];
+        if (i % 2 === 0)
+          html += "<tr class='even";
+        else
+          html += "<tr class='odd";
+
+        if (curProp.name == "id")
+          html += " id";
+        else if (curProp.name == "descriptor")
+          html += " descriptor";
+
+        html += "'>";
+        html += "<th>" + curProp.name + "<span class='prop_name'>";
+        if (curProp.rdonly == "true")
+          html += "<div class='prop_attr prop_attr_red'>R</div>";
+        if (curProp.derived == "true")
+          html += "<div class='prop_attr prop_attr_green'>D</div>";
+        if (curProp.exportable == "true")
+          html += "<div class='prop_attr prop_attr_blue'>E</div>";
+        html += "</span></th>";
+
+        for (var a = 0; a < datas.length; a++) {
+          var propValue = datas[a][curProp.name];
+          html += BDA_REPOSITORY.renderProperty(curProp, propValue, datas[a].id, isItemTree);
+        }
+        html += "</tr>";
+      }
+      html += "</table>";
+      return html;
+    },
+
+    getDescriptorAndDefaultValues: function(itemDescriptor, $xmlDef, descriptorAndDefaultValues) {
+      descriptorAndDefaultValues[itemDescriptor] = {};
+      var itemDefinition = $xmlDef.find("item-descriptor[name=" + itemDescriptor + "]");
+      var defaultProperties = $xmlDef.find("item-descriptor[name=" + itemDescriptor + "] property[default]");
+      if (itemDefinition !== undefined && itemDefinition.length > 0) {
+        var superType = itemDefinition[0].getAttribute("super-type");
+        defaultProperties = defaultProperties.toArray().concat($xmlDef.find("item-descriptor[name=" + superType + "] property[default]").toArray());
+      }
+      for (var defaultPropertiesIndex = 0; defaultPropertiesIndex < defaultProperties.length; defaultPropertiesIndex++) {
+        var defaultProperty = defaultProperties[defaultPropertiesIndex];
+        var defaultPropertyName = defaultProperty.getAttribute("name");
+        var defaultPropertyValue = defaultProperty.getAttribute("default");
+        descriptorAndDefaultValues[itemDescriptor][defaultPropertyName] = defaultPropertyValue;
+      }
+    },
+
+    //same as getDescriptorAndDefaultValues but using Objects
+    buildItemDescriptor: function(itemDescriptorName, $xmlDef, repository) {
+      BDA_REPOSITORY.PERF_MONITOR.start('buildItemDescriptor');
+      //  console.time(itemDescriptorName);
+      var $itemDefinition = $xmlDef.find('item-descriptor[name={0}]'.format(itemDescriptorName));
+
+      // first get properties from the parent, if it exists
+      var superType = $itemDefinition.attr("super-type");
+      let parent = null;
+      if (!_.isNil(superType)) {
+        parent = repository.getItemDescriptor(superType); //this will build parents by recursion if necessary
+      }
+      let propertyDescriptors = {};
+      if (!_.isNil(parent)) {
+        propertyDescriptors = parent.properties;
+      }
+
+      // then add current properties
+      var $properties = $itemDefinition.find('property');
+
+      var selfPropertyDescriptors = {};
+      $properties.each(function() {
+        let $prop = $(this);
+        let name = $prop.attr('name');
+        let propDesc = new PropertyDescriptor($prop, repository);
+        let defaultValue = $prop.attr('default');
+        if (!_.isNil(defaultValue)) {
+          propDesc.defaultValue = defaultValue;
+        }
+        selfPropertyDescriptors[name] = propDesc;
+      });
+
+      propertyDescriptors = _.merge(propertyDescriptors, selfPropertyDescriptors);
+      propertyDescriptors = _.sortKeysBy(propertyDescriptors);
+
+      let desc = new ItemDescriptor({
+        name: itemDescriptorName,
+        xmlDefinition: $itemDefinition,
+        properties: propertyDescriptors
+      });
+      //  console.timeEnd(itemDescriptorName);
+      BDA_REPOSITORY.PERF_MONITOR.cumul('buildItemDescriptor');
+      return desc;
+    },
+
+    getRepositoryAsync: function(path, callback) {
+      logTrace('getRepositoryAsync', path);
+      let repository = BDA_REPOSITORY.repositories[path];
+      if (_.isNil(repository)) {
+        processRepositoryXmlDef("definitionFiles",
+          ($xmlDef) => {
+
+            repository = BDA_REPOSITORY.getRepository($xmlDef, path);
+            callback(repository);
+          }, path)
+
+      } else {
+        callback(repository)
+      }
+    },
+
+    getRepository: function($xmlDef, repositoryPath) {
+      logTrace('getRepository', repositoryPath);
+      let repository = BDA_REPOSITORY.repositories[repositoryPath];
+      if (_.isNil(repository)) {
+        repository = new Repository({
+          path: repositoryPath,
+          xmlDefinition: $xmlDef
+        })
+        BDA_REPOSITORY.repositories[repositoryPath] = repository;
+      }
+      return repository;
+    },
+
+
+    showXMLAsTab: function(rawXml, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
+      let xmlContent = sanitizeXml(rawXml);
+
+      console.time('showXMLAsTab_new');
+      if (_.isEmpty(repositoryPath)) {
+        repositoryPath = getCurrentComponentPath();
+      }
+      let repository = BDA_REPOSITORY.getRepository($xmlDef, repositoryPath);
+      let parsedResult = BDA_REPOSITORY.parseXmlResult(xmlContent, repository, rawXml);
+
+      let items = parsedResult.items;
+      let logs = parsedResult.logs;
+
+      BDA_REPOSITORY.renderResultSection(items, repository, $outputDiv, isItemTree);
+
+      //  if (isItemTree) {
+      BDA_REPOSITORY.createSpeedbar_new($outputDiv);
+      //}
+
+      BDA_REPOSITORY.PERF_MONITOR.log();
+      console.timeEnd('showXMLAsTab_new');
+      return logs;
+    },
+
+    renderResultSection: function(items, repository, $outputDiv, isItemTree) {
+      console.time('renderResultSection');
+      // now render the result section
+      $outputDiv.append("<div class='prop_attr prop_attr_red'>R</div> : read-only " +
+        "<div class='prop_attr prop_attr_green'>D</div> : derived " +
+        "<div class='prop_attr prop_attr_blue'>E</div> : export is false," +
+        '&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i> : Link to other Repository,' +
+        '&nbsp;<span class="default">grey</span> : default value');
+
+      // show all button
+      let showAll = $('<button>Show All <i class="fa fa-expand" aria-hidden="true"></i></button>');
+      let hideAll = $('<button>Collapse All <i class="fa fa-compress" aria-hidden="true"></i></button>');
+
+      showAll.on('click', function() {
+        $('.property')
+          .removeClass('show-short')
+          .addClass('show-long');
+        $(this).hide();
+        hideAll.show();
+      })
+
+      hideAll.on('click', function() {
+        $('.property')
+          .addClass('show-short')
+          .removeClass('show-long');
+        $(this).hide();
+        showAll.show();
+      }).hide();
+
+
+      $outputDiv.append($('<p></p>').append(showAll).append(hideAll));
+
+      if (isItemTree) {
+        $('<button>Show speedbar</button></p>')
+          .on('click', () => $('#speedbar').fadeIn(200))
+          .appendTo($outputDiv);
+      }
+
+
+      BDA_REPOSITORY.formatTabResult(repository, items, $outputDiv);
+      console.timeEnd('renderResultSection');
+
+    },
+
+    parseXhrResult: function(xhrResult, repositoryPath, callback) {
+
+      BDA_REPOSITORY.getRepositoryAsync(repositoryPath, (repository) => {
+        try {
+          logTrace('parseXhrResult', repositoryPath, xhrResult);
+          var rawXml = $('<div>' + xhrResult + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
+          let xmlContent = sanitizeXml(rawXml);
+          let result = BDA_REPOSITORY.parseXmlResult(xmlContent, repository, rawXml);
+          result.repository = repository;
+          logTrace('parseXhrResult result:', result);
+          callback(result);
+        } catch (e) {
+          console.error(e);
+        }
+      })
+
+    },
+
+    parseXmlResult: function(xmlContent, repository, rawXml) {
+      console.time('parseXmlResult');
+      try {
+
+        var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
+        var $xml = $(xmlDoc);
+        var rawXmlDoc = $($.parseXML("<xml>" + rawXml + "</xml>"));
+        var $addItems = $xml.find("add-item");
+        let items = BDA_REPOSITORY.parseXmlAsObjects($addItems, repository, rawXmlDoc);
+        let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
+        console.timeEnd('parseXmlResult');
+        return {
+          items: items,
+          logs: logs
+        }
+      } catch (e) {
+        console.error(e);
+        console.timeEnd('parseXmlResult');
+      }
+
+    },
+    getExecutionLogs: function(xmlContent) {
+      var log = $("<xml>" + xmlContent + "</xml>")
+        .children()
+        .remove()
+        .end()
+        .text()
+        .trim();
+      return log;
+    },
+
+    getChunkSize: function() {
+      let chunkSize = 1;
+      var splitObj = BDA_STORAGE.getStoredSplitObj();
+      // activeSplit == don't split - don't ask me why this name...
+      if (_.isNil(splitObj) || !!splitObj.activeSplit) {
+        chunkSize = Number.MAX_SAFE_INTEGER;
+      } else {
+        chunkSize = parseInt(splitObj.splitValue);
+      }
+      if (chunkSize < 1) {
+        chunkSize = 1; // safety
+      }
+      return chunkSize;
+    },
+
+    formatTabResult: function(repository, repositoryItems, result) {
+      console.time('formatTabResult');
+      try {
+        let itemsByType = _.groupBy(repositoryItems, repoItem => !_.isNil(repoItem.itemDescriptor) ? repoItem.itemDescriptor.name : null);
+        let nbItemDescriptors = _.keys(itemsByType).length;
+        let res = $(BDA_REPOSITORY.templates.resultHeader.format(repositoryItems.length, nbItemDescriptors))
+
+        var chunkSize = BDA_REPOSITORY.getChunkSize();
+
+        // for each property, only display it if it'si not empty in one result
+        let renderContext = {}
+        _(itemsByType)
+          .each((items, itemDescName) => {
+            let desc = repository.getItemDescriptor(itemDescName);
+            renderContext[itemDescName] = {};
+            _.each(desc.properties, property => {
+              try {
+                renderContext[itemDescName][property.name] = _.some(items, item => item.hasValueFor(property.name));
+
+              } catch (e) {
+                console.err('error finding render context for: itemDescName,items, property', itemDescName, items, property);
+              }
             })
-            return res;
-        },
+          });
 
-        appendToDataTable: function(id, itemDescriptorName, repositoryPath, dataTable, tempResult, cb) {
-            let propertySelector = '.property[data-id="{0}"]'.format(id);
-            tempResult.find(propertySelector).each(function() {
-                let $this = $(this);
-                let propertyName = $this.attr('data-property');
-                dataTable.find('.item-line[data-property="{0}"]'.format(propertyName)).append($this);
+
+        // for each group of item by descriptor, split in chunks of same descriptor and max size 'chunkSize'
+        let chunks = _(itemsByType)
+          .map(group => _.chunk(group, chunkSize)) //split each group
+          .flatMap() //flatten the array of arrays
+          .value();
+
+
+        //now render each tab
+        let firstResult = _.chain(chunks)
+          .map(chunk => BDA_REPOSITORY.buildResultTable(chunk, renderContext, repository))
+          .filter(table => !_.isNil(table))
+          .map(table => {
+            table.appendTo(result)
+            return table;
+          })
+          .head().value();
+
+        return firstResult;
+
+      } catch (e) {
+        console.error(e);
+      }
+      console.timeEnd('formatTabResult');
+    },
+
+    parseXmlAsObjects: function($addItems, repository, rawXmlDoc) {
+      BDA_REPOSITORY.PERF_MONITOR.start('parseXmlAsObjects');
+      let res = $addItems.map(function() {
+        var currentItem = $(this);
+        var descriptorName = currentItem.attr("item-descriptor");
+        var id = currentItem.attr("id");
+        let itemDescriptor = repository.getItemDescriptor(descriptorName);
+        let rawXml;
+        if (!_.isNil(rawXmlDoc)) {
+          rawXml = rawXmlDoc.find('add-item[item-descriptor="{0}"][id="{1}"]'.format(descriptorName, id));
+        }
+        let repositoryItem = new RepositoryItem({
+          itemDescriptor: itemDescriptor,
+          id: id,
+          xmlDefinition: currentItem,
+          rawXml: rawXml.outerHTML()
+        })
+
+        currentItem.find('set-property').each(function() {
+          let currentProperty = $(this);
+          let propertyName = currentProperty.attr('name');
+          let propertyDescriptor;
+          if (!_.isNil(itemDescriptor)) {
+            propertyDescriptor = itemDescriptor.properties[propertyName];
+          }
+          let val = repositoryItem.values[propertyName];
+          if (_.isNil(val)) {
+            val = new PropertyValue(propertyDescriptor, currentProperty);
+            repositoryItem.values[propertyName] = val;
+          } else {
+            val.setValueFromXml(currentProperty);
+          }
+        })
+        logTrace('repoItem', repositoryItem);
+        return repositoryItem;
+      });
+      BDA_REPOSITORY.PERF_MONITOR.cumul('parseXmlAsObjects');
+      return res;
+    },
+
+    showNonEmptyLines: function(resultTable) {
+      resultTable.find('.item-line.hidden').each(function() {
+        let line = $(this);
+        let mustShow = _.some(line.find('.propertyValue').get(),
+          (elem) => !_.isEmpty($(elem).attr('data-raw'))
+        );
+        if (mustShow) {
+          line.removeClass('hidden');
+        }
+      })
+    },
+
+    buildResultTable: function(items, renderContext, repo) {
+      console.time('buildResultTable')
+      let res;
+      if (!_.isNil(items) && items.length > 0) {
+        let itemDescriptor = items[0].itemDescriptor;
+        let itemDescriptorName = itemDescriptor ? itemDescriptor.name : '';
+        let table = $(BDA_REPOSITORY.templates.resultTable.format(itemDescriptorName, repo.path));
+        let tableHead = $('<thead></thead>').appendTo(table);
+
+        let idLine = $('<tr class="id even"><th>{0}</th></tr>'.format(itemDescriptorName)).appendTo(tableHead);
+        _(items)
+          .map(item => $(BDA_REPOSITORY.templates.idCell.format(item.id, itemDescriptorName, repo.path)).data('repositoryItem', item))
+          .each((elem) => {
+            elem.appendTo(idLine)
+          });
+
+
+        // let descLineElems = _(items).map((item) => BDA_REPOSITORY.templates.descriptorCell.format(itemDescriptorName, item.id)).join('');
+        // let descLine = $('<tr class="descriptor odd"><th>descriptor</th>{0}</tr>'.format(descLineElems)).appendTo(tableHead);
+
+        let tbody = $('<tbody></tbody>').appendTo(table);
+        //for each property, get 
+        let index = 1;
+        console.time('build all items');
+        _(itemDescriptor.properties)
+          .each((property) => {
+
+            // hiden lines that have all null values
+            let lineIsVisible = !!renderContext[itemDescriptor.name][property.name]
+
+            let line = $('<tr class="item-line {0} {1}" data-property="{2}"></tr>'.format(getEvenOddClass(index), lineIsVisible ? '' : 'hidden', property.name));
+
+            //build property name cell
+            // the following flags have been set on the repoItem level :
+
+            let propertyNameCell = $('<th>{0}<span class="prop_name"></span></th>'.format(property.name)).appendTo(line);
+
+            let sampleItem = null
+
+            if (lineIsVisible) {
+              sampleItem = _.find(items, item => !_.isNil(item.values[property.name]));
+              index++;
+            }
+
+
+            if (lineIsVisible && !_.isNil(sampleItem)) {
+              let sampleValue = sampleItem.values[property.name];
+              if (!!sampleValue.derived) {
+                propertyNameCell.append('<div class="prop_attr prop_attr_green">D</div>');
+                line.addClass('derived');
+              }
+              if (!!sampleValue.rdonly) {
+                propertyNameCell.append('<div class="prop_attr prop_attr_red">R</div>');
+                line.addClass('rdonly');
+              }
+              if (!!sampleValue.exportable) {
+                propertyNameCell.append('<div class="prop_attr prop_attr_blue">E</div>');
+                line.addClass('exportable');
+              }
+              if (property.isItem && !property.isItemOfSameRepository) {
+                propertyNameCell.append('&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i>');
+                line.addClass('other-repository');
+              }
+            }
+
+            // add all cells
+            //   console.time('build all cells');
+            let cellsAsString = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem, repo, lineIsVisible));
+            // console.timeEnd('build all cells');
+            //console.time('append all cells');
+
+            $(cellsAsString.join()).appendTo(line);
+            // _.each(cells, cell => cell.appendTo(line));
+
+            //   console.timeEnd('append all cells');
+            line.appendTo(tbody);
+
+          });
+
+        //enable local collapse/expand
+        console.time('bind actions');
+        table
+          .on('click', '.actions .collapse', function() {
+            $(this).closest('.property').addClass('show-short').removeClass('show-long');
+          })
+          .on('click', '.actions .expand', function() {
+            $(this).closest('.property').removeClass('show-short').addClass('show-long');
+          })
+          .on('click', '.actions .start-edit', function() {
+            BDA_REPOSITORY.onEdit($(this));
+
+          })
+          .on('click', '.id .reload-item', function() {
+            BDA_REPOSITORY.onReload(this);
+          })
+          .on('click', '.id .copy-xml', function() {
+            copyToClipboard($(this).closest('.property').data('repositoryItem').rawXml);
+          })
+          .on('click', '.id .close-elem', function() {
+            logTrace('close-elem', $(this));
+            BDA_REPOSITORY.closeTab($(this).closest('.property'));
+          })
+          .on('click', '.loadable_property', function() {
+            BDA_REPOSITORY.onClickOnLoadSubItem($(this));
+          })
+        console.timeEnd('bind actions');
+
+        console.timeEnd('build all items');
+        res = table;
+      }
+      console.timeEnd('buildResultTable')
+      return res;
+    },
+
+    buildPropertyValueCell: function(item, property, referencePropertyValue, repository, lineIsVisible) {
+      BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell');
+
+      // get the value from the repoItem
+      BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.extractValue');
+      let propertyValue = item.values[property.name];
+      logTrace('buildPropertyValueCell : propertyValue', propertyValue);
+      let val;
+      try {
+        val = propertyValue.value;
+      } catch (e) {
+        val = '';
+      }
+      BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.extractValue');
+
+      // if the property is an item, build links
+      BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.displayedVal');
+      let displayedVal;
+      if (lineIsVisible && property.isItem) {
+
+        displayedVal = BDA_REPOSITORY.buildLinkToOtherItem(val, property);
+
+      } else {
+        displayedVal = val;
+      }
+      BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.displayedVal');
+
+
+      // now if the property is very long, create a trunctated version
+      BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.innerVal');
+      let innerVal;
+      let long = false;
+      if (val.length <= BDA_REPOSITORY.CELL_MAX_LENGTH) {
+        innerVal = BDA_REPOSITORY.templates.shortPropertyCell.format(val, displayedVal);
+      } else {
+        long = true;
+        let short = val.substr(0, BDA_REPOSITORY.CELL_MAX_LENGTH) + ' ...';
+        innerVal = BDA_REPOSITORY.templates.longPropertyCell.format(short, val, displayedVal);
+      }
+      BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.innerVal');
+
+
+      // finally build the cell
+      BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.formatCell');
+      let resAsString = BDA_REPOSITORY.templates.propertyCell.format(
+        innerVal,
+        item.id,
+        property.name,
+        long ? 'toggable' : '',
+        (propertyValue && propertyValue.isDefault) ? 'default' : '',
+        displayedVal);
+
+      BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.formatCell');
+
+      BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell');
+
+      return resAsString;
+    },
+
+    onReload: function(elem) {
+      console.log('reloadItem')
+      let $this = $(elem);
+      let property = $this.closest('.property');
+      let id = property.attr('data-id');
+      let item = property.attr('data-item');
+      let repoPath = property.attr('data-repository');
+      let parentTab = $this.closest('.dataTable');
+      $this.addClass('fa-spin');
+      BDA_REPOSITORY.reloadTab(id, item, repoPath, parentTab, () => {
+        $this.removeClass('fa-spin');
+        $.notify(
+          "Success: Reloaded {0} {1}".format(item, id), {
+            className: "success",
+            position: "top center",
+            autoHideDelay: 3000
+          }
+        );
+
+      });
+    },
+
+    onEdit: function($this) {
+      logInfo('click on start edit');
+
+      let propertyElem = $this.closest('.property');
+
+
+      if (_.isNil(propertyElem.attr('data-form-generated'))) {
+
+        try {
+
+          let dataTable = propertyElem.closest('.dataTable');
+          let line = propertyElem.closest('.item-line')
+
+          let itemName = dataTable.attr('data-descriptor');
+          let repositoryPath = dataTable.attr('data-repository');
+
+          let itemId = propertyElem.attr('data-id');
+          let propertyName = propertyElem.attr('data-property');
+
+
+          let val = propertyElem.find('.propertyValue').attr('data-raw');
+
+
+          BDA_REPOSITORY.addInlineEditForm(propertyElem, val, propertyName, itemName, itemId, repositoryPath);
+          propertyElem.attr('data-form-generated', true);
+
+        } catch (e) {
+          console.error(e);
+        }
+
+
+      }
+
+      propertyElem.addClass('show-edit').find('.inline-input').focus();
+    },
+
+    buildLinkToOtherItem: function(val, property) {
+      BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.buildLinkToOtherItem');
+
+      let res = "";
+      // handle map types
+      let ids = _(val)
+        .split(',')
+        .map(sPair => _.split(sPair, '='))
+        .map(pairArray => {
+          if (pairArray.length >= 2) {
+            return {
+              id: pairArray[1].trim(),
+              key: pairArray[0].trim()
+            }
+          } else if (pairArray.length == 1) {
+            return {
+              id: pairArray[0].trim()
+            }
+          } else {
+            return null;
+          }
+
+        })
+        .filter(elem => !_.isNil(elem))
+        .value();
+
+      console.log('link ids', ids);
+
+      _(ids)
+        .map(elem => {
+          let cell = '<span class="clickable_property loadable_property {1}" data-samerepo="{2}" data-id="{3}" data-item-desc="{4}" data-repository="{5}">{0}</span>'
+            .format(elem.id, property.isItemOfSameRepository ? '' : 'newpage', property.isItemOfSameRepository, elem.id, property.itemType, property.itemRepository)
+
+          return {
+            key: elem.key,
+            cell: cell
+          }
+
+        })
+        .each((elem, idx) => {
+          if (!_.isNil(elem.key)) {
+            res += '{0} = '.format(elem.key);
+          }
+          res += elem.cell
+          if (idx < ids.length - 1) {
+            res += ' , ';
+          }
+        });
+      BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.buildLinkToOtherItem');
+      return res;
+    },
+
+    onClickOnLoadSubItem: function(elem) {
+      let $this = $(elem);
+      let property = $this.closest('.property');
+
+      let isItemOfSameRepository = $this.attr('data-samerepo') === 'true'; //data is saved as string
+
+      let itemId = $this.attr('data-id');
+      let itemType = $this.attr('data-item-desc');
+      let repositoryPath = $this.attr('data-repository');
+
+      if (isItemOfSameRepository) {
+        try {
+          //find the item if same id
+          // load the result in the parent section (repo/itemtree/dashscreen)
+          let outputDiv = $this.closest('.rqlResultContainer');
+          let selector = '.idCell[data-id="{0}"]'.format(itemId);
+          let resultTable = outputDiv.find(selector);
+          // if the result already exists, just scroll to it
+          if (resultTable.length > 0) {
+            resultTable.scrollTo();
+            resultTable.find('[data-id="{0}"]'.format(itemId)).flash(); //flash the whole tab
+          } else {
+            let $property = $this.parent().parent();
+            $property.addClass('loading');
+            let endLoadingFc = () => {
+              $property.removeClass('loading');
+            };
+            BDA_REPOSITORY.loadSubItem(itemId, itemType, repositoryPath, outputDiv, null, null, endLoadingFc);
+          }
+        } catch (e) {
+          console.error(e)
+        }
+
+      } else {
+        //create a form that will post to a new tab
+        try {
+
+          var xmlText = BDA_REPOSITORY.templates.printItem.format(itemType, itemId);
+          let form = $('<form  action="/dyn/admin/nucleus{0}/" method="POST" target="_blank"><textarea name="xmltext" ></textarea><input value="Enter" type="submit"></form>'.format(repositoryPath));
+          form
+            .appendTo('body')
+            .find('textarea')
+            .val(xmlText)
+            .end()
+            .submit()
+            .remove();
+
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    },
+
+    addInlineEditFormFromObjects: function(output, val, property, item, repository) {
+      BDA_REPOSITORY.addInlineEditForm(output, val, property.name, item.id, repository.path);
+    },
+
+    addInlineEditForm: function(output, val, propertyName, itemName, itemId, repositoryPath) {
+      BDA_REPOSITORY.PERF_MONITOR.start('addInlineEditForm');
+      logInfo('addInlineEditForm', arguments);
+      try {
+
+        let form = $('<form class="edit"></form>');
+        let input = $('<textarea class="inline-input" rows="1"></input>').val(val);
+        input.appendTo(form);
+        input.on('blur', function() {
+
+          try {
+
+            let newVal = input.val();
+            if (newVal === val) {
+              input.closest('.property').removeClass('show-edit');
+              return; // exit if no change
+            }
+            var xmlText = BDA_REPOSITORY.templates.editProperty.format(itemName, itemId, propertyName, newVal);
+            let highlighted = $('<div class="xml"><pre><code></code></pre></div>');
+            highlighted.find('code').text(xmlText);
+            highlighted.each(function(i, block) {
+              hljs.highlightBlock(block);
             })
-
-            //  update the data
-            let idSelector = '.idCell[data-id="{0}"]'.format(id, itemDescriptorName);
-            dataTable.find('tr.id').append(tempResult.find(idSelector));
-            BDA_REPOSITORY.showNonEmptyLines(dataTable);
-            if (cb) {
-                cb();
-            }
-        },
-
-        reloadTab: function(id, itemDescriptorName, repositoryPath, parentTab, cb) {
-            if (_.isNil(repositoryPath)) {
-                repositoryPath = getCurrentComponentPath();
-            }
-            BDA_REPOSITORY.executePrintItem('', itemDescriptorName, id, repositoryPath,
-                function(result) {
-                    BDA_REPOSITORY.parseXhrResult(result, repositoryPath, (parsed) => {
-
-                        try {
-
-                            let tempResult = $('<div></div>');
-                            BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, tempResult);
-
-                            let propertySelector = '.property[data-id="{0}"]'.format(id);
-                            tempResult.find(propertySelector).each(function() {
-                                let $this = $(this);
-                                let propertyName = $this.attr('data-property');
-                                parentTab.find(propertySelector + '[data-property="{0}"]'.format(propertyName)).replaceWith(this);
-                            })
-
-                            //  update the data
-                            let idSelector = '.idCell[data-identifier="id_{0}_{1}"]'.format(id, itemDescriptorName);
-                            parentTab.find(idSelector).replaceWith(tempResult.find(idSelector));
-
-                            parentTab.find('[data-id="{0}"]'.format(id)).flash();
-
-                            BDA_REPOSITORY.showNonEmptyLines(parentTab);
-
-                            if (cb) {
-                                cb();
-                            }
-                        } catch (e) {
-                            console.error(e);
-                        }
-
-                    })
-                },
-
-                function(jqXHR, textStatus, errorThrown) {
-                    $.notify(
-                        "Error during call: " + errorThrown + ".", {
-                            className: "error",
-                            position: "top center"
-                        }
-                    );
-
-                })
-        },
-
-        // load sub item with an ajax call
-        loadSubItem: function(id, itemDescriptorName, repositoryPath, $outputDiv, cbSuccess, cbErr, cbEnd) {
-            if (_.isNil(repositoryPath)) {
-                repositoryPath = getCurrentComponentPath();
-            }
-
-            // : function(domain, itemDescriptor, id, repository, callback, errCallback) {
-            BDA_REPOSITORY.executePrintItem('', itemDescriptorName, id, repositoryPath,
-                function(result) {
-                    BDA_REPOSITORY.parseXhrResult(result, repositoryPath, (parsed) => {
-
-                        let temp = $('<div></div>');
-
-                        let top = BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, temp);
-                        //use the itemDescriptor from the result, not the query (ex payment group vs creditCard)
-
-                        let resultDescriptorName = _.first(parsed.items).itemDescriptor.name;
-                        let targetTab = BDA_REPOSITORY.findTabToAppendTo(resultDescriptorName, $outputDiv);
-                        if (_.isNil(targetTab) || targetTab.length === 0) {
-                            temp.children().appendTo($outputDiv);
-                        } else {
-                            BDA_REPOSITORY.appendToDataTable(id, resultDescriptorName, repositoryPath, targetTab, temp);
-                            top = targetTab;
-                        }
-
-                        BDA_REPOSITORY.reloadSpeedBar($outputDiv);
-                        if (top) {
-                            top.scrollTo();
-                            top.find('[data-id="{0}"]'.format(id)).flash();
-                        }
-                        if (cbSuccess) {
-                            cbSuccess();
-                        }
-                        if (cbEnd) {
-                            cbEnd();
-                        }
-                    });
-                },
-                function(jqXHR, textStatus, errorThrown) {
-                    $.notify(
-                        "Error during call: " + errorThrown + ".", {
-                            className: "error",
-                            position: "top center"
-                        }
-                    );
-                    if (cbErr) {
-                        cbErr();
-                    }
-                    if (cbEnd) {
-                        cbEnd();
-                    }
-                }
-            )
-        },
-
-        oldShowXMLAsTab: function(xmlContent, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
-
-
-            console.time("oldShowXMLAsTab");
-            var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
-            var $xml = $(xmlDoc);
-            var $addItems = $xml.find("add-item");
-            var types = {};
-            var datas = [];
-            var nbTypes = 0;
-            var typesNames = {};
-
-            var log = $("<xml>" + xmlContent + "</xml>")
-                .children()
-                .remove()
-                .end()
-                .text()
-                .trim();
-
-            var descriptorAndDefaultValues = {};
-            if ($xmlDef != null) {
-                for (var i = 0; i < $addItems.length; i++) {
-                    var itemDescriptor = $addItems[i].getAttribute("item-descriptor");
-
-                    if (descriptorAndDefaultValues.hasOwnProperty(itemDescriptor) === false) {
-                        BDA_REPOSITORY.getDescriptorAndDefaultValues(itemDescriptor, $xmlDef, descriptorAndDefaultValues);
-                    }
-                    for (var defaultPropertyName in descriptorAndDefaultValues[itemDescriptor]) {
-                        var exists = $($addItems[i]).find("[name=" + defaultPropertyName + "]").length;
-                        if (exists == 0) {
-                            $addItems[i].innerHTML += '<set-property name="' + defaultPropertyName + '"><![CDATA[' + descriptorAndDefaultValues[itemDescriptor][defaultPropertyName] + ']]></set-property>';
-                        }
-                    }
-                }
-            }
-
-
-            $addItems.each(function() {
-                var curItemDesc = "_" + $(this).attr("item-descriptor");
-                if (!types[curItemDesc])
-                    types[curItemDesc] = [];
-                if (!typesNames[curItemDesc])
-                    typesNames[curItemDesc] = [];
-                if (!datas[curItemDesc]) {
-                    datas[curItemDesc] = [];
-                    nbTypes++;
-                }
-                var curData = {};
-
-                $(this).find("set-property").each(function(index) {
-                    var $curProp = $(this);
-                    curData[$curProp.attr("name")] = $curProp.text();
-                    var type = {};
-                    type.name = $curProp.attr("name");
-                    if ($.inArray(type.name, typesNames[curItemDesc]) == -1) {
-                        type.rdonly = $curProp.attr("rdonly");
-                        type.derived = $curProp.attr("derived");
-                        type.exportable = $curProp.attr("exportable");
-                        var typeItemDesc = BDA_REPOSITORY.isTypeId(type.name, curItemDesc.substr(1), $xmlDef);
-                        if (typeItemDesc === null)
-                            type.isId = false;
-                        else {
-                            type.isId = true;
-                            type.itemDesc = typeItemDesc;
-                        }
-                        types[curItemDesc].push(type);
-                        typesNames[curItemDesc].push(type.name);
-                    }
-                });
-                if ($.inArray("descriptor", typesNames[curItemDesc]) == -1) {
-                    var typeDescriptor = {};
-                    typeDescriptor.name = "descriptor";
-                    types[curItemDesc].unshift(typeDescriptor);
-                    typesNames[curItemDesc].push("descriptor");
-                }
-                if ($.inArray("id", typesNames[curItemDesc]) == -1) {
-                    var typeId = {};
-                    typeId.name = "id";
-                    types[curItemDesc].unshift(typeId);
-                    typesNames[curItemDesc].push("id");
-                }
-                curData.descriptor = curItemDesc;
-                curData.id = $(this).attr("id");
-                datas[curItemDesc].push(curData);
-            });
-            var html = "<p class='nbResults'>" + $addItems.length + " items in " + nbTypes + " descriptor(s)</p>";
-            var splitValue;
-            var splitObj = BDA_STORAGE.getStoredSplitObj();
-            if (splitObj === undefined || splitObj === null || splitObj.activeSplit === true)
-                splitValue = 0;
-            else
-                splitValue = parseInt(splitObj.splitValue);
-            for (var itemDesc in datas) {
-                if (splitValue === 0)
-                    splitValue = datas[itemDesc].length;
-                var nbTab = 0;
-                if (datas[itemDesc].length <= splitValue) {
-                    html += BDA_REPOSITORY.renderTab(itemDesc, types[itemDesc], datas[itemDesc], itemDesc.substr(1), isItemTree);
-                } else {
-                    while ((splitValue * nbTab) < datas[itemDesc].length) {
-                        var start = splitValue * nbTab;
-                        var end = start + splitValue;
-                        if (end > datas[itemDesc].length)
-                            end = datas[itemDesc].length;
-                        var subDatas = datas[itemDesc].slice(start, end);
-                        html += BDA_REPOSITORY.renderTab(itemDesc, types[itemDesc], subDatas, itemDesc + "_" + nbTab, isItemTree);
-                        nbTab++;
-                    }
-                }
-            }
-            $outputDiv.append(html);
-            $outputDiv.prepend("<div class='prop_attr prop_attr_red'>R</div> : read-only " + "<div class='prop_attr prop_attr_green'>D</div> : derived " + "<div class='prop_attr prop_attr_blue'>E</div> : export is false");
-
-            if ($(".copyField").length > 0) {
-                // reuse $outputDiv in case we have several results set on the page (RQL query + get item tool)
-                $outputDiv.find("p.nbResults").append("<br><a href='javascript:void(0)' class='showFullTextLink'>Show full text</a>");
-                $outputDiv.find(".showFullTextLink").click(function() {
-                    console.time("showFullText");
-                    $(".copyField").each(function() {
-                        $(this).parent().html($(this).html());
-                    });
-                    console.timeEnd("showFullText");
-                    $(this).hide();
-                });
-            }
-
-            if (_.isNil(loadSubItemCb)) {
-                $outputDiv.find(".loadable_property").click(BDA_REPOSITORY.showLoadSubItemAlert);
-
-            } else {
-                $outputDiv.find(".loadable_property").click(loadSubItemCb);
-            }
-
-            if (isItemTree)
-                BDA_REPOSITORY.createSpeedbar();
-
-            console.timeEnd("oldShowXMLAsTab");
-            return log;
-        },
-
-        showLoadSubItemAlert: function() {
-            logTrace('click on loadable');
-            var $elm = $(this);
-            var id = $elm.attr("data-id");
-            var itemDesc = $elm.attr("data-descriptor");
-            var query = "<print-item id='" + id + "' item-descriptor='" + itemDesc + "' />\n";
 
             $('body').bdaAlert({
-                msg: 'You are about to add this query and reload the page: \n' + query,
-                options: [{
-                    label: 'Add & Reload',
-                    _callback: function() {
-                        BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
-                        $("#RQLForm").submit();
-                    }
-                }, {
-                    label: 'Just Add',
-                    _callback: function() {
-                        BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
-                    }
-                }, {
-                    label: 'Cancel'
-                }]
-            });
-        },
+              msg: 'You are about to execute this query : \n {0}'.format(highlighted.html()),
+              options: [{
+                label: 'Confirm',
+                _callback: function() {
+                  BDA_REPOSITORY.executeQuery('', xmlText, repositoryPath,
+                    (result) => {
+                      try {
+                        var xmlContent = $('<div>' + result + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
+                        let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
 
-        showRQLLog: function(log, error) {
-            logTrace("Execution log : " + log);
-            if (log && log.length > 0) {
-                $("<h3>Execution log</h3><div id='RQLLog'></div>").insertAfter("#RQLResults");
-                var cleanLog = log.replace(/\n{2,}/g, '\n').replace(/------ /g, "").trim();
-                $("#RQLLog").html(cleanLog);
-            }
-            if (error)
-                $("#RQLLog").addClass("error");
-        },
+                        let parentTab = input.closest('.dataTable');
+                        BDA_REPOSITORY.reloadTab(itemId, itemName, repositoryPath, parentTab, () => {
 
-        showRQLResults: function() {
-            logTrace("Start showRQLResults");
-            // Add 'show raw xml' link
-            var html = "<p>" + "<a href='javascript:void(0)' id='rawXmlLink'>Show raw xml</a>" + "</p>\n";
-            html += "<p id='rawXml'></p>";
-            $("#RQLResults").addClass('rqlResultContainer').append(html);
+                          $.notify(
+                            "Success: \n{0}".format(logs), {
+                              className: "success",
+                              position: "top center",
+                              autoHideDelay: 5000
 
-            var xmlContent = $(BDA_REPOSITORY.resultsSelector).next().text().trim();
-            // xmlContent = sanitizeXml(xmlContent); //sanitize later
-
-            BDA_REPOSITORY.PERF_MONITOR.reset();
-            BDA_REPOSITORY.PERF_MONITOR.start('processRepositoryXmlDef');
-            processRepositoryXmlDef("definitionFiles", function($xmlDef) {
-                BDA_REPOSITORY.PERF_MONITOR.cumul('processRepositoryXmlDef');
-                var log = BDA_REPOSITORY.showXMLAsTab(xmlContent, $xmlDef, $("#RQLResults"), false);
-                BDA_REPOSITORY.showRQLLog(log, false);
-                // Move raw xml
-                $(BDA_REPOSITORY.resultsSelector).next().appendTo("#rawXml");
-                $(BDA_REPOSITORY.resultsSelector).remove();
-
-                $("#rawXmlLink").click(function() {
-                    BDA_REPOSITORY.toggleRawXml();
-                    var xmlSize = $("#rawXml pre").html().length;
-                    logTrace("raw XML size : " + xmlSize);
-                    logTrace("XML max size : " + BDA_REPOSITORY.xmlDefinitionMaxSize);
-                    if (xmlSize < BDA_REPOSITORY.xmlDefinitionMaxSize) {
-                        $('#rawXml').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    } else {
-                        // Check if button already exists
-                        if ($("#xmlHighlight").length === 0) {
-                            $("<p id='xmlHighlight' />")
-                                .html("The XML result is big, to avoid slowing down the page, XML highlight have been disabled. " + "<br> <button id='xmlHighlightBtn'>Highlight XML now</button> <small>(takes few seconds)</small>")
-                                .prependTo($("#rawXml"));
-                            $("#xmlHighlightBtn").click(function() {
-                                $('#rawXml pre').each(function(i, block) {
-                                    hljs.highlightBlock(block);
-                                });
-                            });
-                        }
-                    }
-                });
-
-                $(".copyLink").click(function() {
-                    BDA_REPOSITORY.showTextField($(this).attr("id").replace("link_", ""));
-                });
-            });
-        },
-
-        showRqlErrors: function() {
-            var error = "";
-            if ($(BDA_REPOSITORY.errorsSelector1).length > 0) {
-                logTrace("Case of error  : 1");
-                error = $(BDA_REPOSITORY.errorsSelector1).next().text();
-                $(BDA_REPOSITORY.resultsSelector).next().remove();
-                $(BDA_REPOSITORY.resultsSelector).remove();
-                $(BDA_REPOSITORY.errorsSelector1).next().remove();
-                $(BDA_REPOSITORY.errorsSelector1).remove();
-            } else {
-                logTrace("Case of error  : 2");
-                error = $(BDA_REPOSITORY.errorsSelector2).text();
-            }
-            error = BDA_REPOSITORY.purgeXml(error);
-            BDA_REPOSITORY.showRQLLog(error, true);
-        },
-
-        escapeHTML: function(s) {
-            return String(s).replace(/&(?!\w+;)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-        },
-
-        propertiesDef: function(hljs) {
-            logTrace("propertiesDef");
-            return {
-                case_insensitive: true,
-                contains: [{
-                    className: 'comment',
-                    begin: '#',
-                    end: '$'
-                }, {
-                    className: 'setting',
-                    begin: '^[a-z0-9\\[\\]_-]+[ \\t]*=[ \\t]*',
-                    end: '$',
-                    contains: [{
-                        className: 'value',
-                        endsWithParent: true,
-                        keywords: 'on off true false yes no',
-                        contains: [hljs.QUOTE_STRING_MODE, hljs.NUMBER_MODE],
-                        relevance: 0
-                    }]
-                }]
-            };
-        },
-
-        //--- Item Tree functions ------------------------------------------------------------------------
-
-        setupItemTreeForm: function() {
-            $("<div id='itemTree' />").insertAfter("#RQLEditor");
-            var $itemTree = $("#itemTree");
-            $itemTree.append("<h2>Get Item Tree</h2>");
-            $itemTree.append("<p>This tool will recursively retrieve items and print the result with the chosen output." + "<br> For example, if you give an order ID in the form below, you will get all shipping groups, payment groups, commerceItems, priceInfo... of the given order" + "<br><b> Be careful when using this tool on a live instance ! Set a low max items value.</b></p>");
-
-            $itemTree.append("<div id='itemTreeForm'>" + "id : <input type='text' id='itemTreeId' /> &nbsp;" + "descriptor :  <span id='itemTreeDescriptorField' ><select id='itemTreeDesc' class='itemDescriptor' >" + BDA_REPOSITORY.getDescriptorOptions() + "</select></span>" + "max items : <input type='text' id='itemTreeMax' value='50' /> &nbsp;<br><br>" + "output format :  <select id='itemTreeOutput'>" + "<option value='HTMLtab'>HTML tab</option>" + "<option value='addItem'>add-item XML</option>" + "<option value='removeItem'>remove-item XML</option>" + "<option value='printItem'>print-item XML</option>" + "<option value='tree'>Tree (experimental)</option>" + "</select>&nbsp;" + "<input type='checkbox' id='printRepositoryAttr' /><label for='printRepositoryAttr'>Print attribute : </label>" + "<pre style='margin:0; display:inline;'>repository='" + getCurrentComponentPath() + "'</pre> <br><br>" + "<button id='itemTreeBtn'>Enter <i class='fa fa-play fa-x'></i></button>" + "</div>");
-            $itemTree.append("<div id='itemTreeInfo' />");
-            $itemTree.append("<div id='itemTreeResult' class='rqlResultContainer' />");
-            $("#itemTreeBtn").click(function() {
-                var descriptor = $("#itemTreeDesc").val();
-                var id = $("#itemTreeId").val().trim();
-                var maxItem = parseInt($("#itemTreeMax").val());
-                var outputType = $("#itemTreeOutput").val();
-                var printRepoAttr = $("#printRepositoryAttr").is(':checked');
-                logTrace("max item : " + maxItem);
-                BDA_REPOSITORY.getItemTree(id, descriptor, maxItem, outputType, printRepoAttr);
-            });
-
-        },
-
-        getSubItems: function(items, $xmlDef, maxItem, outputType, printRepoAttr) {
-            var nbItem = BDA_REPOSITORY.itemTree.size;
-            logTrace("maxItem : " + maxItem + ", nbItem : " + nbItem);
-
-            // Ensure that getSubItems is not call more than maxItem times
-            if (nbItem >= maxItem) {
-                logTrace("max Item (" + maxItem + ") reached, stopping recursion");
-                return;
-            }
-
-            var xmlText = "";
-            for (var batchSize = 0; batchSize != items.length; batchSize++) {
-                // Don"t ask for more items than limit
-                if ((BDA_REPOSITORY.nbItemReceived + batchSize) >= maxItem)
-                    break;
-                xmlText += "<print-item id='" + items[batchSize].id + "' item-descriptor='" + items[batchSize].desc + "' />\n";
-            }
-            logTrace(xmlText);
-            logTrace("batch size : " + batchSize);
-            // Only request if the batchSize contains something
-            if (batchSize > 0) {
-                $.ajax({
-                    type: "POST",
-                    url: document.URL,
-                    data: {
-                        xmltext: xmlText
-                    },
-                    success: function(result, status, jqXHR) {
-
-                        var rawItemsXml = $(result).find("code").html();
-                        // remove first 2 lines
-                        var tab = rawItemsXml.split("\n");
-                        tab.splice(0, 2);
-                        rawItemsXml = tab.join("\n").trim();
-                        // unescape HTML
-                        rawItemsXml = "<xml>" + rawItemsXml.replace(/&lt;/g, "<").replace(/&gt;/g, ">") + "</xml>";
-
-                        var xmlDoc = jQuery.parseXML(rawItemsXml);
-                        BDA_REPOSITORY.nbItemReceived += $(xmlDoc).find("add-item").length;
-                        $("#itemTreeInfo").html("<p>" + BDA_REPOSITORY.nbItemReceived + " items retrieved</p>");
-
-                        var subItems = [];
-                        $(xmlDoc).find("add-item").each(function() {
-                            var $itemXml = $(this);
-                            var itemId = $itemXml.attr("id");
-                            if (BDA_REPOSITORY.itemTree.get(itemId) === undefined) {
-                                var rawItemXml = $itemXml[0].outerHTML;
-                                BDA_REPOSITORY.itemTree.set(itemId, rawItemXml);
-                                var descriptor = $itemXml.attr("item-descriptor");
-                                var $itemDesc = $xmlDef.find("item-descriptor[name=" + descriptor + "]");
-                                var superType = $itemDesc.attr("super-type");
-                                while (superType !== undefined) {
-                                    var $parentDesc = $xmlDef.find("item-descriptor[name=" + $itemDesc.attr("super-type") + "]");
-                                    $itemDesc = $itemDesc.add($parentDesc);
-                                    superType = $parentDesc.attr("super-type");
-                                }
-                                // One to One relation
-                                $itemDesc.find('property[item-type]')
-                                    .each(function(index, elm) {
-                                        var $elm = $(elm);
-                                        var subProperty = $elm.attr("name");
-                                        var subId = $itemXml.find("set-property[name=" + subProperty + "]").text();
-                                        if ($elm.attr("repository") === undefined && subId.length > 0) {
-                                            // avoid infinite recursion
-                                            if (BDA_REPOSITORY.itemTree.get(subId) === undefined) {
-                                                subItems.push({
-                                                    'id': subId,
-                                                    'desc': $elm.attr("item-type")
-                                                });
-                                            }
-                                        }
-                                    });
-
-                                // One to Many relation with list, array or map
-                                $itemDesc.find('property[component-item-type]')
-                                    .each(function(index, elm) {
-                                        var $elm = $(elm);
-                                        var subProperty = $elm.attr("name");
-                                        var subId = $itemXml.find("set-property[name=" + subProperty + "]").text();
-                                        if ($elm.attr("repository") === undefined && subId.length > 0) {
-                                            var desc = $elm.attr("component-item-type");
-                                            var ids = BDA_REPOSITORY.parseRepositoryId(subId);
-                                            for (var i = 0; i != ids.length; i++) {
-                                                // avoid infinite recursion
-                                                if (ids[i] !== BDA_REPOSITORY.MAP_SEPARATOR && ids[i] !== BDA_REPOSITORY.LIST_SEPARATOR && BDA_REPOSITORY.itemTree.get(ids[i]) === undefined)
-                                                    subItems.push({
-                                                        'id': ids[i],
-                                                        'desc': desc
-                                                    });
-                                            }
-                                        }
-                                    });
                             }
+                          );
+
                         });
 
-                        logTrace(subItems.length + " items to retrieved in next request. Limit reach : " + (BDA_REPOSITORY.nbItemReceived >= maxItem));
-                        if (subItems.length > 0 && BDA_REPOSITORY.nbItemReceived < maxItem)
-                            BDA_REPOSITORY.getSubItems(subItems, $xmlDef, maxItem, outputType, printRepoAttr);
-                        else
-                            BDA_REPOSITORY.renderItemTreeTab(outputType, printRepoAttr, $xmlDef, maxItem);
-                    },
-                });
-            } else
-                logTrace("Request is empty, nothing to do.");
-        },
-
-        getItemTree: function(id, descriptor, maxItem, outputType, printRepoAttr) {
-            logTrace("getItemTree - start");
-            // reset divs
-            $("#itemTreeResult").empty();
-            $("#itemTreeInfo").empty();
-
-            if (!id) {
-                $("#itemTreeInfo").html("<p>Please provide a valid ID</p>");
-                return;
-            }
-
-            console.time("getItemTree");
-            console.time("retrieveItem");
-            // Get XML definition of the repository
-            $("#itemTreeInfo").html("<p>Getting XML definition of this repository...</p>");
-            var $xmlDef = processRepositoryXmlDef("definitionFiles", function($xmlDef) {
-                if (!$xmlDef) {
-                    $("#itemTreeInfo").html("<p>Unable to parse XML definition of this repository !</p>");
-                    return;
-                }
-                logTrace("descriptor : " + $xmlDef.find("item-descriptor").length);
-                // get tree
-                BDA_REPOSITORY.itemTree = new Map();
-                BDA_REPOSITORY.nbItemReceived = 0;
-                BDA_REPOSITORY.getSubItems([{
-                    'id': id,
-                    'desc': descriptor
-                }], $xmlDef, maxItem, outputType, printRepoAttr);
-            });
-        },
-
-        renderItemTreeTab: function(outputType, printRepoAttr, $xmlDef, maxItem) {
-            console.timeEnd("retrieveItem");
-            logTrace("Render item tree tab : " + outputType);
-
-            //  If the max item is reached before recursion ended, we notify the user
-            if (BDA_REPOSITORY.nbItemReceived >= maxItem) {
-                $.notify(
-                    "Item tree stopped because the maximum items limit was reached : " + maxItem + ".", {
-                        className: "warn",
-                        position: "top center"
-                    }
-                );
-            }
-
-            $("#itemTreeInfo").empty();
-            $("#itemTreeResult").empty();
-            var res = "";
-            if (outputType !== "HTMLtab" && outputType != "tree") {
-                logTrace("Render copy button");
-                $("#itemTreeInfo").append("<input type='button' id='itemTreeCopyButton' value='Copy result to clipboard'></input>");
-                $('#itemTreeCopyButton').click(function() {
-                    copyToClipboard($('#itemTreeResult').text());
-                });
-            }
-            if (outputType == "addItem") {
-                BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-                    if (printRepoAttr) {
-                        var xmlDoc = jQuery.parseXML(data);
-                        var $itemXml = $(xmlDoc).find("add-item");
-                        $itemXml.attr("repository", getCurrentComponentPath());
-                        res += $itemXml[0].outerHTML;
-                    } else
-                        res += data;
-                    res += "\n\n";
-                }, BDA_REPOSITORY.itemTree);
-                res = "<import-items>\n" + res + "\n</import-items>";
-                $("#itemTreeResult").append("<pre />");
-                $("#itemTreeResult pre").text(res);
-            } else if (outputType == "HTMLtab") {
-                BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-                    res += data;
-                }, BDA_REPOSITORY.itemTree);
-                BDA_REPOSITORY.showXMLAsTab(res, $xmlDef, $("#itemTreeResult"), true);
-            } else if (outputType == "removeItem" || outputType == "printItem") {
-                BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-                    var xmlDoc = jQuery.parseXML(data);
-                    var $itemXml = $(xmlDoc).find("add-item");
-                    res += "<";
-                    if (outputType == "removeItem")
-                        res += "remove-item";
-                    else
-                        res += "print-item";
-                    res += ' id="' + $itemXml.attr("id") + '" item-descriptor="' + $itemXml.attr("item-descriptor") + "\"";
-                    if (printRepoAttr)
-                        res += " repository='" + getCurrentComponentPath() + "'";
-                    res += ' />\n';
-                }, BDA_REPOSITORY.itemTree);
-
-                $("#itemTreeResult").append("<pre />");
-                $("#itemTreeResult pre").text(res);
-            } else if (outputType == "tree") {
-                BDA_REPOSITORY.renderAsTree($xmlDef);
-            }
-
-            console.timeEnd("getItemTree");
-        },
-
-        renderAsTree: function($xmlDef) {
-            logTrace("render as tree");
-            console.time('renderAsTree.setup');
-            var nodes = new vis.DataSet();
-            var edges = new vis.DataSet();
-            var legends = new Map();
-            var descById = new Map();
-            var itemIdToVisId = {};
-            var i = 0;
-            BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-                itemIdToVisId[id] = i;
-                i++;
-            });
-
-            BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-                var xmlDoc = $.parseXML("<xml>" + data + "</xml>");
-                var $xml = $(xmlDoc);
-                var $addItem = $xml.find("add-item").first();
-                var itemDesc = $addItem.attr("item-descriptor");
-                var itemId = $addItem.attr("id");
-
-                $addItem.children().each(function(index) {
-                    var $this = $(this);
-                    var propertyName = $this.attr("name");
-                    var propertyValue = $this.text();
-                    if (BDA_REPOSITORY.edgesToIgnore.indexOf(propertyName) === -1) {
-                        var isId = BDA_REPOSITORY.isTypeId(propertyName, itemDesc, $xmlDef)
-                        if (isId != null && isId != "FOUND_NOT_ID") {
-                            var idAsTab = BDA_REPOSITORY.parseRepositoryId(propertyValue);
-                            for (var i = 0; i != idAsTab.length; i++) {
-                                if (idAsTab[i] != "," && idAsTab[i] != "=") {
-                                    edges.add({
-                                        from: itemIdToVisId[itemId],
-                                        to: itemIdToVisId[idAsTab[i]],
-                                        arrows: 'to',
-                                        title: propertyName
-                                    });
-                                }
-                            }
-                        }
-                    }
-                });
-
-                var nodeColor = colorToCss(stringToColour(itemDesc));
-                nodes.add({
-                    id: itemIdToVisId[itemId],
-                    label: itemDesc + "\n" + itemId,
-                    color: nodeColor,
-                    shape: 'box'
-                });
-                legends.set(itemDesc, nodeColor);
-
-                if (descById.get(itemDesc))
-                    descById.get(itemDesc).push(itemId);
-                else
-                    descById.set(itemDesc, [itemId]);
-            });
-            console.timeEnd('renderAsTree.setup');
-            // Create popup
-            $("#itemTreeResult").empty()
-                .append("<div class='popup_block' id='treePopup'>" + "<div><a href='javascript:void(0)' class='close'><i class='fa fa-times'></i></a></div>" + "<div id='treeLegend'></div>" + "<div class='flexContainer'>" + "<div id='treeInfo'></div>" + "<div id='treeContainer'></div>" + "</div>" + "</div>");
-            $("#treePopup .close").click(function() {
-                logTrace("click on close");
-                $("#treePopup").hide();
-            });
-
-            // Setup legend
-            legends.forEach(function(value, key) {
-                $("#treeLegend").append("<div class='legend' style='background-color:" + value + "' id='" + key + "'>" + key + "</div>");
-            });
-
-            logTrace("Number for nodes : " + nodes.length);
-            logTrace("Number for edges : " + edges.length);
-
-            $("#treePopup").show();
-            console.time('renderAsTree.render');
-
-            // Create the network
-            var data = {
-                nodes: nodes,
-                edges: edges
-            };
-
-            var options = {
-                physics: {
-                    stabilization: false
-                },
-                edges: {
-                    smooth: true
-                },
-                nodes: {
-                    font: {
-                        color: "#FFFFFF"
-                    }
-                }
-            };
-
-            var container = document.getElementById('treeContainer');
-            var network = new vis.Network(container, data, options);
-            console.timeEnd('renderAsTree.render')
-
-            network.on("click", function(params) {
-                params.event = "[original event]";
-                if (params.nodes && params.nodes.length == 1) {
-                    $("#treeInfo").empty();
-                    var visId = params.nodes[0];
-                    var itemId = null;
-                    logTrace("Click on " + visId);
-                    // Find itemId from visID
-                    for (var id in itemIdToVisId) {
-                        if (visId === itemIdToVisId[id]) {
-                            itemId = id;
-                            break;
-                        }
-                    }
-                    logTrace("itemId : " + itemId);
-                    logTrace(BDA_REPOSITORY.itemTree.get(itemId));
-                    BDA_REPOSITORY.showXMLAsTab(BDA_REPOSITORY.itemTree.get(itemId), null, $("#treeInfo"), false);
-                    logTrace($("#treeInfo").html());
-                    $("#treeInfo").show();
-                }
-            });
-
-            $(".legend").click(function() {
-                // This feature is disabled for now.
-                return;
-                logTrace("click on legend");
-                var id = $(this).attr('id');
-                logTrace(id);
-                var ids = descById.get(id);
-                var nodesAndEdgesToHide = {};
-                for (var i = 0; i != ids.length; i++) {
-                    nodesAndEdgesToHide = BDA_REPOSITORY.findNodesAndEdgesToHide(ids[i], network, edges, nodes);
-
-                    // Foreach nodesAndEdgesToHide.nodes
-                    for (var a = 0; a != nodesAndEdgesToHide.nodes.length; a++) {
-                        nodes.update([{
-                            id: nodesAndEdgesToHide.nodes[a],
-                            hidden: true
-                        }]);
-                    }
-                    // Foreach nodesAndEdgesToHide.edges
-                    for (var a = 0; a != nodesAndEdgesToHide.edges.length; a++) {
-                        edges.update([{
-                            id: nodesAndEdgesToHide.edges[a],
-                            hidden: true
-                        }]);
-                    }
-                }
-            });
-        },
-
-        findNodesAndEdgesToHide: function(id, network, edges, nodes) {
-            logTrace("findNodesAndEdgesToHide for ID : " + id);
-            var nodesAndEdgesToHide = {};
-            nodesAndEdgesToHide.nodes = BDA_REPOSITORY.findOrphanSon(id, network, edges, nodes, [id]);
-            nodesAndEdgesToHide.edges = [];
-            for (var i = 0; i != nodesAndEdgesToHide.nodes.length; i++) {
-                nodesAndEdgesToHide.edges = nodesAndEdgesToHide.edges.concat(network.getConnectedEdges(nodesAndEdgesToHide.nodes[i]));
-            }
-            logTrace("nodesAndEdgesToHide.nodes : ");
-            logTrace(nodesAndEdgesToHide.nodes);
-            logTrace("nodesAndEdgesToHide.edges : ");
-            logTrace(nodesAndEdgesToHide.edges);
-            return nodesAndEdgesToHide;
-        },
-
-        findOrphanSon: function(id, network, edges, nodes, orphanSons) {
-            logTrace("About to find orphan for node : " + id);
-            edges.forEach(function(elm) {
-                //logTrace(elm);
-                if (elm.from == id) {
-                    var isOrphan = true;
-                    var connectedEdges = network.getConnectedEdges(elm.to);
-
-                    for (var i = 0; i != connectedEdges.length; i++) {
-                        var edge = edges.get(connectedEdges[i]);
-                        logTrace("connectedEdge - from : " + edge.to + " - " + edge.from);
-                        if (edge.to == elm.to && edge.from != id) {
-                            isOrphan = false;
-                            break;
-                        }
-                    }
-                    if (isOrphan && orphanSons.indexOf(elm.to) === -1) {
-                        logTrace(elm.to + " is a new orphan son of node : " + id);
-                        orphanSons.push(elm.to);
-                        BDA_REPOSITORY.findOrphanSon(elm.to, network, edges, nodes, orphanSons);
-                    }
-                }
-            });
-            return orphanSons;
-        },
-
-
-        createSpeedbar_new: function(resultElem) {
-            logTrace('createSpeedbar_new')
-            try {
-
-                let speedbar = $('<div class="speedbar"><div class="widget"><i class="fa fa-times close"></i><p>Quick links :</p><ul></ul></div></div>');
-                speedbar.find('.close').on('click', () => {
-                    speedbar.fadeOut(200);
-                })
-
-                let list = speedbar.find('ul');
-                resultElem.find(".dataTable").each(function(index) {
-                    var $tab = $(this);
-                    var id = $tab.attr("id");
-                    var descriptor = $tab.attr('data-descriptor');
-
-                    var nbItem = $tab.find("td").length / $tab.find("tr").length;
-                    let elem = $("<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<span class='clickable_property'>" + descriptor + "</span> (" + nbItem + ")</li>");
-                    elem.on('click', () => $tab.scrollTo());
-                    list.append(elem);
-                });
-                speedbar.prependTo(resultElem);
-
-                let container = $(resultElem);
-
-                let widget = speedbar.find('.widget');
-                let initialTop = container.offset().top;
-                var initialBot = initialTop + container.height();
-                $(window).scroll(function() {
-                    var windowTop = $(window).scrollTop();
-                    if (initialTop < windowTop && initialBot > windowTop) {
-                        widget.addClass('sticky-top-100');
-                    } else {
-                        widget.removeClass('sticky-top-100');
-                    }
-                });
-
-            } catch (e) {
-                console.error(e);
-            }
-
-        },
-
-        reloadSpeedBar: function(resultElem) {
-            resultElem.find('.speedbar').remove();
-            BDA_REPOSITORY.createSpeedbar_new(resultElem);
-        },
-
-        createSpeedbar: function() {
-            var speedBarHtml = "<a class='close' href='javascript:void(0)'><i class='fa fa-times'></i></a><p>Quick links :</p><ul>";
-            $("#itemTreeResult .dataTable").each(function(index) {
-                var $tab = $(this);
-                var id = $tab.attr("id");
-                var name = id;
-                if (id.indexOf("_") != -1) {
-                    var tab = id.split("_");
-                    name = tab[1];
-                }
-                var nbItem = $tab.find("td").length / $tab.find("tr").length;
-                speedBarHtml += "<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<a href='#" + id + "'>" + name.trim() + " (" + nbItem + ")</a></li>";
-            });
-            speedBarHtml += "</ul>";
-            $("#itemTreeInfo").append("<div id='speedbar'><div id='widget' class='sticky'>" + speedBarHtml + "</div></div>");
-            $('#speedbar .close').click(function() {
-                $("#speedbar").fadeOut(200);
-            });
-            var stickyTop = $('.sticky').offset().top;
-            $(window).scroll(function() { // scroll event
-                var windowTop = $(window).scrollTop();
-                if (stickyTop < windowTop)
-                    $('.sticky').css({
-                        position: 'fixed',
-                        top: 100
-                    });
-                else
-                    $('.sticky').css('position', 'static');
-            });
-        },
-
-
-        showQueryList: function() {
-            var html = "";
-            // fix delete query : the index used to delete was not correct
-            // we need to keep original index
-            var rqlQueries = BDA_STORAGE.getStoredRQLQueries();
-            var currComponentName = getComponentNameFromPath(getCurrentComponentPath());
-            var nbQuery = 0;
-            if (rqlQueries && rqlQueries.length > 0) {
-                html += "<ul>";
-                for (var i = 0; i != rqlQueries.length; i++) {
-                    var storeQuery = rqlQueries[i];
-                    if (!storeQuery.hasOwnProperty("repo") || storeQuery.repo == currComponentName) {
-                        var escapedQuery = $("<div>").text(storeQuery.query).html();
-                        html += "<li class='savedQuery'>";
-                        html += "<a href='javascript:void(0)'>" + storeQuery.name + "</a>";
-                        html += "<span id='previewQuery" + i + "'class='previewQuery'>";
-                        html += "<i class='fa fa-eye'></i>";
-                        html += "</span>";
-                        html += "<span id='deleteQuery" + i + "'class='deleteQuery'>";
-                        html += "<i class='fa fa-trash-o'></i>";
-                        html += "</span>";
-                        html += "<span id='queryView" + i + "'class='queryView'>";
-                        html += "<pre>" + escapedQuery + "</pre>";
-                        html += "</span>";
-                        html += "</li>";
-                        nbQuery++;
-                    }
-                }
-                html += "</ul>";
-                if (nbQuery > 0)
-                    $("#storedQueries").html(html);
-            }
-
-            // $('#storedQueries .queryView').each(function(i, block) {
-            //   hljs.highlightBlock(block);
-            // });
-
-            $(".savedQuery").on('click', 'a', function() {
-                logTrace("click on query : " + $(this).find("a").html());
-                BDA_REPOSITORY.printStoredQuery($(this).find("a").html());
-            });
-
-            $(".previewQuery").on('click', function() {
-
-                try {
-
-
-                    let block = $(this).parent("li").find("span.queryView").each(function(i, block) {
-                        hljs.highlightBlock(block);
-                    });
-
-                    $('body').bdaAlert({
-                        msg: block.html(),
-                        width: '900px',
-                        options: [{
-                            label: 'OK'
-                        }]
-                    });
-                } catch (e) {
-                    console.error(e);
-                }
-
-
-            });
-
-            $(".deleteQuery")
-                .click(function() {
-                    var index = this.id.replace("deleteQuery", "");
-                    logTrace("Delete query #" + index);
-                    logTrace(BDA_STORAGE.deleteRQLQuery);
-                    BDA_STORAGE.deleteRQLQuery(index);
-                    BDA_REPOSITORY.reloadQueryList();
-                });
-        },
-
-        purgeRQLQuery: function(rqlQueries) {
-            // Purge query
-            var purgedRqlQueries = [];
-            for (var i = 0; i != rqlQueries.length; i++) {
-                var query = rqlQueries[i];
-                if (!query.hasOwnProperty("repo") || query.repo == getComponentNameFromPath(getCurrentComponentPath())) {
-                    purgedRqlQueries.push(rqlQueries[i]);
-                }
-            }
-            return purgedRqlQueries;
-        },
-
-        reloadQueryList: function() {
-            $("#storedQueries").empty();
-            BDA_REPOSITORY.showQueryList();
-        },
-
-        printStoredQuery: function(name) {
-            logTrace("printStoredQuery : " + name);
-            var rqlQueries = BDA_STORAGE.getStoredRQLQueries();
-            logTrace(rqlQueries);
-            if (rqlQueries) {
-                for (var i = 0; i != rqlQueries.length; i++) {
-                    if (rqlQueries[i].name == name)
-                        BDA_REPOSITORY.setQueryEditorValue(rqlQueries[i].query + "\n");
-                }
-            }
-        },
-
-        getToggleLabel: function(state) {
-            if (state == 1)
-                return "Show less...";
-            return "Show more...";
-        },
-
-        toggleShowLabel: function(contentDisplay, selector) {
-            if (contentDisplay == "none")
-                $(selector).html("Show more...");
-            else
-                $(selector).html("Show less...");
-        },
-
-        toggleCacheUsage: function() {
-            var $cacheUsage = $(BDA_REPOSITORY.cacheUsageSelector);
-            $cacheUsage.next().toggle().next().toggle();
-            BDA_REPOSITORY.toggleShowLabel($cacheUsage.next().css("display"), "#showMoreCacheUsage");
-            BDA_STORAGE.storeToggleState("showMoreCacheUsage", $cacheUsage.next().css("display"));
-        },
-
-        toggleRepositoryView: function() {
-            $(BDA_REPOSITORY.repositoryViewSelector).next().toggle().next().toggle();
-            BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.repositoryViewSelector).next().css("display"), "#showMoreRepositoryView");
-            BDA_STORAGE.storeToggleState("showMoreRepositoryView", $(BDA_REPOSITORY.repositoryViewSelector).next().css("display"));
-        },
-
-        toggleProperties: function() {
-            $(BDA_REPOSITORY.propertiesSelector).next().toggle();
-            BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.propertiesSelector).next().css("display"), "#showMoreProperties");
-            BDA_STORAGE.storeToggleState("showMoreProperties", $(BDA_REPOSITORY.propertiesSelector).next().css("display"));
-        },
-
-        toggleEventSets: function() {
-            $(BDA_REPOSITORY.eventSetsSelector).next().toggle();
-            BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.eventSetsSelector).next().css("display"), "#showMoreEventsSets");
-            BDA_STORAGE.storeToggleState("showMoreEventsSets", $(BDA_REPOSITORY.eventSetsSelector).next().css("display"));
-        },
-
-        toggleMethods: function() {
-            $(BDA_REPOSITORY.methodsSelector).next().toggle();
-            BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.methodsSelector).next().css("display"), "#showMoreMethods");
-            BDA_STORAGE.storeToggleState("showMoreMethods", $(BDA_REPOSITORY.methodsSelector).next().css("display"));
-        },
-
-        toggleRawXml: function() {
-            $("#rawXml").toggle();
-            if ($("#rawXml").css("display") == "none")
-                $("#rawXmlLink").html("show raw XML");
-            else
-                $("#rawXmlLink").html("hide raw XML");
-        },
-
-        // simply handles an ajax call to a repository and parse the result
-        // xmltext : full xml text
-        // repository : only the strict nucleus path
-        // callback : take 1 param :  object {item: array of add-items, head}
-        executeQuery: function(domain, xmltext, repository, callback, errCallback) {
-
-            if (isNull(domain)) {
-                domain = "";
-            }
-            var url = '{0}/dyn/admin/nucleus/{1}/'.format(domain, repository);
-
-            $.ajax({
-                type: "POST",
-                url: url,
-                data: {
-                    xmltext: xmltext
-                },
-                success: function(result, status, jqXHR) {
-
-                    //check for errors
-                    try {
-
-                        let errors = BDA_REPOSITORY.getErrors(result);
-
-                        var rawItemsXml;
-
-                        if (_.isEmpty(errors)) {
-                            rawItemsXml = $(result).find("code").html();
-                            if (_.isEmpty(rawItemsXml)) {
-                                errors = "Null response";
-                            }
-                        }
-
-                        if (_.isEmpty(errors)) {
-                            callback(result);
-                        } else {
-                            errCallback(null, 'Execution Error', errors);
-                        }
-
-                    } catch (e) {
+                      } catch (e) {
                         console.error(e);
-                    }
+                      }
 
-
-                },
-                error: function(jqXHR, textStatus, errorThrown) {
-                    if (!isNull(errCallback)) {
-                        errCallback(jqXHR, textStatus, errorThrown);
-                    }
+                    },
+                    (jqXHR, textStatus, errorThrown) => {
+                      $.notify(
+                        "Error during call: {0}.".format(errorThrown), {
+                          className: "error",
+                          position: "top center",
+                          autoHide: false
+                        }
+                      );
+                    });
                 }
+              }, {
+                label: 'Cancel'
+              }]
             });
-        },
+          } catch (e) {
+            console.error(e);
+          }
 
-        getErrors: function(res) {
+        })
+        output.append(form);
+      } catch (e) {
+        console.error(e);
+      }
+      BDA_REPOSITORY.PERF_MONITOR.cumul('addInlineEditForm');
 
-            var $res = $(res);
-            var errorsSelector1 = "Errors:";
-            let errorMsg = null;
-            if ($res.text().indexOf(errorsSelector1) != -1) {
-                errorMsg = $res.find("code").text().trim();
-            }
+    },
+    closeTab: function(idCell, container) {
+      try {
+        logTrace('closetab', idCell);
+        let tab = idCell.closest('.dataTable');
+        tab.find('[data-id="{0}"]'.format(idCell.attr('data-id'))).remove();
+        //if last item remove tab
+        let tabSize = tab.find('.idCell').length;
+        let container = tab.closest('.rqlResultContainer');
+        BDA_REPOSITORY.reloadSpeedBar(container);
+        if (tabSize == 0) {
+          tab.remove();
+        }
+      } catch (e) {
+        console.error(e);
+      }
 
-            return errorMsg;
-        },
+    },
 
-        executePrintItem: function(domain, itemDescriptor, id, repository, callback, errCallback) {
-            var xmlText = BDA_REPOSITORY.templates.printItem.format(itemDescriptor, id);
-            BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
-        },
+    findTabToAppendTo: function(itemDescriptorName, outputDiv) {
+      let dataTables = outputDiv.find('.dataTable[data-descriptor="{0}"]'.format(itemDescriptorName));
+      var max = BDA_REPOSITORY.getChunkSize();
+      let res;
+      logTrace('dataTables', dataTables);
+      dataTables.each(function(idx, table) {
+        let $table = $(table);
+        logTrace('table', $table);
+        if ($table.find('.idCell').length < max) {
+          res = $table;
+        }
+      })
+      return res;
+    },
 
-        executeQueryItems: function(domain, itemDescriptor, query, repository, callback, errCallback) {
-            var xmlText = BDA_REPOSITORY.templates.queryItems.format(itemDescriptor, query);
-            BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
-        },
+    appendToDataTable: function(id, itemDescriptorName, repositoryPath, dataTable, tempResult, cb) {
+      let propertySelector = '.property[data-id="{0}"]'.format(id);
+      tempResult.find(propertySelector).each(function() {
+        let $this = $(this);
+        let propertyName = $this.attr('data-property');
+        dataTable.find('.item-line[data-property="{0}"]'.format(propertyName)).append($this);
+      })
 
-        previewRql: function(queryType, values) {
-            let xmlText;
-            switch (queryType) {
-                case 'print':
-                    xmlText = BDA_REPOSITORY.templates.printItem.format(values.itemDescriptor, values.id);
-                    break;
-                case 'query':
-                    xmlText = BDA_REPOSITORY.templates.queryItems.format(values.itemDescriptor, values.text);
-                    break;
-                default:
-                    xmlText = values.text
+      //  update the data
+      let idSelector = '.idCell[data-id="{0}"]'.format(id, itemDescriptorName);
+      dataTable.find('tr.id').append(tempResult.find(idSelector));
+      BDA_REPOSITORY.showNonEmptyLines(dataTable);
+      if (cb) {
+        cb();
+      }
+    },
 
-            }
-            return xmlText;
-        },
-
-        setupRepositoryCacheSection: function() {
+    reloadTab: function(id, itemDescriptorName, repositoryPath, parentTab, cb) {
+      if (_.isNil(repositoryPath)) {
+        repositoryPath = getCurrentComponentPath();
+      }
+      BDA_REPOSITORY.executePrintItem('', itemDescriptorName, id, repositoryPath,
+        function(result) {
+          BDA_REPOSITORY.parseXhrResult(result, repositoryPath, (parsed) => {
 
             try {
 
-                console.time("setupRepositoryCacheSection");
+              let tempResult = $('<div></div>');
+              BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, tempResult);
 
-                //global css setups to aid further customisation
-                var $cacheUsage = $(this.cacheUsageSelector);
-                var $cacheTable = $cacheUsage.next().next().find('table');
-                BDA_REPOSITORY.$cacheTable = $cacheTable;
-                $cacheTable.addClass('cache').removeAttr('border'); //remove border - will be handled by css
+              let propertySelector = '.property[data-id="{0}"]'.format(id);
+              tempResult.find(propertySelector).each(function() {
+                let $this = $(this);
+                let propertyName = $this.attr('data-property');
+                parentTab.find(propertySelector + '[data-property="{0}"]'.format(propertyName)).replaceWith(this);
+              })
 
+              //  update the data
+              let idSelector = '.idCell[data-identifier="id_{0}_{1}"]'.format(id, itemDescriptorName);
+              parentTab.find(idSelector).replaceWith(tempResult.find(idSelector));
 
-                //move the header in a thead
-                var $header = $cacheTable.find('tr').first();
-                $header.detach();
-                var $thead = $('<thead></thead>').prependTo($cacheTable).append($header);
+              parentTab.find('[data-id="{0}"]'.format(id)).flash();
 
-                //mark the sub-headers
-                var index = 0;
-                $cacheTable.find('tr').each(function() {
-                    var $tr = $(this);
-                    //if header
-                    if ((index - 1) % 3 == 0) { //if sub-header
-                        //highlight per item
-                        $tr.addClass('odd cache-subheader');
-                    }
-                    index++;
-                });
-                var $tBody = $cacheTable.find('tbody:first');
+              BDA_REPOSITORY.showNonEmptyLines(parentTab);
 
-
-                BDA_REPOSITORY.setupCacheCollapse($header, $cacheTable);
-
-
-                //collapse all button
-                var $resetLink = $cacheUsage.next();
-                var $buttons = $('<div></div>').appendTo($resetLink);
-
-                var $expandAll = $('<button></button>', {
-                        id: 'cacheExpandAll',
-                        class: ' cache expand',
-                        value: 'expandAll',
-                        html: 'Expand All'
-                    })
-                    .bind('click', function() {
-                        $cacheTable.find('tr.cache-subheader.collapsed').each(BDA_REPOSITORY.toggleCacheLines);
-                    })
-                    .appendTo($buttons);
-
-                var $collapseAll = $('<button></button>', {
-                        id: 'collapseAll',
-                        class: 'cache collapse',
-                        value: 'collapseAll',
-                        html: 'Collapse All'
-                    })
-                    .on('click', function() {
-                        $cacheTable.find('tr.cache-subheader.expanded').each(BDA_REPOSITORY.toggleCacheLines);
-                    })
-                    .appendTo($buttons);
-
-                $collapseAll = $('<button></button>', {
-                        id: 'exportCSV',
-                        class: 'cache export',
-                        value: 'exportCSV',
-                        html: 'Export as CSV'
-                    })
-                    .on('click', function() {
-                        BDA_REPOSITORY.exportCacheStatsAsCSV();
-                    })
-                    .appendTo($buttons);
-
-                BDA_REPOSITORY.setupCacheTableHeaderFixed($header, $cacheTable);
-
-
-                //collapse all (after setup fixed header because we need full width)
-                $cacheTable.find('.cache-subheader').each(function() {
-                    $(this).addClass('collapsed')
-                        .next().css('display', 'none')
-                        .next().css('display', 'none');
-                });
-
-                console.timeEnd("setupRepositoryCacheSection");
-            } catch (err) {
-                console.error(err);
+              if (cb) {
+                cb();
+              }
+            } catch (e) {
+              console.error(e);
             }
 
+          })
         },
 
-        setupCacheCollapse: function($header, $cacheTable) {
+        function(jqXHR, textStatus, errorThrown) {
+          $.notify(
+            "Error during call: " + errorThrown + ".", {
+              className: "error",
+              position: "top center"
+            }
+          );
 
-            var fullColSize = 23;
-            if (BDA.isOldDynamo) {
-                fullColSize = 18;
+        })
+    },
 
+    // load sub item with an ajax call
+    loadSubItem: function(id, itemDescriptorName, repositoryPath, $outputDiv, cbSuccess, cbErr, cbEnd) {
+      if (_.isNil(repositoryPath)) {
+        repositoryPath = getCurrentComponentPath();
+      }
+
+      // : function(domain, itemDescriptor, id, repository, callback, errCallback) {
+      BDA_REPOSITORY.executePrintItem('', itemDescriptorName, id, repositoryPath,
+        function(result) {
+          BDA_REPOSITORY.parseXhrResult(result, repositoryPath, (parsed) => {
+
+            let temp = $('<div></div>');
+
+            let top = BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, temp);
+            //use the itemDescriptor from the result, not the query (ex payment group vs creditCard)
+
+            let resultDescriptorName = _.first(parsed.items).itemDescriptor.name;
+            let targetTab = BDA_REPOSITORY.findTabToAppendTo(resultDescriptorName, $outputDiv);
+            if (_.isNil(targetTab) || targetTab.length === 0) {
+              temp.children().appendTo($outputDiv);
+            } else {
+              BDA_REPOSITORY.appendToDataTable(id, resultDescriptorName, repositoryPath, targetTab, temp);
+              top = targetTab;
             }
 
-
-            $cacheTable.find('.cache-subheader').each(function() {
-                var $tr = $(this);
-
-                //expand the cell width
-                var $td = $tr.find('td').first();
-
-                $td.attr('colspan', fullColSize); //extend to full with
-                //query cache line
-                var $queryCols = $tr.next().next().children('td');
-                if ($queryCols.length == 1) {
-                    $queryCols.attr('colspan', fullColSize);
-                }
-
-                //enhance the title line
-                var text = $td.find('b:contains("item-descriptor")').first().text();
-
-                var match = BDA_REPOSITORY.CACHE_STAT_TITLE_REGEXP.exec(text);
-                var newText = '';
-                var itemDesc = '',
-                    cacheMode = '',
-                    cacheLocality = '';
-                if (!isNull(match[1])) {
-                    itemDesc = match[1];
-                    newText += '<span> item-descriptor=<b>{0}</b>'.format(itemDesc);
-                }
-                if (!isNull(match[2])) {
-                    cacheMode = match[2];
-                    newText += '<span> cache-mode=<b>{0}</b>'.format(cacheMode);
-                }
-                if (!isNull(match[3])) {
-                    cacheLocality = match[3];
-                    newText += '<span> cache-locality=<b>{0}</b>'.format(cacheLocality);
-                }
-
-                //add as attr for easier handling
-                $tr.attr('data-item-desc', itemDesc)
-                    .attr('data-cache-mode', cacheMode)
-                    .attr('data-cache-locality', cacheLocality);
-
-                var $arrow = $('<span class="cacheArrow"><i class="up fa fa-arrow-right"></i></span>' + newText);
-                $td.html($arrow);
-
-                //collapse items
-                $tr.bind('click', BDA_REPOSITORY.toggleCacheLines);
-
-
-
-            });
-        },
-
-        setupCacheTableHeaderFixed: function($header, $cacheTable) {
-
-            traceTime('setupCacheTableHeaderFixed')
-
-            //make the header fixed with css
-            $cacheTable.addClass('fixed_headers');
-            logTrace('isOldDynamo ' + BDA.isOldDynamo)
-            if (BDA.isOldDynamo) {
-                $cacheTable.addClass('oldDynamo');
+            BDA_REPOSITORY.reloadSpeedBar($outputDiv);
+            if (top) {
+              top.scrollTo();
+              top.find('[data-id="{0}"]'.format(id)).flash();
             }
-
-            //clone the header
-
-            var $copy = $header.clone().addClass('sticky-header-copy');
-            $header.addClass('sticky-header-original');
-            $copy.insertAfter($header).hide();
-
-            var left = null;
-            var setupDone = false;
-            $(window).scroll(function() { // scroll event
-                var $window = $(window);
-                var windowTop = $window.scrollTop();
-                //get the value now because it changes on show/hide/collapse
-                var top = $cacheTable.offset().top;
-                var bot = top + $cacheTable.height();
-
-                try {
-
-                    if (top < windowTop && bot > windowTop) {
-                        $copy.addClass('sticky-top');
-                        var windowLeft = $window.scrollLeft();
-                        if (!setupDone) {
-                            left = $cacheTable.offset().left;
-                            BDA_REPOSITORY.setupCacheHeaderWidth($header, $copy);
-                            setupDone = true;
-                        }
-                        $copy.css('left', -windowLeft + left);
-                        $copy.show();
-                    } else {
-                        $copy.removeClass('sticky-top');
-                        $copy.css('left', 0);
-                        $copy.hide();
-                    }
-
-                } catch (e) {
-                    console.error(e);
-                }
-
-            });
-            traceTimeEnd('setupCacheTableHeaderFixed')
-
-        },
-
-        setupCacheHeaderWidth: function($header, $copy) {
-            traceTime('setupCacheHeaderWidth.getWidth')
-            //since we set all column with the same width we can use only the first cell as reference
-            var w = $('th:first', $header).width() + "px"; // .width() is very slow :(
-            //var w =first.width()
-            traceTimeEnd('setupCacheHeaderWidth.getWidth')
-
-            var $child;
-            traceTime('setupCacheHeaderWidth.setFixedWidth')
-            $copy.children('th').each(function(idx, child) {
-                $child = $(child);
-                $child.css({
-                    'max-width': w,
-                    'min-width': w,
-                })
-            });
-            traceTimeEnd('setupCacheHeaderWidth.setFixedWidth')
-
-        },
-
-        toggleCacheLines: function() {
-            var $tr = $(this);
-            $tr.toggleClass('collapsed')
-                .toggleClass('expanded');
-            $tr.next().toggle();
-            $tr.next().next().toggle();
-            rotateArrowQuarter($tr.find('.cacheArrow i'));
-        },
-
-        exportCacheStatsAsCSV: function() {
-            var data = [];
-            var line, $tr, $dataTr;
-            //header
-            data.push([
-                'Item Descriptor',
-                'Cache Mode',
-                'Cache locality',
-                'type',
-                'localEntries',
-                'externEntries',
-                'weakEntries',
-                'localCacheSize',
-                'usedRatio',
-                'totalHits',
-                'totalMisses',
-                'ratio',
-                'localHits',
-                'localMisses',
-                'externalHits',
-                'externalMisses',
-                'weakHits',
-                'weakMisses',
-                'cacheInvalidations',
-                'entryInvalidations',
-                'localCulls',
-                'localItemsCulled',
-                'localMaxCulled',
-                'weakCulls',
-                'weakItemsCulled',
-                'weakMaxCulled'
-            ]);
-
-            BDA_REPOSITORY.$cacheTable.find('tr.cache-subheader').each(function(idx, elem) {
-                $tr = $(elem);
-                line = [];
-                line.push($tr.attr('data-item-desc'));
-                line.push($tr.attr('data-cache-mode'));
-                line.push($tr.attr('data-cache-locality'));
-                line.push('item-cache');
-
-                $tr.next().children('td').each(function() {
-                    line.push($(this).text());
-                });
-
-                data.push(line);
-
-                var $queryTr = $tr.next().next();
-                var $cols = $queryTr.children('td');
-                if ($cols.length > 1) {
-                    //query caching available
-                    line = [];
-                    line.push($tr.attr('data-item-desc'));
-                    line.push($tr.attr('data-cache-mode'));
-                    line.push($tr.attr('data-cache-locality'));
-                    line.push('query-cache');
-
-                    $cols.each(function() {
-                        line.push($(this).text());
-                    });
-                    data.push(line);
-                }
-            });
-
-            var linesText = [];
-            for (var i = 0; i < data.length; i++) {
-                linesText.push(data[i].join(';'))
+            if (cbSuccess) {
+              cbSuccess();
             }
-
-            var csv = linesText.join('\n');
-
-            copyToClipboard(csv);
-
+            if (cbEnd) {
+              cbEnd();
+            }
+          });
+        },
+        function(jqXHR, textStatus, errorThrown) {
+          $.notify(
+            "Error during call: " + errorThrown + ".", {
+              className: "error",
+              position: "top center"
+            }
+          );
+          if (cbErr) {
+            cbErr();
+          }
+          if (cbEnd) {
+            cbEnd();
+          }
         }
-    };
+      )
+    },
 
-    // Reference to BDA_STORAGE
-    var BDA_STORAGE, BDA;
+    oldShowXMLAsTab: function(xmlContent, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
 
-    // Jquery plugin creation
-    $.fn.bdaRepository = function(theBDA) {
-        logTrace('Init plugin {0}'.format('bdaRepository'));
-        //settings = $.extend({}, defaults, options);
-        BDA = theBDA;
-        BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
-        BDA_REPOSITORY.build();
-        return this;
-    };
 
-    $.fn.bdaRepository.reloadQueryList = function() {
-        if (BDA_REPOSITORY.isRepositoryPage)
-            BDA_REPOSITORY.reloadQueryList();
-    };
+      console.time("oldShowXMLAsTab");
+      var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
+      var $xml = $(xmlDoc);
+      var $addItems = $xml.find("add-item");
+      var types = {};
+      var datas = [];
+      var nbTypes = 0;
+      var typesNames = {};
 
-    $.fn.executePrintItem = function(domain, itemDescriptor, id, repository, callback, errCallback) {
-        BDA_REPOSITORY.executePrintItem(domain, itemDescriptor, id, repository, callback, errCallback);
-    };
+      var log = $("<xml>" + xmlContent + "</xml>")
+        .children()
+        .remove()
+        .end()
+        .text()
+        .trim();
 
-    $.fn.executeQueryItems = function(domain, itemDescriptor, query, repository, callback, errCallback) {
-        BDA_REPOSITORY.executeQueryItems(domain, itemDescriptor, query, repository, callback, errCallback);
-    };
+      var descriptorAndDefaultValues = {};
+      if ($xmlDef != null) {
+        for (var i = 0; i < $addItems.length; i++) {
+          var itemDescriptor = $addItems[i].getAttribute("item-descriptor");
 
-    $.fn.executeRql = function(domain, xmlText, repository, callback, errCallback) {
-        BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
-    };
+          if (descriptorAndDefaultValues.hasOwnProperty(itemDescriptor) === false) {
+            BDA_REPOSITORY.getDescriptorAndDefaultValues(itemDescriptor, $xmlDef, descriptorAndDefaultValues);
+          }
+          for (var defaultPropertyName in descriptorAndDefaultValues[itemDescriptor]) {
+            var exists = $($addItems[i]).find("[name=" + defaultPropertyName + "]").length;
+            if (exists == 0) {
+              $addItems[i].innerHTML += '<set-property name="' + defaultPropertyName + '"><![CDATA[' + descriptorAndDefaultValues[itemDescriptor][defaultPropertyName] + ']]></set-property>';
+            }
+          }
+        }
+      }
 
-    $.fn.previewRql = function(queryType, values) {
-        return BDA_REPOSITORY.previewRql(queryType, values);
+
+      $addItems.each(function() {
+        var curItemDesc = "_" + $(this).attr("item-descriptor");
+        if (!types[curItemDesc])
+          types[curItemDesc] = [];
+        if (!typesNames[curItemDesc])
+          typesNames[curItemDesc] = [];
+        if (!datas[curItemDesc]) {
+          datas[curItemDesc] = [];
+          nbTypes++;
+        }
+        var curData = {};
+
+        $(this).find("set-property").each(function(index) {
+          var $curProp = $(this);
+          curData[$curProp.attr("name")] = $curProp.text();
+          var type = {};
+          type.name = $curProp.attr("name");
+          if ($.inArray(type.name, typesNames[curItemDesc]) == -1) {
+            type.rdonly = $curProp.attr("rdonly");
+            type.derived = $curProp.attr("derived");
+            type.exportable = $curProp.attr("exportable");
+            var typeItemDesc = BDA_REPOSITORY.isTypeId(type.name, curItemDesc.substr(1), $xmlDef);
+            if (typeItemDesc === null)
+              type.isId = false;
+            else {
+              type.isId = true;
+              type.itemDesc = typeItemDesc;
+            }
+            types[curItemDesc].push(type);
+            typesNames[curItemDesc].push(type.name);
+          }
+        });
+        if ($.inArray("descriptor", typesNames[curItemDesc]) == -1) {
+          var typeDescriptor = {};
+          typeDescriptor.name = "descriptor";
+          types[curItemDesc].unshift(typeDescriptor);
+          typesNames[curItemDesc].push("descriptor");
+        }
+        if ($.inArray("id", typesNames[curItemDesc]) == -1) {
+          var typeId = {};
+          typeId.name = "id";
+          types[curItemDesc].unshift(typeId);
+          typesNames[curItemDesc].push("id");
+        }
+        curData.descriptor = curItemDesc;
+        curData.id = $(this).attr("id");
+        datas[curItemDesc].push(curData);
+      });
+      var html = "<p class='nbResults'>" + $addItems.length + " items in " + nbTypes + " descriptor(s)</p>";
+      var splitValue;
+      var splitObj = BDA_STORAGE.getStoredSplitObj();
+      if (splitObj === undefined || splitObj === null || splitObj.activeSplit === true)
+        splitValue = 0;
+      else
+        splitValue = parseInt(splitObj.splitValue);
+      for (var itemDesc in datas) {
+        if (splitValue === 0)
+          splitValue = datas[itemDesc].length;
+        var nbTab = 0;
+        if (datas[itemDesc].length <= splitValue) {
+          html += BDA_REPOSITORY.renderTab(itemDesc, types[itemDesc], datas[itemDesc], itemDesc.substr(1), isItemTree);
+        } else {
+          while ((splitValue * nbTab) < datas[itemDesc].length) {
+            var start = splitValue * nbTab;
+            var end = start + splitValue;
+            if (end > datas[itemDesc].length)
+              end = datas[itemDesc].length;
+            var subDatas = datas[itemDesc].slice(start, end);
+            html += BDA_REPOSITORY.renderTab(itemDesc, types[itemDesc], subDatas, itemDesc + "_" + nbTab, isItemTree);
+            nbTab++;
+          }
+        }
+      }
+      $outputDiv.append(html);
+      $outputDiv.prepend("<div class='prop_attr prop_attr_red'>R</div> : read-only " + "<div class='prop_attr prop_attr_green'>D</div> : derived " + "<div class='prop_attr prop_attr_blue'>E</div> : export is false");
+
+      if ($(".copyField").length > 0) {
+        // reuse $outputDiv in case we have several results set on the page (RQL query + get item tool)
+        $outputDiv.find("p.nbResults").append("<br><a href='javascript:void(0)' class='showFullTextLink'>Show full text</a>");
+        $outputDiv.find(".showFullTextLink").click(function() {
+          console.time("showFullText");
+          $(".copyField").each(function() {
+            $(this).parent().html($(this).html());
+          });
+          console.timeEnd("showFullText");
+          $(this).hide();
+        });
+      }
+
+      if (_.isNil(loadSubItemCb)) {
+        $outputDiv.find(".loadable_property").click(BDA_REPOSITORY.showLoadSubItemAlert);
+
+      } else {
+        $outputDiv.find(".loadable_property").click(loadSubItemCb);
+      }
+
+      if (isItemTree)
+        BDA_REPOSITORY.createSpeedbar();
+
+      console.timeEnd("oldShowXMLAsTab");
+      return log;
+    },
+
+    showLoadSubItemAlert: function() {
+      logTrace('click on loadable');
+      var $elm = $(this);
+      var id = $elm.attr("data-id");
+      var itemDesc = $elm.attr("data-descriptor");
+      var query = "<print-item id='" + id + "' item-descriptor='" + itemDesc + "' />\n";
+
+      $('body').bdaAlert({
+        msg: 'You are about to add this query and reload the page: \n' + query,
+        options: [{
+          label: 'Add & Reload',
+          _callback: function() {
+            BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
+            $("#RQLForm").submit();
+          }
+        }, {
+          label: 'Just Add',
+          _callback: function() {
+            BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
+          }
+        }, {
+          label: 'Cancel'
+        }]
+      });
+    },
+
+    showRQLLog: function(log, error) {
+      logTrace("Execution log : " + log);
+      if (log && log.length > 0) {
+        $("<h3>Execution log</h3><div id='RQLLog'></div>").insertAfter("#RQLResults");
+        var cleanLog = log.replace(/\n{2,}/g, '\n').replace(/------ /g, "").trim();
+        $("#RQLLog").html(cleanLog);
+      }
+      if (error)
+        $("#RQLLog").addClass("error");
+    },
+
+    showRQLResults: function() {
+      logTrace("Start showRQLResults");
+      // Add 'show raw xml' link
+      var html = "<p>" + "<a href='javascript:void(0)' id='rawXmlLink'>Show raw xml</a>" + "</p>\n";
+      html += "<p id='rawXml'></p>";
+      $("#RQLResults").addClass('rqlResultContainer').append(html);
+
+      var xmlContent = $(BDA_REPOSITORY.resultsSelector).next().text().trim();
+      // xmlContent = sanitizeXml(xmlContent); //sanitize later
+
+      BDA_REPOSITORY.PERF_MONITOR.reset();
+      BDA_REPOSITORY.PERF_MONITOR.start('processRepositoryXmlDef');
+      processRepositoryXmlDef("definitionFiles", function($xmlDef) {
+        BDA_REPOSITORY.PERF_MONITOR.cumul('processRepositoryXmlDef');
+        var log = BDA_REPOSITORY.showXMLAsTab(xmlContent, $xmlDef, $("#RQLResults"), false);
+        BDA_REPOSITORY.showRQLLog(log, false);
+        // Move raw xml
+        $(BDA_REPOSITORY.resultsSelector).next().appendTo("#rawXml");
+        $(BDA_REPOSITORY.resultsSelector).remove();
+
+        $("#rawXmlLink").click(function() {
+          BDA_REPOSITORY.toggleRawXml();
+          var xmlSize = $("#rawXml pre").html().length;
+          logTrace("raw XML size : " + xmlSize);
+          logTrace("XML max size : " + BDA_REPOSITORY.xmlDefinitionMaxSize);
+          if (xmlSize < BDA_REPOSITORY.xmlDefinitionMaxSize) {
+            $('#rawXml').each(function(i, block) {
+              hljs.highlightBlock(block);
+            });
+          } else {
+            // Check if button already exists
+            if ($("#xmlHighlight").length === 0) {
+              $("<p id='xmlHighlight' />")
+                .html("The XML result is big, to avoid slowing down the page, XML highlight have been disabled. " + "<br> <button id='xmlHighlightBtn'>Highlight XML now</button> <small>(takes few seconds)</small>")
+                .prependTo($("#rawXml"));
+              $("#xmlHighlightBtn").click(function() {
+                $('#rawXml pre').each(function(i, block) {
+                  hljs.highlightBlock(block);
+                });
+              });
+            }
+          }
+        });
+
+        $(".copyLink").click(function() {
+          BDA_REPOSITORY.showTextField($(this).attr("id").replace("link_", ""));
+        });
+      });
+    },
+
+    showRqlErrors: function() {
+      var error = "";
+      if ($(BDA_REPOSITORY.errorsSelector1).length > 0) {
+        logTrace("Case of error  : 1");
+        error = $(BDA_REPOSITORY.errorsSelector1).next().text();
+        $(BDA_REPOSITORY.resultsSelector).next().remove();
+        $(BDA_REPOSITORY.resultsSelector).remove();
+        $(BDA_REPOSITORY.errorsSelector1).next().remove();
+        $(BDA_REPOSITORY.errorsSelector1).remove();
+      } else {
+        logTrace("Case of error  : 2");
+        error = $(BDA_REPOSITORY.errorsSelector2).text();
+      }
+      error = BDA_REPOSITORY.purgeXml(error);
+      BDA_REPOSITORY.showRQLLog(error, true);
+    },
+
+    escapeHTML: function(s) {
+      return String(s).replace(/&(?!\w+;)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    },
+
+    propertiesDef: function(hljs) {
+      logTrace("propertiesDef");
+      return {
+        case_insensitive: true,
+        contains: [{
+          className: 'comment',
+          begin: '#',
+          end: '$'
+        }, {
+          className: 'setting',
+          begin: '^[a-z0-9\\[\\]_-]+[ \\t]*=[ \\t]*',
+          end: '$',
+          contains: [{
+            className: 'value',
+            endsWithParent: true,
+            keywords: 'on off true false yes no',
+            contains: [hljs.QUOTE_STRING_MODE, hljs.NUMBER_MODE],
+            relevance: 0
+          }]
+        }]
+      };
+    },
+
+    //--- Item Tree functions ------------------------------------------------------------------------
+
+    setupItemTreeForm: function() {
+      $("<div id='itemTree' />").insertAfter("#RQLEditor");
+      var $itemTree = $("#itemTree");
+      $itemTree.append("<h2>Get Item Tree</h2>");
+      $itemTree.append("<p>This tool will recursively retrieve items and print the result with the chosen output." + "<br> For example, if you give an order ID in the form below, you will get all shipping groups, payment groups, commerceItems, priceInfo... of the given order" + "<br><b> Be careful when using this tool on a live instance ! Set a low max items value.</b></p>");
+
+      $itemTree.append("<div id='itemTreeForm'>" + "id : <input type='text' id='itemTreeId' /> &nbsp;" + "descriptor :  <span id='itemTreeDescriptorField' ><select id='itemTreeDesc' class='itemDescriptor' >" + BDA_REPOSITORY.getDescriptorOptions() + "</select></span>" + "max items : <input type='text' id='itemTreeMax' value='50' /> &nbsp;<br><br>" + "output format :  <select id='itemTreeOutput'>" + "<option value='HTMLtab'>HTML tab</option>" + "<option value='addItem'>add-item XML</option>" + "<option value='removeItem'>remove-item XML</option>" + "<option value='printItem'>print-item XML</option>" + "<option value='tree'>Tree (experimental)</option>" + "</select>&nbsp;" + "<input type='checkbox' id='printRepositoryAttr' /><label for='printRepositoryAttr'>Print attribute : </label>" + "<pre style='margin:0; display:inline;'>repository='" + getCurrentComponentPath() + "'</pre> <br><br>" + "<button id='itemTreeBtn'>Enter <i class='fa fa-play fa-x'></i></button>" + "</div>");
+      $itemTree.append("<div id='itemTreeInfo' />");
+      $itemTree.append("<div id='itemTreeResult' class='rqlResultContainer' />");
+      $("#itemTreeBtn").click(function() {
+        var descriptor = $("#itemTreeDesc").val();
+        var id = $("#itemTreeId").val().trim();
+        var maxItem = parseInt($("#itemTreeMax").val());
+        var outputType = $("#itemTreeOutput").val();
+        var printRepoAttr = $("#printRepositoryAttr").is(':checked');
+        logTrace("max item : " + maxItem);
+        BDA_REPOSITORY.getItemTree(id, descriptor, maxItem, outputType, printRepoAttr);
+      });
+
+    },
+
+    getSubItems: function(items, $xmlDef, maxItem, outputType, printRepoAttr) {
+      var nbItem = BDA_REPOSITORY.itemTree.size;
+      logTrace("maxItem : " + maxItem + ", nbItem : " + nbItem);
+
+      // Ensure that getSubItems is not call more than maxItem times
+      if (nbItem >= maxItem) {
+        logTrace("max Item (" + maxItem + ") reached, stopping recursion");
+        return;
+      }
+
+      var xmlText = "";
+      for (var batchSize = 0; batchSize != items.length; batchSize++) {
+        // Don"t ask for more items than limit
+        if ((BDA_REPOSITORY.nbItemReceived + batchSize) >= maxItem)
+          break;
+        xmlText += "<print-item id='" + items[batchSize].id + "' item-descriptor='" + items[batchSize].desc + "' />\n";
+      }
+      logTrace(xmlText);
+      logTrace("batch size : " + batchSize);
+      // Only request if the batchSize contains something
+      if (batchSize > 0) {
+        $.ajax({
+          type: "POST",
+          url: document.URL,
+          data: {
+            xmltext: xmlText
+          },
+          success: function(result, status, jqXHR) {
+
+            var rawItemsXml = $(result).find("code").html();
+            // remove first 2 lines
+            var tab = rawItemsXml.split("\n");
+            tab.splice(0, 2);
+            rawItemsXml = tab.join("\n").trim();
+            // unescape HTML
+            rawItemsXml = "<xml>" + rawItemsXml.replace(/&lt;/g, "<").replace(/&gt;/g, ">") + "</xml>";
+
+            var xmlDoc = jQuery.parseXML(rawItemsXml);
+            BDA_REPOSITORY.nbItemReceived += $(xmlDoc).find("add-item").length;
+            $("#itemTreeInfo").html("<p>" + BDA_REPOSITORY.nbItemReceived + " items retrieved</p>");
+
+            var subItems = [];
+            $(xmlDoc).find("add-item").each(function() {
+              var $itemXml = $(this);
+              var itemId = $itemXml.attr("id");
+              if (BDA_REPOSITORY.itemTree.get(itemId) === undefined) {
+                var rawItemXml = $itemXml[0].outerHTML;
+                BDA_REPOSITORY.itemTree.set(itemId, rawItemXml);
+                var descriptor = $itemXml.attr("item-descriptor");
+                var $itemDesc = $xmlDef.find("item-descriptor[name=" + descriptor + "]");
+                var superType = $itemDesc.attr("super-type");
+                while (superType !== undefined) {
+                  var $parentDesc = $xmlDef.find("item-descriptor[name=" + $itemDesc.attr("super-type") + "]");
+                  $itemDesc = $itemDesc.add($parentDesc);
+                  superType = $parentDesc.attr("super-type");
+                }
+                // One to One relation
+                $itemDesc.find('property[item-type]')
+                  .each(function(index, elm) {
+                    var $elm = $(elm);
+                    var subProperty = $elm.attr("name");
+                    var subId = $itemXml.find("set-property[name=" + subProperty + "]").text();
+                    if ($elm.attr("repository") === undefined && subId.length > 0) {
+                      // avoid infinite recursion
+                      if (BDA_REPOSITORY.itemTree.get(subId) === undefined) {
+                        subItems.push({
+                          'id': subId,
+                          'desc': $elm.attr("item-type")
+                        });
+                      }
+                    }
+                  });
+
+                // One to Many relation with list, array or map
+                $itemDesc.find('property[component-item-type]')
+                  .each(function(index, elm) {
+                    var $elm = $(elm);
+                    var subProperty = $elm.attr("name");
+                    var subId = $itemXml.find("set-property[name=" + subProperty + "]").text();
+                    if ($elm.attr("repository") === undefined && subId.length > 0) {
+                      var desc = $elm.attr("component-item-type");
+                      var ids = BDA_REPOSITORY.parseRepositoryId(subId);
+                      for (var i = 0; i != ids.length; i++) {
+                        // avoid infinite recursion
+                        if (ids[i] !== BDA_REPOSITORY.MAP_SEPARATOR && ids[i] !== BDA_REPOSITORY.LIST_SEPARATOR && BDA_REPOSITORY.itemTree.get(ids[i]) === undefined)
+                          subItems.push({
+                            'id': ids[i],
+                            'desc': desc
+                          });
+                      }
+                    }
+                  });
+              }
+            });
+
+            logTrace(subItems.length + " items to retrieved in next request. Limit reach : " + (BDA_REPOSITORY.nbItemReceived >= maxItem));
+            if (subItems.length > 0 && BDA_REPOSITORY.nbItemReceived < maxItem)
+              BDA_REPOSITORY.getSubItems(subItems, $xmlDef, maxItem, outputType, printRepoAttr);
+            else
+              BDA_REPOSITORY.renderItemTreeTab(outputType, printRepoAttr, $xmlDef, maxItem);
+          },
+        });
+      } else
+        logTrace("Request is empty, nothing to do.");
+    },
+
+    getItemTree: function(id, descriptor, maxItem, outputType, printRepoAttr) {
+      logTrace("getItemTree - start");
+      // reset divs
+      $("#itemTreeResult").empty();
+      $("#itemTreeInfo").empty();
+
+      if (!id) {
+        $("#itemTreeInfo").html("<p>Please provide a valid ID</p>");
+        return;
+      }
+
+      console.time("getItemTree");
+      console.time("retrieveItem");
+      // Get XML definition of the repository
+      $("#itemTreeInfo").html("<p>Getting XML definition of this repository...</p>");
+      var $xmlDef = processRepositoryXmlDef("definitionFiles", function($xmlDef) {
+        if (!$xmlDef) {
+          $("#itemTreeInfo").html("<p>Unable to parse XML definition of this repository !</p>");
+          return;
+        }
+        logTrace("descriptor : " + $xmlDef.find("item-descriptor").length);
+        // get tree
+        BDA_REPOSITORY.itemTree = new Map();
+        BDA_REPOSITORY.nbItemReceived = 0;
+        BDA_REPOSITORY.getSubItems([{
+          'id': id,
+          'desc': descriptor
+        }], $xmlDef, maxItem, outputType, printRepoAttr);
+      });
+    },
+
+    renderItemTreeTab: function(outputType, printRepoAttr, $xmlDef, maxItem) {
+      console.timeEnd("retrieveItem");
+      logTrace("Render item tree tab : " + outputType);
+
+      //  If the max item is reached before recursion ended, we notify the user
+      if (BDA_REPOSITORY.nbItemReceived >= maxItem) {
+        $.notify(
+          "Item tree stopped because the maximum items limit was reached : " + maxItem + ".", {
+            className: "warn",
+            position: "top center"
+          }
+        );
+      }
+
+      $("#itemTreeInfo").empty();
+      $("#itemTreeResult").empty();
+      var res = "";
+      if (outputType !== "HTMLtab" && outputType != "tree") {
+        logTrace("Render copy button");
+        $("#itemTreeInfo").append("<input type='button' id='itemTreeCopyButton' value='Copy result to clipboard'></input>");
+        $('#itemTreeCopyButton').click(function() {
+          copyToClipboard($('#itemTreeResult').text());
+        });
+      }
+      if (outputType == "addItem") {
+        BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+          if (printRepoAttr) {
+            var xmlDoc = jQuery.parseXML(data);
+            var $itemXml = $(xmlDoc).find("add-item");
+            $itemXml.attr("repository", getCurrentComponentPath());
+            res += $itemXml[0].outerHTML;
+          } else
+            res += data;
+          res += "\n\n";
+        }, BDA_REPOSITORY.itemTree);
+        res = "<import-items>\n" + res + "\n</import-items>";
+        $("#itemTreeResult").append("<pre />");
+        $("#itemTreeResult pre").text(res);
+      } else if (outputType == "HTMLtab") {
+        BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+          res += data;
+        }, BDA_REPOSITORY.itemTree);
+        BDA_REPOSITORY.showXMLAsTab(res, $xmlDef, $("#itemTreeResult"), true);
+      } else if (outputType == "removeItem" || outputType == "printItem") {
+        BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+          var xmlDoc = jQuery.parseXML(data);
+          var $itemXml = $(xmlDoc).find("add-item");
+          res += "<";
+          if (outputType == "removeItem")
+            res += "remove-item";
+          else
+            res += "print-item";
+          res += ' id="' + $itemXml.attr("id") + '" item-descriptor="' + $itemXml.attr("item-descriptor") + "\"";
+          if (printRepoAttr)
+            res += " repository='" + getCurrentComponentPath() + "'";
+          res += ' />\n';
+        }, BDA_REPOSITORY.itemTree);
+
+        $("#itemTreeResult").append("<pre />");
+        $("#itemTreeResult pre").text(res);
+      } else if (outputType == "tree") {
+        BDA_REPOSITORY.renderAsTree($xmlDef);
+      }
+
+      console.timeEnd("getItemTree");
+    },
+
+    renderAsTree: function($xmlDef) {
+      logTrace("render as tree");
+      console.time('renderAsTree.setup');
+      var nodes = new vis.DataSet();
+      var edges = new vis.DataSet();
+      var legends = new Map();
+      var descById = new Map();
+      var itemIdToVisId = {};
+      var i = 0;
+      BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+        itemIdToVisId[id] = i;
+        i++;
+      });
+
+      BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+        var xmlDoc = $.parseXML("<xml>" + data + "</xml>");
+        var $xml = $(xmlDoc);
+        var $addItem = $xml.find("add-item").first();
+        var itemDesc = $addItem.attr("item-descriptor");
+        var itemId = $addItem.attr("id");
+
+        $addItem.children().each(function(index) {
+          var $this = $(this);
+          var propertyName = $this.attr("name");
+          var propertyValue = $this.text();
+          if (BDA_REPOSITORY.edgesToIgnore.indexOf(propertyName) === -1) {
+            var isId = BDA_REPOSITORY.isTypeId(propertyName, itemDesc, $xmlDef)
+            if (isId != null && isId != "FOUND_NOT_ID") {
+              var idAsTab = BDA_REPOSITORY.parseRepositoryId(propertyValue);
+              for (var i = 0; i != idAsTab.length; i++) {
+                if (idAsTab[i] != "," && idAsTab[i] != "=") {
+                  edges.add({
+                    from: itemIdToVisId[itemId],
+                    to: itemIdToVisId[idAsTab[i]],
+                    arrows: 'to',
+                    title: propertyName
+                  });
+                }
+              }
+            }
+          }
+        });
+
+        var nodeColor = colorToCss(stringToColour(itemDesc));
+        nodes.add({
+          id: itemIdToVisId[itemId],
+          label: itemDesc + "\n" + itemId,
+          color: nodeColor,
+          shape: 'box'
+        });
+        legends.set(itemDesc, nodeColor);
+
+        if (descById.get(itemDesc))
+          descById.get(itemDesc).push(itemId);
+        else
+          descById.set(itemDesc, [itemId]);
+      });
+      console.timeEnd('renderAsTree.setup');
+      // Create popup
+      $("#itemTreeResult").empty()
+        .append("<div class='popup_block' id='treePopup'>" + "<div><a href='javascript:void(0)' class='close'><i class='fa fa-times'></i></a></div>" + "<div id='treeLegend'></div>" + "<div class='flexContainer'>" + "<div id='treeInfo'></div>" + "<div id='treeContainer'></div>" + "</div>" + "</div>");
+      $("#treePopup .close").click(function() {
+        logTrace("click on close");
+        $("#treePopup").hide();
+      });
+
+      // Setup legend
+      legends.forEach(function(value, key) {
+        $("#treeLegend").append("<div class='legend' style='background-color:" + value + "' id='" + key + "'>" + key + "</div>");
+      });
+
+      logTrace("Number for nodes : " + nodes.length);
+      logTrace("Number for edges : " + edges.length);
+
+      $("#treePopup").show();
+      console.time('renderAsTree.render');
+
+      // Create the network
+      var data = {
+        nodes: nodes,
+        edges: edges
+      };
+
+      var options = {
+        physics: {
+          stabilization: false
+        },
+        edges: {
+          smooth: true
+        },
+        nodes: {
+          font: {
+            color: "#FFFFFF"
+          }
+        }
+      };
+
+      var container = document.getElementById('treeContainer');
+      var network = new vis.Network(container, data, options);
+      console.timeEnd('renderAsTree.render')
+
+      network.on("click", function(params) {
+        params.event = "[original event]";
+        if (params.nodes && params.nodes.length == 1) {
+          $("#treeInfo").empty();
+          var visId = params.nodes[0];
+          var itemId = null;
+          logTrace("Click on " + visId);
+          // Find itemId from visID
+          for (var id in itemIdToVisId) {
+            if (visId === itemIdToVisId[id]) {
+              itemId = id;
+              break;
+            }
+          }
+          logTrace("itemId : " + itemId);
+          logTrace(BDA_REPOSITORY.itemTree.get(itemId));
+          BDA_REPOSITORY.showXMLAsTab(BDA_REPOSITORY.itemTree.get(itemId), null, $("#treeInfo"), false);
+          logTrace($("#treeInfo").html());
+          $("#treeInfo").show();
+        }
+      });
+
+      $(".legend").click(function() {
+        // This feature is disabled for now.
+        return;
+        logTrace("click on legend");
+        var id = $(this).attr('id');
+        logTrace(id);
+        var ids = descById.get(id);
+        var nodesAndEdgesToHide = {};
+        for (var i = 0; i != ids.length; i++) {
+          nodesAndEdgesToHide = BDA_REPOSITORY.findNodesAndEdgesToHide(ids[i], network, edges, nodes);
+
+          // Foreach nodesAndEdgesToHide.nodes
+          for (var a = 0; a != nodesAndEdgesToHide.nodes.length; a++) {
+            nodes.update([{
+              id: nodesAndEdgesToHide.nodes[a],
+              hidden: true
+            }]);
+          }
+          // Foreach nodesAndEdgesToHide.edges
+          for (var a = 0; a != nodesAndEdgesToHide.edges.length; a++) {
+            edges.update([{
+              id: nodesAndEdgesToHide.edges[a],
+              hidden: true
+            }]);
+          }
+        }
+      });
+    },
+
+    findNodesAndEdgesToHide: function(id, network, edges, nodes) {
+      logTrace("findNodesAndEdgesToHide for ID : " + id);
+      var nodesAndEdgesToHide = {};
+      nodesAndEdgesToHide.nodes = BDA_REPOSITORY.findOrphanSon(id, network, edges, nodes, [id]);
+      nodesAndEdgesToHide.edges = [];
+      for (var i = 0; i != nodesAndEdgesToHide.nodes.length; i++) {
+        nodesAndEdgesToHide.edges = nodesAndEdgesToHide.edges.concat(network.getConnectedEdges(nodesAndEdgesToHide.nodes[i]));
+      }
+      logTrace("nodesAndEdgesToHide.nodes : ");
+      logTrace(nodesAndEdgesToHide.nodes);
+      logTrace("nodesAndEdgesToHide.edges : ");
+      logTrace(nodesAndEdgesToHide.edges);
+      return nodesAndEdgesToHide;
+    },
+
+    findOrphanSon: function(id, network, edges, nodes, orphanSons) {
+      logTrace("About to find orphan for node : " + id);
+      edges.forEach(function(elm) {
+        //logTrace(elm);
+        if (elm.from == id) {
+          var isOrphan = true;
+          var connectedEdges = network.getConnectedEdges(elm.to);
+
+          for (var i = 0; i != connectedEdges.length; i++) {
+            var edge = edges.get(connectedEdges[i]);
+            logTrace("connectedEdge - from : " + edge.to + " - " + edge.from);
+            if (edge.to == elm.to && edge.from != id) {
+              isOrphan = false;
+              break;
+            }
+          }
+          if (isOrphan && orphanSons.indexOf(elm.to) === -1) {
+            logTrace(elm.to + " is a new orphan son of node : " + id);
+            orphanSons.push(elm.to);
+            BDA_REPOSITORY.findOrphanSon(elm.to, network, edges, nodes, orphanSons);
+          }
+        }
+      });
+      return orphanSons;
+    },
+
+
+    createSpeedbar_new: function(resultElem) {
+      logTrace('createSpeedbar_new')
+      try {
+
+        let speedbar = $('<div class="speedbar"><div class="widget"><i class="fa fa-times close"></i><p>Quick links :</p><ul></ul></div></div>');
+        speedbar.find('.close').on('click', () => {
+          speedbar.fadeOut(200);
+        })
+
+        let list = speedbar.find('ul');
+        resultElem.find(".dataTable").each(function(index) {
+          var $tab = $(this);
+          var id = $tab.attr("id");
+          var descriptor = $tab.attr('data-descriptor');
+
+          var nbItem = $tab.find("td").length / $tab.find("tr").length;
+          let elem = $("<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<span class='clickable_property'>" + descriptor + "</span> (" + nbItem + ")</li>");
+          elem.on('click', () => $tab.scrollTo());
+          list.append(elem);
+        });
+        speedbar.prependTo(resultElem);
+
+        let container = $(resultElem);
+
+        let widget = speedbar.find('.widget');
+        let initialTop = container.offset().top;
+        var initialBot = initialTop + container.height();
+        $(window).scroll(function() {
+          var windowTop = $(window).scrollTop();
+          if (initialTop < windowTop && initialBot > windowTop) {
+            widget.addClass('sticky-top-100');
+          } else {
+            widget.removeClass('sticky-top-100');
+          }
+        });
+
+      } catch (e) {
+        console.error(e);
+      }
+
+    },
+
+    reloadSpeedBar: function(resultElem) {
+      resultElem.find('.speedbar').remove();
+      BDA_REPOSITORY.createSpeedbar_new(resultElem);
+    },
+
+    createSpeedbar: function() {
+      var speedBarHtml = "<a class='close' href='javascript:void(0)'><i class='fa fa-times'></i></a><p>Quick links :</p><ul>";
+      $("#itemTreeResult .dataTable").each(function(index) {
+        var $tab = $(this);
+        var id = $tab.attr("id");
+        var name = id;
+        if (id.indexOf("_") != -1) {
+          var tab = id.split("_");
+          name = tab[1];
+        }
+        var nbItem = $tab.find("td").length / $tab.find("tr").length;
+        speedBarHtml += "<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<a href='#" + id + "'>" + name.trim() + " (" + nbItem + ")</a></li>";
+      });
+      speedBarHtml += "</ul>";
+      $("#itemTreeInfo").append("<div id='speedbar'><div id='widget' class='sticky'>" + speedBarHtml + "</div></div>");
+      $('#speedbar .close').click(function() {
+        $("#speedbar").fadeOut(200);
+      });
+      var stickyTop = $('.sticky').offset().top;
+      $(window).scroll(function() { // scroll event
+        var windowTop = $(window).scrollTop();
+        if (stickyTop < windowTop)
+          $('.sticky').css({
+            position: 'fixed',
+            top: 100
+          });
+        else
+          $('.sticky').css('position', 'static');
+      });
+    },
+
+
+    showQueryList: function() {
+      var html = "";
+      // fix delete query : the index used to delete was not correct
+      // we need to keep original index
+      var rqlQueries = BDA_STORAGE.getStoredRQLQueries();
+      var currComponentName = getComponentNameFromPath(getCurrentComponentPath());
+      var nbQuery = 0;
+      if (rqlQueries && rqlQueries.length > 0) {
+        html += "<ul>";
+        for (var i = 0; i != rqlQueries.length; i++) {
+          var storeQuery = rqlQueries[i];
+          if (!storeQuery.hasOwnProperty("repo") || storeQuery.repo == currComponentName) {
+            var escapedQuery = $("<div>").text(storeQuery.query).html();
+            html += "<li class='savedQuery'>";
+            html += "<a href='javascript:void(0)'>" + storeQuery.name + "</a>";
+            html += "<span id='previewQuery" + i + "'class='previewQuery'>";
+            html += "<i class='fa fa-eye'></i>";
+            html += "</span>";
+            html += "<span id='deleteQuery" + i + "'class='deleteQuery'>";
+            html += "<i class='fa fa-trash-o'></i>";
+            html += "</span>";
+            html += "<span id='queryView" + i + "'class='queryView'>";
+            html += "<pre>" + escapedQuery + "</pre>";
+            html += "</span>";
+            html += "</li>";
+            nbQuery++;
+          }
+        }
+        html += "</ul>";
+        if (nbQuery > 0)
+          $("#storedQueries").html(html);
+      }
+
+      // $('#storedQueries .queryView').each(function(i, block) {
+      //   hljs.highlightBlock(block);
+      // });
+
+      $(".savedQuery").on('click', 'a', function() {
+        logTrace("click on query : " + $(this).find("a").html());
+        BDA_REPOSITORY.printStoredQuery($(this).find("a").html());
+      });
+
+      $(".previewQuery").on('click', function() {
+
+        try {
+
+
+          let block = $(this).parent("li").find("span.queryView").each(function(i, block) {
+            hljs.highlightBlock(block);
+          });
+
+          $('body').bdaAlert({
+            msg: block.html(),
+            width: '900px',
+            options: [{
+              label: 'OK'
+            }]
+          });
+        } catch (e) {
+          console.error(e);
+        }
+
+
+      });
+
+      $(".deleteQuery")
+        .click(function() {
+          var index = this.id.replace("deleteQuery", "");
+          logTrace("Delete query #" + index);
+          logTrace(BDA_STORAGE.deleteRQLQuery);
+          BDA_STORAGE.deleteRQLQuery(index);
+          BDA_REPOSITORY.reloadQueryList();
+        });
+    },
+
+    purgeRQLQuery: function(rqlQueries) {
+      // Purge query
+      var purgedRqlQueries = [];
+      for (var i = 0; i != rqlQueries.length; i++) {
+        var query = rqlQueries[i];
+        if (!query.hasOwnProperty("repo") || query.repo == getComponentNameFromPath(getCurrentComponentPath())) {
+          purgedRqlQueries.push(rqlQueries[i]);
+        }
+      }
+      return purgedRqlQueries;
+    },
+
+    reloadQueryList: function() {
+      $("#storedQueries").empty();
+      BDA_REPOSITORY.showQueryList();
+    },
+
+    printStoredQuery: function(name) {
+      logTrace("printStoredQuery : " + name);
+      var rqlQueries = BDA_STORAGE.getStoredRQLQueries();
+      logTrace(rqlQueries);
+      if (rqlQueries) {
+        for (var i = 0; i != rqlQueries.length; i++) {
+          if (rqlQueries[i].name == name)
+            BDA_REPOSITORY.setQueryEditorValue(rqlQueries[i].query + "\n");
+        }
+      }
+    },
+
+    getToggleLabel: function(state) {
+      if (state == 1)
+        return "Show less...";
+      return "Show more...";
+    },
+
+    toggleShowLabel: function(contentDisplay, selector) {
+      if (contentDisplay == "none")
+        $(selector).html("Show more...");
+      else
+        $(selector).html("Show less...");
+    },
+
+    toggleCacheUsage: function() {
+      var $cacheUsage = $(BDA_REPOSITORY.cacheUsageSelector);
+      $cacheUsage.next().toggle().next().toggle();
+      BDA_REPOSITORY.toggleShowLabel($cacheUsage.next().css("display"), "#showMoreCacheUsage");
+      BDA_STORAGE.storeToggleState("showMoreCacheUsage", $cacheUsage.next().css("display"));
+    },
+
+    toggleRepositoryView: function() {
+      $(BDA_REPOSITORY.repositoryViewSelector).next().toggle().next().toggle();
+      BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.repositoryViewSelector).next().css("display"), "#showMoreRepositoryView");
+      BDA_STORAGE.storeToggleState("showMoreRepositoryView", $(BDA_REPOSITORY.repositoryViewSelector).next().css("display"));
+    },
+
+    toggleProperties: function() {
+      $(BDA_REPOSITORY.propertiesSelector).next().toggle();
+      BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.propertiesSelector).next().css("display"), "#showMoreProperties");
+      BDA_STORAGE.storeToggleState("showMoreProperties", $(BDA_REPOSITORY.propertiesSelector).next().css("display"));
+    },
+
+    toggleEventSets: function() {
+      $(BDA_REPOSITORY.eventSetsSelector).next().toggle();
+      BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.eventSetsSelector).next().css("display"), "#showMoreEventsSets");
+      BDA_STORAGE.storeToggleState("showMoreEventsSets", $(BDA_REPOSITORY.eventSetsSelector).next().css("display"));
+    },
+
+    toggleMethods: function() {
+      $(BDA_REPOSITORY.methodsSelector).next().toggle();
+      BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.methodsSelector).next().css("display"), "#showMoreMethods");
+      BDA_STORAGE.storeToggleState("showMoreMethods", $(BDA_REPOSITORY.methodsSelector).next().css("display"));
+    },
+
+    toggleRawXml: function() {
+      $("#rawXml").toggle();
+      if ($("#rawXml").css("display") == "none")
+        $("#rawXmlLink").html("show raw XML");
+      else
+        $("#rawXmlLink").html("hide raw XML");
+    },
+
+    // simply handles an ajax call to a repository and parse the result
+    // xmltext : full xml text
+    // repository : only the strict nucleus path
+    // callback : take 1 param :  object {item: array of add-items, head}
+    executeQuery: function(domain, xmltext, repository, callback, errCallback) {
+
+      if (isNull(domain)) {
+        domain = "";
+      }
+      var url = '{0}/dyn/admin/nucleus/{1}/'.format(domain, repository);
+
+      $.ajax({
+        type: "POST",
+        url: url,
+        data: {
+          xmltext: xmltext
+        },
+        success: function(result, status, jqXHR) {
+
+          //check for errors
+          try {
+
+            let errors = BDA_REPOSITORY.getErrors(result);
+
+            var rawItemsXml;
+
+            if (_.isEmpty(errors)) {
+              rawItemsXml = $(result).find("code").html();
+              if (_.isEmpty(rawItemsXml)) {
+                errors = "Null response";
+              }
+            }
+
+            if (_.isEmpty(errors)) {
+              callback(result);
+            } else {
+              errCallback(null, 'Execution Error', errors);
+            }
+
+          } catch (e) {
+            console.error(e);
+          }
+
+
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+          if (!isNull(errCallback)) {
+            errCallback(jqXHR, textStatus, errorThrown);
+          }
+        }
+      });
+    },
+
+    getErrors: function(res) {
+
+      var $res = $(res);
+      var errorsSelector1 = "Errors:";
+      let errorMsg = null;
+      if ($res.text().indexOf(errorsSelector1) != -1) {
+        errorMsg = $res.find("code").text().trim();
+      }
+
+      return errorMsg;
+    },
+
+    executePrintItem: function(domain, itemDescriptor, id, repository, callback, errCallback) {
+      var xmlText = BDA_REPOSITORY.templates.printItem.format(itemDescriptor, id);
+      BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
+    },
+
+    executeQueryItems: function(domain, itemDescriptor, query, repository, callback, errCallback) {
+      var xmlText = BDA_REPOSITORY.templates.queryItems.format(itemDescriptor, query);
+      BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
+    },
+
+    previewRql: function(queryType, values) {
+      let xmlText;
+      switch (queryType) {
+        case 'print':
+          xmlText = BDA_REPOSITORY.templates.printItem.format(values.itemDescriptor, values.id);
+          break;
+        case 'query':
+          xmlText = BDA_REPOSITORY.templates.queryItems.format(values.itemDescriptor, values.text);
+          break;
+        default:
+          xmlText = values.text
+
+      }
+      return xmlText;
+    },
+
+    setupRepositoryCacheSection: function() {
+
+      try {
+
+        console.time("setupRepositoryCacheSection");
+
+        //global css setups to aid further customisation
+        var $cacheUsage = $(this.cacheUsageSelector);
+        var $cacheTable = $cacheUsage.next().next().find('table');
+        BDA_REPOSITORY.$cacheTable = $cacheTable;
+        $cacheTable.addClass('cache').removeAttr('border'); //remove border - will be handled by css
+
+
+        //move the header in a thead
+        var $header = $cacheTable.find('tr').first();
+        $header.detach();
+        var $thead = $('<thead></thead>').prependTo($cacheTable).append($header);
+
+        //mark the sub-headers
+        var index = 0;
+        $cacheTable.find('tr').each(function() {
+          var $tr = $(this);
+          //if header
+          if ((index - 1) % 3 == 0) { //if sub-header
+            //highlight per item
+            $tr.addClass('odd cache-subheader');
+          }
+          index++;
+        });
+        var $tBody = $cacheTable.find('tbody:first');
+
+
+        BDA_REPOSITORY.setupCacheCollapse($header, $cacheTable);
+
+
+        //collapse all button
+        var $resetLink = $cacheUsage.next();
+        var $buttons = $('<div></div>').appendTo($resetLink);
+
+        var $expandAll = $('<button></button>', {
+            id: 'cacheExpandAll',
+            class: ' cache expand',
+            value: 'expandAll',
+            html: 'Expand All'
+          })
+          .bind('click', function() {
+            $cacheTable.find('tr.cache-subheader.collapsed').each(BDA_REPOSITORY.toggleCacheLines);
+          })
+          .appendTo($buttons);
+
+        var $collapseAll = $('<button></button>', {
+            id: 'collapseAll',
+            class: 'cache collapse',
+            value: 'collapseAll',
+            html: 'Collapse All'
+          })
+          .on('click', function() {
+            $cacheTable.find('tr.cache-subheader.expanded').each(BDA_REPOSITORY.toggleCacheLines);
+          })
+          .appendTo($buttons);
+
+        $collapseAll = $('<button></button>', {
+            id: 'exportCSV',
+            class: 'cache export',
+            value: 'exportCSV',
+            html: 'Export as CSV'
+          })
+          .on('click', function() {
+            BDA_REPOSITORY.exportCacheStatsAsCSV();
+          })
+          .appendTo($buttons);
+
+        BDA_REPOSITORY.setupCacheTableHeaderFixed($header, $cacheTable);
+
+
+        //collapse all (after setup fixed header because we need full width)
+        $cacheTable.find('.cache-subheader').each(function() {
+          $(this).addClass('collapsed')
+            .next().css('display', 'none')
+            .next().css('display', 'none');
+        });
+
+        console.timeEnd("setupRepositoryCacheSection");
+      } catch (err) {
+        console.error(err);
+      }
+
+    },
+
+    setupCacheCollapse: function($header, $cacheTable) {
+
+      var fullColSize = 23;
+      if (BDA.isOldDynamo) {
+        fullColSize = 18;
+
+      }
+
+
+      $cacheTable.find('.cache-subheader').each(function() {
+        var $tr = $(this);
+
+        //expand the cell width
+        var $td = $tr.find('td').first();
+
+        $td.attr('colspan', fullColSize); //extend to full with
+        //query cache line
+        var $queryCols = $tr.next().next().children('td');
+        if ($queryCols.length == 1) {
+          $queryCols.attr('colspan', fullColSize);
+        }
+
+        //enhance the title line
+        var text = $td.find('b:contains("item-descriptor")').first().text();
+
+        var match = BDA_REPOSITORY.CACHE_STAT_TITLE_REGEXP.exec(text);
+        var newText = '';
+        var itemDesc = '',
+          cacheMode = '',
+          cacheLocality = '';
+        if (!isNull(match[1])) {
+          itemDesc = match[1];
+          newText += '<span> item-descriptor=<b>{0}</b>'.format(itemDesc);
+        }
+        if (!isNull(match[2])) {
+          cacheMode = match[2];
+          newText += '<span> cache-mode=<b>{0}</b>'.format(cacheMode);
+        }
+        if (!isNull(match[3])) {
+          cacheLocality = match[3];
+          newText += '<span> cache-locality=<b>{0}</b>'.format(cacheLocality);
+        }
+
+        //add as attr for easier handling
+        $tr.attr('data-item-desc', itemDesc)
+          .attr('data-cache-mode', cacheMode)
+          .attr('data-cache-locality', cacheLocality);
+
+        var $arrow = $('<span class="cacheArrow"><i class="up fa fa-arrow-right"></i></span>' + newText);
+        $td.html($arrow);
+
+        //collapse items
+        $tr.bind('click', BDA_REPOSITORY.toggleCacheLines);
+
+
+
+      });
+    },
+
+    setupCacheTableHeaderFixed: function($header, $cacheTable) {
+
+      traceTime('setupCacheTableHeaderFixed')
+
+      //make the header fixed with css
+      $cacheTable.addClass('fixed_headers');
+      logTrace('isOldDynamo ' + BDA.isOldDynamo)
+      if (BDA.isOldDynamo) {
+        $cacheTable.addClass('oldDynamo');
+      }
+
+      //clone the header
+
+      var $copy = $header.clone().addClass('sticky-header-copy');
+      $header.addClass('sticky-header-original');
+      $copy.insertAfter($header).hide();
+
+      var left = null;
+      var setupDone = false;
+      $(window).scroll(function() { // scroll event
+        var $window = $(window);
+        var windowTop = $window.scrollTop();
+        //get the value now because it changes on show/hide/collapse
+        var top = $cacheTable.offset().top;
+        var bot = top + $cacheTable.height();
+
+        try {
+
+          if (top < windowTop && bot > windowTop) {
+            $copy.addClass('sticky-top');
+            var windowLeft = $window.scrollLeft();
+            if (!setupDone) {
+              left = $cacheTable.offset().left;
+              BDA_REPOSITORY.setupCacheHeaderWidth($header, $copy);
+              setupDone = true;
+            }
+            $copy.css('left', -windowLeft + left);
+            $copy.show();
+          } else {
+            $copy.removeClass('sticky-top');
+            $copy.css('left', 0);
+            $copy.hide();
+          }
+
+        } catch (e) {
+          console.error(e);
+        }
+
+      });
+      traceTimeEnd('setupCacheTableHeaderFixed')
+
+    },
+
+    setupCacheHeaderWidth: function($header, $copy) {
+      traceTime('setupCacheHeaderWidth.getWidth')
+      //since we set all column with the same width we can use only the first cell as reference
+      var w = $('th:first', $header).width() + "px"; // .width() is very slow :(
+      //var w =first.width()
+      traceTimeEnd('setupCacheHeaderWidth.getWidth')
+
+      var $child;
+      traceTime('setupCacheHeaderWidth.setFixedWidth')
+      $copy.children('th').each(function(idx, child) {
+        $child = $(child);
+        $child.css({
+          'max-width': w,
+          'min-width': w,
+        })
+      });
+      traceTimeEnd('setupCacheHeaderWidth.setFixedWidth')
+
+    },
+
+    toggleCacheLines: function() {
+      var $tr = $(this);
+      $tr.toggleClass('collapsed')
+        .toggleClass('expanded');
+      $tr.next().toggle();
+      $tr.next().next().toggle();
+      rotateArrowQuarter($tr.find('.cacheArrow i'));
+    },
+
+    exportCacheStatsAsCSV: function() {
+      var data = [];
+      var line, $tr, $dataTr;
+      //header
+      data.push([
+        'Item Descriptor',
+        'Cache Mode',
+        'Cache locality',
+        'type',
+        'localEntries',
+        'externEntries',
+        'weakEntries',
+        'localCacheSize',
+        'usedRatio',
+        'totalHits',
+        'totalMisses',
+        'ratio',
+        'localHits',
+        'localMisses',
+        'externalHits',
+        'externalMisses',
+        'weakHits',
+        'weakMisses',
+        'cacheInvalidations',
+        'entryInvalidations',
+        'localCulls',
+        'localItemsCulled',
+        'localMaxCulled',
+        'weakCulls',
+        'weakItemsCulled',
+        'weakMaxCulled'
+      ]);
+
+      BDA_REPOSITORY.$cacheTable.find('tr.cache-subheader').each(function(idx, elem) {
+        $tr = $(elem);
+        line = [];
+        line.push($tr.attr('data-item-desc'));
+        line.push($tr.attr('data-cache-mode'));
+        line.push($tr.attr('data-cache-locality'));
+        line.push('item-cache');
+
+        $tr.next().children('td').each(function() {
+          line.push($(this).text());
+        });
+
+        data.push(line);
+
+        var $queryTr = $tr.next().next();
+        var $cols = $queryTr.children('td');
+        if ($cols.length > 1) {
+          //query caching available
+          line = [];
+          line.push($tr.attr('data-item-desc'));
+          line.push($tr.attr('data-cache-mode'));
+          line.push($tr.attr('data-cache-locality'));
+          line.push('query-cache');
+
+          $cols.each(function() {
+            line.push($(this).text());
+          });
+          data.push(line);
+        }
+      });
+
+      var linesText = [];
+      for (var i = 0; i < data.length; i++) {
+        linesText.push(data[i].join(';'))
+      }
+
+      var csv = linesText.join('\n');
+
+      copyToClipboard(csv);
+
     }
+  };
 
-    $.fn.getBdaRepository = function() {
-        return BDA_REPOSITORY;
-    };
+  // Reference to BDA_STORAGE
+  var BDA_STORAGE, BDA;
+
+  // Jquery plugin creation
+  $.fn.bdaRepository = function(theBDA) {
+    logTrace('Init plugin {0}'.format('bdaRepository'));
+    //settings = $.extend({}, defaults, options);
+    BDA = theBDA;
+    BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
+    BDA_REPOSITORY.build();
+    return this;
+  };
+
+  $.fn.bdaRepository.reloadQueryList = function() {
+    if (BDA_REPOSITORY.isRepositoryPage)
+      BDA_REPOSITORY.reloadQueryList();
+  };
+
+  $.fn.executePrintItem = function(domain, itemDescriptor, id, repository, callback, errCallback) {
+    BDA_REPOSITORY.executePrintItem(domain, itemDescriptor, id, repository, callback, errCallback);
+  };
+
+  $.fn.executeQueryItems = function(domain, itemDescriptor, query, repository, callback, errCallback) {
+    BDA_REPOSITORY.executeQueryItems(domain, itemDescriptor, query, repository, callback, errCallback);
+  };
+
+  $.fn.executeRql = function(domain, xmlText, repository, callback, errCallback) {
+    BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
+  };
+
+  $.fn.previewRql = function(queryType, values) {
+    return BDA_REPOSITORY.previewRql(queryType, values);
+  }
+
+  $.fn.getBdaRepository = function() {
+    return BDA_REPOSITORY;
+  };
 
 })(jQuery);

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1865,8 +1865,17 @@
 
             let errors = BDA_REPOSITORY.getErrors(result);
 
+            var rawItemsXml;
+
             if (_.isEmpty(errors)) {
-              var rawItemsXml = $(result).find("code").html();
+              rawItemsXml = $(result).find("code").html();
+              if (_.isEmpty(rawItemsXml)) {
+                errors = "Null response";
+              }
+            }
+
+            if (_.isEmpty(errors)) {
+
 
               // remove first 2 lines
               var tab = rawItemsXml.split("\n");

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1265,7 +1265,7 @@
       }).hide();
 
 
-      $outputDiv.append($('<p></p>').append(showAll).append(hideAll));
+      $outputDiv.append($('<p id="resultToolbar"></p>').append(showAll).append(hideAll));
 
 
 
@@ -2730,6 +2730,8 @@
       logTrace('createSpeedbar_new')
       try {
 
+
+
         let speedbar = $('<div class="speedbar"><div class="widget"><i class="fa fa-times close"></i><p>Quick links :</p><ul></ul></div></div>');
         speedbar.find('.close').on('click', () => {
           speedbar.fadeOut(200);
@@ -2748,9 +2750,13 @@
           list.append(elem);
         });
 
-        $('<button>Show speedbar</button></p>')
-          .on('click', () => resultElem.find('.speedbar').fadeIn(200))
-          .prependTo(resultElem);
+
+        let button = $('<button>Show Quick Links <i class="fa fa-bars" aria-hidden="true"></i></button>')
+          .on('click', () => resultElem.find('.speedbar').fadeIn(200));
+
+        resultElem.find('#resultToolbar').append(button);
+
+
 
         speedbar.prependTo(resultElem);
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1549,7 +1549,9 @@
 
         buildPropertyValueCell: function(item, property, referencePropertyValue, repository, lineIsVisible) {
             BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell');
-            //    console.time('buildPropertyValueCell ' + property.name);
+
+
+            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.extractValue');
             let propertyValue = item.values[property.name];
             logTrace('buildPropertyValueCell : propertyValue', propertyValue);
             let val;
@@ -1558,7 +1560,10 @@
             } catch (e) {
                 val = '';
             }
+            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.extractValue');
 
+
+            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.innerVal');
             let innerVal;
             let long = false;
             if (val.length <= BDA_REPOSITORY.CELL_MAX_LENGTH) {
@@ -1568,20 +1573,27 @@
                 let short = val.substr(0, BDA_REPOSITORY.CELL_MAX_LENGTH) + ' ...';
                 innerVal = BDA_REPOSITORY.templates.longPropertyCell.format(short);
             }
+             BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.innerVal');
 
+            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.formatCell');
             res = $(BDA_REPOSITORY.templates.propertyCell.format(innerVal, item.id, property.name));
             if (long) {
                 res.addClass('toggable');
-            }
+            } 
             if (propertyValue && propertyValue.isDefault) {
                 res.addClass('default');
             }
+            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.formatCell');
 
 
+             BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.findLongCell');
             // for id of other items, load sub item on click
             let longCell = res.find('.propertyValue');
             longCell.attr('data-raw', val);
+             BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.findLongCell');
 
+
+            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.appendVal');
             if (lineIsVisible && property.isItem) {
 
                 BDA_REPOSITORY.buildLinkToOtherItem(longCell, val, property);
@@ -1589,6 +1601,7 @@
             } else {
                 longCell.append(val);
             }
+            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.appendVal');
 
             // if (lineIsVisible && !_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
             //   BDA_REPOSITORY.addInlineEditFormFromObjects(res, val, property, item, repository);
@@ -1657,7 +1670,7 @@
         },
 
         buildLinkToOtherItem: function(longCell, val, property) {
-            BDA_REPOSITORY.PERF_MONITOR.start('buildLinkToOtherItem');
+            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell.buildLinkToOtherItem');
             // handle map types
             let ids = _(val)
                 .split(',')
@@ -1743,7 +1756,7 @@
                         longCell.append(' , ');
                     }
                 });
-            BDA_REPOSITORY.PERF_MONITOR.cumul('buildLinkToOtherItem');
+            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell.buildLinkToOtherItem');
         },
 
         addInlineEditFormFromObjects: function(output, val, property, item, repository) {

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1,3338 +1,3349 @@
 (function($) {
 
-  var tags = {
-    '!top': ['add-item', 'query-items', 'print-item', 'remove-item'],
-    '!attrs': {},
-    'toto': {
-
-    },
-    'add-item': {
-      attrs: {
-        'id': null,
-        'item-descriptor': null
-      },
-      children: ['set-property']
-    },
-    'print-item': {
-      attrs: {
-        'id': null,
-        'item-descriptor': null
-      },
-      children: []
-    },
-    'remove-item': {
-      attrs: {
-        'id': null,
-        'item-descriptor': null
-      },
-      children: ['set-property']
-    },
-    'query-items': {
-      attrs: {
-        'item-descriptor': null,
-        'id-only': ['true', 'false']
-      },
-      children: []
-    },
-    'set-property': {
-      attrs: {
-        name: null
-      },
-      children: []
-    }
-  };
-
-  var Repository = function(data) {
-    this.path;
-    this.xmlDefinition;
-    this.descriptors = {}
-    _.merge(this, data);
-  }
-  Repository.prototype.getItemDescriptor = function(itemDescriptorName) {
-    let desc = this.descriptors[itemDescriptorName]
-    if (_.isNil(desc) && !_.isNil(this.xmlDefinition)) {
-      desc = BDA_REPOSITORY.buildItemDescriptor(itemDescriptorName, this.xmlDefinition, this);
-      this.descriptors[itemDescriptorName] = desc;
-    }
-    return desc;
-  }
-
-  var ItemDescriptor = function(data) {
-    this.properties = {}; //PropertyDescriptor
-    this.name;
-    this.xmlDefinition;
-    _.merge(this, data);
-
-  }
-  var PropertyDescriptor = function($xmlDefinition, repository) {
-    this.xmlDefinition = $xmlDefinition;
-    if (this.xmlDefinition) {
-      this.name = this.xmlDefinition.attr('name');
-      this.type = this.xmlDefinition.attr('type');
-      this.itemType = this.xmlDefinition.attr('item-type');
-      this.otherRepositoryPath = this.xmlDefinition.attr('repository');
-      this.componentItemType = this.xmlDefinition.attr('component-item-type');
-
-      if (!!this.itemType || !!this.componentItemType) {
-        this.isItem = true;
-        this.isItemOfSameRepository = _.isNil(this.otherRepositoryPath);
-        if (this.isItemOfSameRepository) {
-          this.itemRepository = repository.path;
-        } else {
-          this.itemRepository = this.otherRepositoryPath;
-        }
-        this.isMulti = !!this.componentItemType;
-        if (!!this.componentItemType) {
-          this.itemType = this.componentItemType; //simplify by using one property
-        }
-      }
-    }
-  }
-
-  var RepositoryItem = function(data) {
-    this.itemDescriptor;
-    this.id;
-    this.repository;
-    this.values = {}; // PropertyValue
-    _.merge(this, data);
-
-    // init default values
-    if (!_.isNil(this.itemDescriptor)) {
-      _(this.itemDescriptor.properties)
-        .filter(propDesc => !_.isEmpty(propDesc.defaultValue))
-        .each(propDesc => {
-          this.values[propDesc.name] = new PropertyValue(propDesc);
-        });
-    }
-
-  }
-  RepositoryItem.prototype.hasValueFor = function(propertyName) {
-    return !_.isNil(this.values[propertyName]) && !_.isEmpty(this.values[propertyName].value)
-  }
-
-  var PropertyValue = function(descriptor, xmlValue) {
-    this.descriptor = descriptor;
-    this.xmlValue = xmlValue;
-    if (!_.isNil(xmlValue)) {
-      this.setValueFromXml(xmlValue)
-    } else if (!_.isNil(descriptor)) {
-      this.value = descriptor.defaultValue;
-      this.isDefault = true;
-    }
-    this.isDefault;
-    // get attribues from the xml result, not the descriptor
-    if (!_.isNil(this.xmlValue)) {
-      this.rdonly = this.xmlValue.attr('rdonly');
-      this.derived = this.xmlValue.attr('derived');
-      this.exportable = this.xmlValue.attr('exportable');
-    }
-  }
-  PropertyValue.prototype.setValueFromXml = function(xmlValue) {
-    this.value = xmlValue.text();
-    this.isDefault = false;
-  }
-  "use scrict";
-  var BDA_REPOSITORY = {
-
-    repositories: {},
-
-    CELL_MAX_LENGTH: 23,
-
-    PERF_MONITOR :null,
-
-    MAP_SEPARATOR: "=",
-    LIST_SEPARATOR: ",",
-    descriptorTableSelector: "table:eq(0)",
-    repositoryViewSelector: "h2:contains('Examine the Repository, Control Debugging')",
-    cacheUsageSelector: "h2:contains('Cache usage statistics')",
-    propertiesSelector: "h1:contains('Properties')",
-    eventSetsSelector: "h1:contains('Event Sets')",
-    methodsSelector: "h1:contains('Methods')",
-    resultsSelector: "h2:contains('Results:')",
-    errorsSelector1: "p:contains('Errors:')",
-    errorsSelector2: "code:contains('*** Query:')",
-    defaultItemByTab: "10",
-    nbItemReceived: 0,
-    itemTree: new Map(),
-    defaultDescriptor: {
-      "OrderRepository": "order",
-      "CsrRepository": "returnRequest",
-      "ProfileAdapterRepository": "user",
-      "ProductCatalog": "sku",
-      "InventoryRepository": "inventory",
-      "PriceLists": "price"
-    },
-    xmlDefinitionMaxSize: 150000, // 150 Ko
-    queryEditor: null,
-    descriptorList: null,
-    isRepositoryPage: false,
-    hasErrors: false,
-    hasResults: false,
-    templates: {
-      printItem: '<print-item item-descriptor="{0}" id="{1}"/>',
-      queryItems: '<query-items item-descriptor="{0}">\n{1}\n</query-items>',
-      resultHeader: '<p class="nbResults"> {0} items in {1} descriptor(s)</p>',
-      resultTable: '<table class="dataTable" data-descriptor="{0}" data-repository="{1}"></table>',
-      idCell: '<td class="property idCell" data-identifier="id_{0}_{1}" data-id="{0}" data-item="{1}" data-repository="{2}" >' +
-        '<div class="flex-wrapper">' +
-        '<div class="value-elem">{0}</div>' +
-        '<span class="actions">' +
-        '<i class="fa fa-refresh action reload-item" aria-hidden="true"></i>' +
-        '<i class="fa fa-code action copy-xml" aria-hidden="true"></i>' +
-        '<i class="fa fa-close action close-elem" aria-hidden="true"></i>' +
-        '</div>' +
-        '</span>' +
-        '</div>' +
-        '</td>',
-      descriptorCell: '<td data-id="{1}">{0}</td>',
-      propertyCell: '<td data-property="{2}" data-id="{1}" class="property show-short"><div class="flex-wrapper">' +
-        '{0}' +
-        '<span class="actions">' +
-        '<i class="fa fa-edit action start-edit" aria-hidden="true"></i>' +
-        '<i class="fa fa-compress action collapse" aria-hidden="true"></i>' +
-        '<i class="fa fa-expand action expand" aria-hidden="true"></i>' +
-        '<i class="fa fa-spinner fa-spin passive-loading-icon" aria-hidden="true"></i>' +
-        '</span>' +
-        '</div></td>',
-      shortPropertyCell: '<div class="value-elem propertyValue"></div>',
-      longPropertyCell: '<span class="value-elem long propertyValue"></span><span class="value-elem short">{0}</span>',
-      editProperty: '<update-item item-descriptor="{0}" id="{1}">\n    <set-property name="{2}"><![CDATA[{3}]]></set-property>\n</update-item>'
-
-
-    },
-    cmAutocomplete: {
-      tags: {
+    var tags = {
         '!top': ['add-item', 'query-items', 'print-item', 'remove-item'],
         '!attrs': {},
         'toto': {
 
         },
         'add-item': {
-          attrs: {
-            'id': null,
-            'item-descriptor': null
-          },
-          children: ['set-property']
+            attrs: {
+                'id': null,
+                'item-descriptor': null
+            },
+            children: ['set-property']
         },
         'print-item': {
-          attrs: {
-            'id': null,
-            'item-descriptor': null
-          },
-          children: []
+            attrs: {
+                'id': null,
+                'item-descriptor': null
+            },
+            children: []
         },
         'remove-item': {
-          attrs: {
-            'id': null,
-            'item-descriptor': null
-          },
-          children: ['set-property']
+            attrs: {
+                'id': null,
+                'item-descriptor': null
+            },
+            children: ['set-property']
         },
         'query-items': {
-          attrs: {
-            'item-descriptor': null,
-            'id-only': ['true', 'false']
-          },
-          children: []
+            attrs: {
+                'item-descriptor': null,
+                'id-only': ['true', 'false']
+            },
+            children: []
         },
         'set-property': {
-          attrs: {
-            name: null
-          },
-          children: []
+            attrs: {
+                name: null
+            },
+            children: []
         }
-      },
-    },
-    CACHE_STAT_TITLE_REGEXP: /item-descriptor=(.*) cache-mode=(.*)( cache-locality=(.*))?/,
-    edgesToIgnore: ["order", "relationships", "orderRef"],
+    };
 
-    build: function() {
-      console.time("bdaRepository");
-      BDA_REPOSITORY.isRepositoryPage = BDA_REPOSITORY.isRepositoryPageFct();
-      BDA_REPOSITORY.hasErrors = BDA_REPOSITORY.hasErrorsFct();
-      BDA_REPOSITORY.hasResults = BDA_REPOSITORY.hasResultsFct(BDA_REPOSITORY.hasErrors);
-      logTrace("isRepositoryPage : " + BDA_REPOSITORY.isRepositoryPage + " Page has results : " + BDA_REPOSITORY.hasResults + ". Page has errors : " + BDA_REPOSITORY.hasErrors);
-      // Setup repository page
-      if (BDA_REPOSITORY.isRepositoryPage)
-        BDA_REPOSITORY.setupRepositoryPage();
-      console.timeEnd("bdaRepository");
-    },
-
-    isRepositoryPageFct: function() {
-      return $("h2:contains('Run XML Operation Tags on the Repository')").length > 0;
-    },
-
-    setupRepositoryPage: function() {
-      // Move RQL editor to the top of the page
-
-      console.time('preparePage');
-
-      BDA_REPOSITORY.PERF_MONITOR = new PerformanceMonitor(true);
-      BDA_REPOSITORY.PERF_MONITOR.reset();
-
-      $(BDA_REPOSITORY.descriptorTableSelector).attr("id", "descriptorTable");
-
-      //save the native form in variable before adding more forms with the showRQLResults methods (inline forms)
-      BDA_REPOSITORY.initialForm = $("form:eq(1)");
-
-      $("<div id='RQLEditor'></div>").insertBefore("h2:first");
-      $("<div id='RQLResults'></div>").insertBefore("#RQLEditor");
-      if (BDA_REPOSITORY.hasErrors)
-        BDA_REPOSITORY.showRqlErrors();
-      if (BDA_REPOSITORY.hasResults && !BDA_REPOSITORY.hasErrors)
-        BDA_REPOSITORY.showRQLResults();
-
-      BDA_REPOSITORY.initialForm
-        .appendTo("#RQLEditor")
-        .attr("id", "RQLForm");
-      var $children = $("#RQLForm").children();
-      $("#RQLForm").empty().append($children);
-      $("textarea[name=xmltext]").attr("id", "xmltext");
-
-      var actionSelect = "<select id='RQLAction' class='js-example-basic-single' style='width:170px'>" + " <optgroup label='Empty queries'>" + "<option value='print-item'>print-item</option>" + "<option value='query-items'>query-items</option>" + "<option value='remove-item'>remove-item</option>" + "<option value='add-item'>add-item</option>" + "<option value='update-item'>update-item</option>" + "</optgroup>" + " <optgroup label='Predefined queries'>" + "<option value='all'>query-items ALL</option>" + "<option value='last_10_ordered'>query-items last 10 order by id</option>" + "<option value='last_10'>query-items last 10</option>" + "</optgroup>" + "</select>";
-
-      $("<div id='RQLToolbar'></div>").append("<div> Action : " + actionSelect + " <span id='editor'>" + "<span id='itemIdField' >ids : <input type='text' id='itemId' placeholder='Id1,Id2,Id3' /></span>" + "<span id='itemDescriptorField' > descriptor :  <select id='itemDescriptor' class='itemDescriptor' >" + BDA_REPOSITORY.getDescriptorOptions() + "</select></span>" + "<span id='idOnlyField' style='display: none;'><label for='idOnly'>&nbsp;id only : </label><input type='checkbox' id='idOnly'></input></span>" + "</span>" + BDA_REPOSITORY.getsubmitButton() + "</div>")
-        .insertBefore("#RQLEditor textarea")
-        .after("<div id='RQLText'></div>");
-
-      $("#xmltext").appendTo("#RQLText");
-      $("#RQLText").after("<div id='tabs'>" + "<ul id='navbar'>" + "<li id='propertiesTab' class='selected'>Properties</li>" + "<li id='queriesTab'>Stored Queries</li>" + "</ul>" + "<div id='storedQueries'><i>No stored query for this repository</i></div>" + "<div id='descProperties'><i>Select a descriptor to see his properties</i></i></div>" + "</div>");
-
-      $("#RQLForm input[type=submit]").remove();
-
-      var splitObj = BDA_STORAGE.getStoredSplitObj();
-      var itemByTab = BDA_REPOSITORY.defaultItemByTab;
-      var isChecked = false;
-      if (splitObj) {
-        itemByTab = splitObj.splitValue;
-        isChecked = splitObj.activeSplit;
-      }
-      var checkboxSplit = "<input type='checkbox' id='noSplit' ";
-      if (isChecked)
-        checkboxSplit += " checked ";
-      checkboxSplit += "/> don't split.";
-
-      $("#tabs").after("<div id='RQLSave'>" + "<div style='display:inline-block;width:200px'><button id='clearQuery' type='button'>Clear <i class='fa fa-ban fa-x'></i></button></div>" + "<div style='display:inline-block;width:530px'>Split tab every :  <input type='text' value='" + itemByTab + "' id='splitValue'> items. " + checkboxSplit + "</div>" + "<button type='submit' id='RQLSubmit'>Enter <i class='fa fa-play fa-x'></i></button>" + "</div>" + "<div><input placeholder='Name this query' type='text' id='queryLabel'>&nbsp;<button type='button' id='saveQuery'>Save <i class='fa fa-save fa-x'></i></button></div>");
-      console.timeEnd('preparePage');
-
-      console.time('showQueryList');
-      BDA_REPOSITORY.showQueryList();
-      console.timeEnd('showQueryList');
-
-      console.time('setupItemTreeForm');
-      BDA_REPOSITORY.setupItemTreeForm();
-      console.timeEnd('setupItemTreeForm');
-
-      console.time('setupItemDescriptorTable');
-      BDA_REPOSITORY.setupItemDescriptorTable();
-      console.timeEnd('setupItemDescriptorTable');
-
-      console.time('setupPropertiesTables');
-      BDA_REPOSITORY.setupPropertiesTables();
-      console.timeEnd('setupPropertiesTables');
-
-      var defaultDescriptor = BDA_REPOSITORY.defaultDescriptor[getComponentNameFromPath(getCurrentComponentPath())];
-      if (defaultDescriptor !== undefined)
-        BDA_REPOSITORY.showItemPropertyList(defaultDescriptor);
-
-      // Default tab position
-      $("#descProperties").css("display", "inline-block");
-      $("#storedQueries").css("display", "none");
-
-      $("#queriesTab").click(function() {
-        logTrace("show stored queries");
-        $("#descProperties").css("display", "none");
-        $("#storedQueries").css("display", "inline-block");
-        $(this).addClass("selected");
-        $("#propertiesTab").removeClass("selected");
-      });
-
-      $("#propertiesTab").click(function() {
-        logTrace("show properties");
-        $("#descProperties").css("display", "inline-block");
-        $("#storedQueries").css("display", "none");
-        $(this).addClass("selected");
-        $("#queriesTab").removeClass("selected");
-
-      });
-
-      $("#RQLAction").change(function() {
-        var action = $(this).val();
-        logTrace("Action change : " + action);
-        if (action == "print-item")
-          BDA_REPOSITORY.getPrintItemEditor();
-        else if (action == "query-items")
-          BDA_REPOSITORY.getQueryItemsEditor();
-        else if (action == "remove-item")
-          BDA_REPOSITORY.getRemoveItemEditor();
-        else if (action == "add-item")
-          BDA_REPOSITORY.getAddItemEditor();
-        else if (action == "update-item")
-          BDA_REPOSITORY.getUpdateItemEditor();
-        else
-          BDA_REPOSITORY.getQueryItemsEditor();
-      });
-
-      $("#RQLSubmit").click(function() {
-        BDA_REPOSITORY.submitRQLQuery(false);
-      });
-
-      $("#RQLGo").click(function() {
-        BDA_REPOSITORY.submitRQLQuery(true);
-      });
-
-      $("#RQLAdd").click(function() {
-        var query = BDA_REPOSITORY.getRQLQuery();
-        BDA_REPOSITORY.addToQueryEditor(query);
-      });
-
-      $("#saveQuery").click(function() {
-        if (BDA_REPOSITORY.getQueryEditorValue().trim().length > 0 && $("#queryLabel").val().trim().length > 0) {
-          BDA_STORAGE.storeRQLQuery($("#queryLabel").val().trim(), BDA_REPOSITORY.getQueryEditorValue().trim());
-          BDA_REPOSITORY.showQueryList();
+    var Repository = function(data) {
+        this.path;
+        this.xmlDefinition;
+        this.descriptors = {}
+        _.merge(this, data);
+    }
+    Repository.prototype.getItemDescriptor = function(itemDescriptorName) {
+        let desc = this.descriptors[itemDescriptorName]
+        if (_.isNil(desc) && !_.isNil(this.xmlDefinition)) {
+            desc = BDA_REPOSITORY.buildItemDescriptor(itemDescriptorName, this.xmlDefinition, this);
+            this.descriptors[itemDescriptorName] = desc;
         }
-      });
-
-      $("#clearQuery").click(function() {
-        BDA_REPOSITORY.setQueryEditorValue("");
-      });
-
-      // Hide other sections
-      var toggleObj = BDA_STORAGE.getToggleObj();
-
-      var repositoryView = "<a href='javascript:void(0)' id='showMoreRepositoryView' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreRepositoryView) + "</a>";
-      var cacheUsage = "&nbsp;<a href='javascript:void(0)' id='showMoreCacheUsage' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreCacheUsage) + "</a>";
-      var properties = "&nbsp;<a href='javascript:void(0)' id='showMoreProperties' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreProperties) + "</a>";
-      var eventSets = "&nbsp;<a href='javascript:void(0)' id='showMoreEventsSets' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreEventsSets) + "</a>";
-      var methods = "&nbsp;<a href='javascript:void(0)' id='showMoreMethods' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreMethods) + "</a>";
-
-      // Auto hide Repository View
-      $(BDA_REPOSITORY.repositoryViewSelector).append(repositoryView);
-
-      if (toggleObj.hasOwnProperty("showMoreRepositoryView") && toggleObj.showMoreRepositoryView == 0)
-        BDA_REPOSITORY.toggleRepositoryView();
-      $("#showMoreRepositoryView").click(function() {
-        BDA_REPOSITORY.toggleRepositoryView();
-      });
-
-      //setup cache section before hidding it
-      BDA_REPOSITORY.setupRepositoryCacheSection();
-
-      // Auto hide Cache usage
-      $(BDA_REPOSITORY.cacheUsageSelector).append(cacheUsage);
-      if (toggleObj.showMoreCacheUsage != 1)
-        BDA_REPOSITORY.toggleCacheUsage();
-      $("#showMoreCacheUsage").click(function() {
-        BDA_REPOSITORY.toggleCacheUsage();
-      });
-      // Auto hide Properties
-      $(BDA_REPOSITORY.propertiesSelector).append(properties);
-      if (toggleObj.showMoreProperties != 1)
-        BDA_REPOSITORY.toggleProperties();
-      $("#showMoreProperties").click(function() {
-        BDA_REPOSITORY.toggleProperties();
-      });
-      // Auto hide Events Sets
-      $(BDA_REPOSITORY.eventSetsSelector).append(eventSets);
-      if (toggleObj.showMoreEventsSets != 1)
-        BDA_REPOSITORY.toggleEventSets();
-      $("#showMoreEventsSets").click(function() {
-        BDA_REPOSITORY.toggleEventSets();
-      });
-      // Auto hide Methods
-      $(BDA_REPOSITORY.methodsSelector).append(methods);
-      if (toggleObj.showMoreMethods != 1)
-        BDA_REPOSITORY.toggleMethods();
-      $("#showMoreMethods").click(function() {
-        BDA_REPOSITORY.toggleMethods();
-      });
-
-      // console.time('setupEditableTable');
-      // BDA_REPOSITORY.setupEditableTable();
-      // console.timeEnd('setupEditableTable');
-      console.time('initCodeMirror');
-      BDA_REPOSITORY.queryEditor = BDA_REPOSITORY.initCodeMirror(true);
-      console.timeEnd('initCodeMirror');
-
-      console.time('initSelect2');
-
-      // Init select2 plugin
-      $("#RQLAction").select2({
-        width: "style",
-        containerCssClass: 'bda-repository',
-        dropdownCssClass: 'bda-repository',
-        minimumResultsForSearch: -1
-      });
-
-      $(".itemDescriptor").select2({
-        placeholder: "Select a descriptor",
-        allowClear: false,
-        width: "element",
-        containerCssClass: 'bda-repository',
-        dropdownCssClass: 'bda-repository',
-        matcher: function(params, data) {
-          // If there are no search terms, return all of the data
-          if ($.trim(params) === '') {
-            return data;
-          }
-          data = data.toUpperCase();
-          params = params.toUpperCase();
-          // `params.term` should be the term that is used for searching
-          // `data.text` is the text that is displayed for the data object
-          if (data.indexOf(params) != -1)
-            return true;
-          return false;
-        }
-      });
-
-      $("#itemDescriptor").on("select2-selecting", function(e) {
-        BDA_REPOSITORY.showItemPropertyList(e.val);
-      });
-
-      console.timeEnd('initSelect2');
-
-
-    },
-
-    initCodeMirror: function(autocomplete) {
-
-      var editor;
-      if (autocomplete) {
-
-        //inner functions for auto-complete
-        //taken from CM XML hint demo
-        //tryed to define them elsewhere but it broke the completion...
-        function completeAfter(cm, pred) {
-          var cur = cm.getCursor();
-          if (!pred || pred()) setTimeout(function() {
-            if (!cm.state.completionActive)
-              cm.showHint({
-                completeSingle: false
-              });
-          }, 100);
-          return CodeMirror.Pass;
-        }
-
-        function completeIfAfterLt(cm) {
-          return completeAfter(cm, function() {
-            var cur = cm.getCursor();
-            return cm.getRange(CodeMirror.Pos(cur.line, cur.ch - 1), cur) == "<";
-          });
-        }
-
-        function completeIfInTag(cm) {
-          return completeAfter(cm, function() {
-            var tok = cm.getTokenAt(cm.getCursor());
-            if (tok.type == "string" && (!/['"]/.test(tok.string.charAt(tok.string.length - 1)) || tok.string.length == 1)) return false;
-            var inner = CodeMirror.innerMode(cm.getMode(), tok.state).state;
-            return inner.tagName;
-          });
-        }
-
-
-        // Init code mirror
-        editor = CodeMirror.fromTextArea(document.getElementById("xmltext"), {
-          lineNumbers: false,
-          mode: 'xml',
-          extraKeys: {
-            "'<'": completeAfter,
-            "'/'": completeIfAfterLt,
-            "' '": completeIfInTag,
-            "'='": completeIfInTag,
-            "Ctrl-Space": "autocomplete"
-          },
-          hintOptions: {
-            schemaInfo: tags
-          }
-        });
-
-        // HACK
-        // on FF + greasemonkey, the hint is not updated when it's already open
-        // mostly working, yet a bit clunky
-        if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-          CodeMirror.on(editor, "cursorActivity", function(cm, object) {
-            if (cm.state.completionActive) {
-              cm.showHint({
-                completeSingle: false
-              });
-            }
-          })
-        }
-      } else {
-
-        // Init code mirror
-        editor = CodeMirror.fromTextArea(document.getElementById("xmltext"), {
-          lineNumbers: false,
-        });
-
-      }
-      return editor;
-    },
-
-    setupEditableTable: function() {
-      $('body').on('click', '.dataTable .fa-pencil-square-o', function(item) {
-        var $target = $(item.target).parent();
-        $target.html('<input type="text" value="' + $target.text().replace(/●/g, ' ') + '"/>');
-        var $input = $($target.children()[0]);
-        $input.focus().blur(function(item) {
-          var $target = $(item.target);
-          var $table = $target.parents(".dataTable");
-          var descriptor = $table.attr("data-descriptor");
-          var itemId = $target.parent().attr("data-id");
-          var propertyName = $target.parent().attr("data-property");
-          if (propertyName == "id" || propertyName == "descriptor") {
-            $input.parent().html($input.val());
-            $.notify(
-              "You can't change value of id or descriptor this way.", {
-                position: "top center",
-                className: "error"
-              }
-            );
-            return;
-          }
-          logTrace(itemId + " " + descriptor + " " + $target.val() + " " + propertyName);
-          var query = '<update-item id="' + itemId + '" item-descriptor="' + descriptor + '">\n' + '  <set-property name="' + propertyName + '"><![CDATA[' + $target.val() + ']]>' + '</set-property>\n</update-item>';
-          var initialValue = $input.attr("value");
-          if (confirm('You are about to execute this query : \n' + query)) {
-            jQuery.post(document.location.href, 'xmltext=' + query, function(res) {
-              var $res = $(res);
-              var errorsSelector1 = "Errors:";
-              if ($res.text().indexOf(errorsSelector1) != -1) {
-                var errorMsg = $res.find("code").text().trim();
-                $.notify(
-                  "Error : " + errorMsg, {
-                    position: "top left",
-                    className: "error",
-                    autoHide: true,
-                    autoHideDelay: 15000
-                  }
-                );
-                $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + initialValue); // reset inital value
-              } else {
-                $.notify(
-                  "Value succesfully changed", {
-                    position: "top center",
-                    className: "success"
-                  }
-                );
-              }
-              $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + $input.val());
-            });
-          } else
-            $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + initialValue); // reset inital value
-        });
-      });
-
-    },
-
-    addToQueryEditor: function(query) {
-      var editor = BDA_REPOSITORY.queryEditor;
-      var editorCursor = editor.getCursor();
-      if (editorCursor.ch !== 0)
-        editor.setCursor(editor.getCursor().line + 1, 0);
-
-      BDA_REPOSITORY.queryEditor.replaceSelection(query);
-    },
-
-    setupPropertiesTables: function() {
-      if ($("a[name=showProperties]").length > 0) {
-        $("a[name=showProperties]").next().attr("id", "propertiesTable");
-        $("#propertiesTable").find("tr:nth-child(odd)").addClass("odd");
-      }
-    },
-
-    setupItemDescriptorTable: function() {
-      var descriptors = BDA_REPOSITORY.getDescriptorList();
-      var componentURI = window.location.pathname;
-      var splitValue = 20;
-      var html = "<p>" + descriptors.length + " descriptors available.</p>";
-      html += "<div>";
-      for (var i = 0; i != descriptors.length; i++) {
-        if (i === 0 || i % splitValue === 0) {
-          html += "<table class='descriptorTable'>";
-          html += "<th>Descriptor</th>";
-          html += "<th>View</th>";
-          html += "<th>Debug</th>";
-        }
-        if (i % 2 === 0)
-          html += "<tr class='even'>";
-        else
-          html += "<tr class='odd'>";
-        var isDebugEnable = false;
-        if ($("a[href='" + componentURI + "?action=clriddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors']").length > 0)
-          isDebugEnable = true;
-        html += "<td class='descriptor'>" + descriptors[i] + "</td>";
-        html += "<td><a class='btn-desc' href='" + componentURI + "?action=seetmpl&itemdesc=" + descriptors[i] + "#showProperties'>Properties</a>";
-        html += "&nbsp;<a class='btn-desc' class='btn-desc' href='" + componentURI + "?action=seenamed&itemdesc=" + descriptors[i] + "#namedQuery'>Named queries</a></td>";
-
-        html += "<td>";
-        if (isDebugEnable)
-          html += "<a class='btn-desc red' href='" + componentURI + "?action=clriddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors'>Disable</a>";
-        else {
-          html += "<a class='btn-desc' href='" + componentURI + "?action=setiddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors'>Enable</a>";
-          html += "&nbsp;<a class='btn-desc' href='" + componentURI + "?action=dbgprops&itemdesc=" + descriptors[i] + "#debugProperties'>Edit</a>";
-        }
-        html += "</td>";
-        html += "</tr>";
-        if (i !== 0 && ((i + 1) % splitValue === 0 || i + 1 === descriptors.length))
-          html += "</table>";
-      }
-      html += "</div>";
-      html += "<div style='clear:both' />";
-
-      $("#descriptorTable").remove();
-      $(html).insertAfter("a[name='listItemDescriptors']");
-    },
-
-
-    showItemPropertyList: function(item) {
-      logTrace("showItemPropertyList");
-      var componentURI = window.location.pathname;
-      var url = componentURI + "?action=seetmpl&itemdesc=" + item + "#showProperties";
-      $.get(url, function(data) {
-        logTrace("Enter showItemPropertyList callback");
-        var $pTable = $(data).find("a[name='showProperties']").next();
-        $pTable.find('th:nth-child(2), td:nth-child(2),th:nth-child(4), td:nth-child(4),th:nth-child(5), td:nth-child(5),th:nth-child(6), td:nth-child(6)').remove();
-        $pTable.find("tr").each(function(index) {
-          var $tr = $(this);
-          $tr.find("td").each(function(i) {
-            var $td = $(this);
-            if (i === 0) {
-              var content = $td.html();
-              var req = /[\w\s']+\((\w+)\)$/i;
-              content = content.replace(req, "<a class='itemPropertyBtn' href='javascript:void(0)'> $1 </a>");
-              $td.html(content);
-            } else if (i === 1)
-              $td.text($td.text().replace("Class", ""));
-
-          });
-        });
-        logTrace($pTable);
-        $("#descProperties")
-          .empty()
-          .append($pTable);
-
-        $('.itemPropertyBtn').click(function(item) {
-          BDA_REPOSITORY.addToQueryEditor('<set-property name="' + $(this).text().trim() + '"><![CDATA[]]></set-property>\n');
-        });
-      });
-    },
-
-    hasResultsFct: function(hasErrors) {
-      return $(BDA_REPOSITORY.resultsSelector).length > 0;
-    },
-
-    hasErrorsFct: function() {
-      return $(BDA_REPOSITORY.errorsSelector1).length > 0 || $(BDA_REPOSITORY.errorsSelector2).length > 0;
-    },
-
-
-    getDescriptorList: function() {
-      if (BDA_REPOSITORY.descriptorList)
-        return BDA_REPOSITORY.descriptorList;
-      var descriptors = [];
-      $("#descriptorTable tr th:first-child:not([colspan])")
-        .sort(function(a, b) {
-          return $(a).text().toLowerCase() > $(b).text().toLowerCase() ? 1 : -1;
-        }).each(function() {
-
-          descriptors.push($(this).html().trim());
-        });
-      BDA_REPOSITORY.descriptorList = descriptors;
-      return descriptors;
-    },
-
-    getDescriptorOptions: function() {
-      var descriptorOptions = "";
-      var descriptors = BDA_REPOSITORY.getDescriptorList();
-      descriptorOptions = "";
-      var defaultDesc = BDA_REPOSITORY.defaultDescriptor[getComponentNameFromPath(getCurrentComponentPath())];
-      if (defaultDesc === undefined)
-        descriptorOptions = "<option></option>";
-      for (var i = 0; i != descriptors.length; i++) {
-        descriptorOptions += "<option value='" + descriptors[i] + "'";
-        if (defaultDesc === descriptors[i])
-          descriptorOptions += "selected='selected'";
-        descriptorOptions += ">" + descriptors[i] + "</option>\n";
-      }
-      return descriptorOptions;
-    },
-
-    getsubmitButton: function() {
-      return "<button type='button' id='RQLAdd'>Add</button>" + "<button type='button' id='RQLGo'>Add & Enter <i class='fa fa-play fa-x'></i></button>";
-    },
-
-    getPrintItemEditor: function() {
-      $("#itemIdField").show();
-      $("#itemDescriptorField").show();
-      $("#idOnlyField").hide();
-    },
-
-    getAddItemEditor: function() {
-      $("#itemIdField").hide();
-      $("#itemDescriptorField").show();
-      $("#idOnlyField").hide();
-    },
-
-    getRemoveItemEditor: function() {
-      BDA_REPOSITORY.getPrintItemEditor();
-    },
-
-    getRemoveItemsEditor: function() {
-      BDA_REPOSITORY.getPrintItemEditor();
-    },
-
-    getUpdateItemEditor: function() {
-      BDA_REPOSITORY.getPrintItemEditor();
-    },
-
-    getQueryItemsEditor: function() {
-      $("#itemIdField").hide();
-      $("#itemDescriptorField").show();
-      $("#idOnlyField").show();
-    },
-
-    getMultiId: function() {
-      var ids = $("#itemId").val().trim();
-      if (ids.indexOf(",") != -1)
-        return ids.split(",");
-      return [ids];
-    },
-
-    getPrintItemQuery: function() {
-      var ids = BDA_REPOSITORY.getMultiId();
-      var descriptor = $("#itemDescriptor").val();
-      var query = "";
-      for (var i = 0; i != ids.length; i++)
-        query += "<print-item id=\"" + ids[i].trim() + "\" item-descriptor=\"" + descriptor + "\" />\n";
-      return query;
-    },
-
-    getRemoveItemQuery: function() {
-      var ids = BDA_REPOSITORY.getMultiId();
-      var descriptor = $("#itemDescriptor").val();
-      var query = "";
-      for (var i = 0; i != ids.length; i++)
-        query += "<remove-item id=\"" + ids[i].trim() + "\" item-descriptor=\"" + descriptor + "\" />\n";
-      return query;
-    },
-
-    getAddItemQuery: function() {
-      var descriptor = $("#itemDescriptor").val();
-      var query = "<add-item item-descriptor=\"" + descriptor + "\" >\n";
-      query += "  <set-property name=\"\"><![CDATA\[]]></set-property>\n";
-      query += "</add-item>\n";
-      return query;
-    },
-
-    getUpdateItemQuery: function() {
-      var descriptor = $("#itemDescriptor").val();
-      var ids = BDA_REPOSITORY.getMultiId();
-      var query = "";
-      for (var i = 0; i != ids.length; i++) {
-        query += "<update-item id=\"" + ids[i] + "\" item-descriptor=\"" + descriptor + "\" >\n";
-        query += "  <set-property name=\"\"><![CDATA\[]]></set-property>\n";
-        query += "</update-item>\n";
-      }
-      return query;
-    },
-
-    getQueryItemsQuery: function() {
-      var descriptor = $("#itemDescriptor").val();
-      var idOnly = $("#idOnly").prop('checked');
-      var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n\n";
-      query += "</query-items>\n";
-      return query;
-    },
-
-    getAllItemQuery: function() {
-      var descriptor = $("#itemDescriptor").val();
-      var idOnly = $("#idOnly").prop('checked');
-      var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
-      query += "ALL\n";
-      query += "</query-items>\n";
-      return query;
-    },
-
-    getLast10ItemQueryOrdered: function() {
-      var descriptor = $("#itemDescriptor").val();
-      var idOnly = $("#idOnly").prop('checked');
-      var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
-      query += "ALL ORDER BY ID DESC RANGE 0+10\n";
-      query += "</query-items>\n";
-      return query;
-    },
-
-
-    getLast10ItemQuery: function() {
-      var descriptor = $("#itemDescriptor").val();
-      var idOnly = $("#idOnly").prop('checked');
-      var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
-      query += "ALL RANGE 0+10\n";
-      query += "</query-items>\n";
-      return query;
-    },
-
-    getRQLQuery: function() {
-      var query = "";
-      var action = $("#RQLAction").val();
-      logTrace("getRQLQuery : " + action);
-      if (action == "print-item")
-        query = BDA_REPOSITORY.getPrintItemQuery();
-      else if (action == "query-items")
-        query = BDA_REPOSITORY.getQueryItemsQuery();
-      else if (action == "remove-item")
-        query = BDA_REPOSITORY.getRemoveItemQuery();
-      else if (action == "add-item")
-        query = BDA_REPOSITORY.getAddItemQuery();
-      else if (action == "update-item")
-        query = BDA_REPOSITORY.getUpdateItemQuery();
-      else if (action == "all")
-        query = BDA_REPOSITORY.getAllItemQuery();
-      else if (action == "last_10_ordered")
-        query = BDA_REPOSITORY.getLast10ItemQueryOrdered();
-      else if (action == "last_10")
-        query = BDA_REPOSITORY.getLast10ItemQuery();
-      return query;
-    },
-    submitRQLQuery: function(addText) {
-      if (addText) {
-        var query = BDA_REPOSITORY.getRQLQuery();
-        BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
-      }
-      BDA_REPOSITORY.sanitizeQuery();
-      BDA_STORAGE.storeSplitValue();
-      // set anchor to the result div
-      location.hash = '#RQLResults';
-      $("#RQLForm").submit();
-    },
-
-    sanitizeQuery: function() {
-      var query = BDA_REPOSITORY.getQueryEditorValue();
-      BDA_REPOSITORY.setQueryEditorValue(query.replace(/repository\=\".+\"/gi, ""));
-    },
-
-    setQueryEditorValue: function(value) {
-      BDA_REPOSITORY.queryEditor.getDoc().setValue(value);
-    },
-
-    getQueryEditorValue: function() {
-      return BDA_REPOSITORY.queryEditor.getDoc().getValue();
-    },
-
-    showTextField: function(baseId) {
-      baseId = BDA_REPOSITORY.sanitizeSelector(baseId);
-      $("#" + baseId).toggle();
-      $("#text_" + baseId).toggle();
-    },
-
-    // Escape '.', ':' in a jquery selector
-    sanitizeSelector: function(id) {
-      return id.replace(/(:|\.|\[|\]|,)/g, "\\$1");
-    },
-
-    purgeXml: function(xmlContent) {
-      var xmlStr = "";
-      var lines = xmlContent.split("\n");
-      for (var i = 0; i != lines.length; i++) {
-        var line = lines[i].trim();
-        if (!(line.substr(0, 1) == "<" && endsWith(line, ">")))
-          xmlStr += line + "\n";
-      }
-      return xmlStr;
-    },
-
-
-    // Check if the given property contains id(s) with the given item descriptor
-    // Return an item descriptor name if the property is an ID,
-    // Return null if the property is not found,
-    // Return "FOUND_NOT_ID" is the property is found but is not an ID
-    isPropertyId: function(propertyName, $itemDesc) {
-      var isId = null;
-      var propertyFound = false;
-      $itemDesc.find("property[name=" + propertyName + "]").each(function() {
-        propertyFound = true;
-        var $property = $(this);
-        if ($property.attr("item-type") !== undefined && $property.attr("repository") === undefined)
-          isId = $property.attr("item-type");
-        else if ($property.attr("component-item-type") !== undefined && $property.attr("repository") === undefined)
-          isId = $property.attr("component-item-type");
-      });
-      if (propertyFound && isId === null)
-        return "FOUND_NOT_ID";
-      return isId;
-    },
-    // Check if the given property contains id(s) with the given repository definition
-    // Only ID from the current repository are take in account
-    // Return the item descriptor name if the type if an ID, null otherwise
-    isTypeId: function(propertyName, itemDesc, $xmlDef) {
-      var isId = null;
-      if ($xmlDef !== null) {
-        var $itemDesc = $xmlDef.find("item-descriptor[name='" + itemDesc + "']");
-        // First check in current item desc
-        isId = BDA_REPOSITORY.isPropertyId(propertyName, $itemDesc);
-        // In case we found the property but it's not an ID, we don't want to search in super-type
-        if (isId == "FOUND_NOT_ID")
-          return null;
-        // In case we found the property and it's an ID
-        if (isId !== null)
-          return isId;
-        // Now we check in each super-type item desc
-        var superType = $itemDesc.attr("super-type");
-        while (superType !== undefined && isId === null) {
-          var $parentDesc = $xmlDef.find("item-descriptor[name='" + superType + "']");
-          isId = BDA_REPOSITORY.isPropertyId(propertyName, $parentDesc);
-          superType = $parentDesc.attr("super-type");
-        }
-        if (isId == "FOUND_NOT_ID")
-          return null;
-      }
-      return isId;
-    },
-
-    // Parse the given repository ID into a tab, each index will contains an ID or a separator : "," or "="
-    parseRepositoryId: function(id) {
-      var idAsTab = [];
-      var tab = [];
-      // Case of simple ID
-      if (id.indexOf(BDA_REPOSITORY.MAP_SEPARATOR) == -1 && id.indexOf(BDA_REPOSITORY.LIST_SEPARATOR) === -1)
-        idAsTab.push(id);
-      // Case of a list of ID
-      else if (id.indexOf(BDA_REPOSITORY.MAP_SEPARATOR) == -1 && id.indexOf(BDA_REPOSITORY.LIST_SEPARATOR) !== -1) {
-        tab = id.split(BDA_REPOSITORY.LIST_SEPARATOR);
-        for (var i = 0; i != tab.length; i++) {
-          if (i !== 0)
-            idAsTab.push(BDA_REPOSITORY.LIST_SEPARATOR);
-          idAsTab.push(tab[i]);
-        }
-      }
-      // Case of a Map of ID
-      else {
-        var mapEntries = id.split(BDA_REPOSITORY.LIST_SEPARATOR);
-        for (var a = 0; a != mapEntries.length; a++) {
-          if (a !== 0)
-            idAsTab.push(BDA_REPOSITORY.LIST_SEPARATOR);
-          var mapValues = mapEntries[a].split(BDA_REPOSITORY.MAP_SEPARATOR);
-          for (var b = 0; b != mapValues.length; b++) {
-            if (b !== 0)
-              idAsTab.push(BDA_REPOSITORY.MAP_SEPARATOR);
-            idAsTab.push(mapValues[b]);
-          }
-        }
-      }
-      return idAsTab;
-    },
-
-    renderProperty: function(curProp, propValue, itemId, isItemTree) {
-      var html = "";
-      var td = "<td data-property='" + curProp.name + "' data-id='" + itemId + "'>";
-      if (propValue !== null && propValue !== undefined) {
-        propValue = propValue.replace(/ /g, '●');
-        // Remove "_"
-        if (curProp.name == "descriptor")
-          propValue = propValue.substr(1);
-        // propertyName_id
-        var base_id = curProp.name + "_" + itemId;
-
-        if (curProp.name == "id")
-          html += "<td id='" + base_id + "'>" + propValue + "</td>";
-        // Hide long value
-        else if (propValue.length > 25) {
-          var link_id = "link_" + base_id;
-          var field_id = "text_" + base_id;
-          propValue = "<a class='copyLink' href='javascript:void(0)' title='Show all' id='" + link_id + "' >" + "<span id='" + base_id + "'>" + BDA_REPOSITORY.escapeHTML(propValue.substr(0, 25)) + "..." + "</span></a><textarea class='copyField' id='" + field_id + "' readonly>" + propValue + "</textarea>";
-          html += td + propValue + "</td>";
-        }
-        // Make IDs clickable
-        else if (curProp.isId === true) {
-          propValue = BDA_REPOSITORY.parseRepositoryId(propValue);
-          html += td;
-          for (var b = 0; b != propValue.length; b++) {
-            if (propValue[b] != BDA_REPOSITORY.MAP_SEPARATOR && propValue[b] != BDA_REPOSITORY.LIST_SEPARATOR) {
-              if (isItemTree) // for item tree we create an anchor link
-                html += "<a class='clickable_property' href='#id_" + propValue[b] + "'>" + propValue[b] + "</a>";
-              else
-                html += "<a class='clickable_property loadable_property' data-id='" + propValue[b] + "' data-descriptor='" + curProp.itemDesc + "'>" + propValue[b] + "</a>";
-            } else
-              html += propValue[b];
-          }
-          html += "</td>";
-        }
-        // descriptor, Read only and derived porperty are not editable
-        else if (curProp.name == "descriptor" || curProp.rdonly == "true" || curProp.derived == "true")
-          html += "<td>" + propValue + "</td>";
-        else
-          html += td + '<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + propValue + "</td>";
-      } else
-        html += td + '<i class="fa fa-pencil-square-o" aria-hidden="true"></i></td>';
-
-      return html;
-    },
-
-    renderTab: function(itemDesc, types, datas, tabId, isItemTree) {
-      var html = "";
-      html += "<table class='dataTable' data-descriptor='" + itemDesc.substr(1) + "' ";
-      if (isItemTree)
-        html += "id='" + tabId + "'";
-      html += ">";
-      for (var i = 0; i != types.length; i++) {
-        var curProp = types[i];
-        if (i % 2 === 0)
-          html += "<tr class='even";
-        else
-          html += "<tr class='odd";
-
-        if (curProp.name == "id")
-          html += " id";
-        else if (curProp.name == "descriptor")
-          html += " descriptor";
-
-        html += "'>";
-        html += "<th>" + curProp.name + "<span class='prop_name'>";
-        if (curProp.rdonly == "true")
-          html += "<div class='prop_attr prop_attr_red'>R</div>";
-        if (curProp.derived == "true")
-          html += "<div class='prop_attr prop_attr_green'>D</div>";
-        if (curProp.exportable == "true")
-          html += "<div class='prop_attr prop_attr_blue'>E</div>";
-        html += "</span></th>";
-
-        for (var a = 0; a < datas.length; a++) {
-          var propValue = datas[a][curProp.name];
-          html += BDA_REPOSITORY.renderProperty(curProp, propValue, datas[a].id, isItemTree);
-        }
-        html += "</tr>";
-      }
-      html += "</table>";
-      return html;
-    },
-
-    getDescriptorAndDefaultValues: function(itemDescriptor, $xmlDef, descriptorAndDefaultValues) {
-      descriptorAndDefaultValues[itemDescriptor] = {};
-      var itemDefinition = $xmlDef.find("item-descriptor[name=" + itemDescriptor + "]");
-      var defaultProperties = $xmlDef.find("item-descriptor[name=" + itemDescriptor + "] property[default]");
-      if (itemDefinition !== undefined && itemDefinition.length > 0) {
-        var superType = itemDefinition[0].getAttribute("super-type");
-        defaultProperties = defaultProperties.toArray().concat($xmlDef.find("item-descriptor[name=" + superType + "] property[default]").toArray());
-      }
-      for (var defaultPropertiesIndex = 0; defaultPropertiesIndex < defaultProperties.length; defaultPropertiesIndex++) {
-        var defaultProperty = defaultProperties[defaultPropertiesIndex];
-        var defaultPropertyName = defaultProperty.getAttribute("name");
-        var defaultPropertyValue = defaultProperty.getAttribute("default");
-        descriptorAndDefaultValues[itemDescriptor][defaultPropertyName] = defaultPropertyValue;
-      }
-    },
-
-    //same as getDescriptorAndDefaultValues but using Objects
-    buildItemDescriptor: function(itemDescriptorName, $xmlDef, repository) {
-      BDA_REPOSITORY.PERF_MONITOR.start('buildItemDescriptor');
-    //  console.time(itemDescriptorName);
-      var $itemDefinition = $xmlDef.find('item-descriptor[name={0}]'.format(itemDescriptorName));
-
-      // first get properties from the parent, if it exists
-      var superType = $itemDefinition.attr("super-type");
-      let parent = null;
-      if (!_.isNil(superType)) {
-        parent = repository.getItemDescriptor(superType); //this will build parents by recursion if necessary
-      }
-      let propertyDescriptors = {};
-      if (!_.isNil(parent)) {
-        propertyDescriptors = parent.properties;
-      }
-
-      // then add current properties
-      var $properties = $itemDefinition.find('property');
-
-      var selfPropertyDescriptors = {};
-      $properties.each(function() {
-        let $prop = $(this);
-        let name = $prop.attr('name');
-        let propDesc = new PropertyDescriptor($prop, repository);
-        let defaultValue = $prop.attr('default');
-        if (!_.isNil(defaultValue)) {
-          propDesc.defaultValue = defaultValue;
-        }
-        selfPropertyDescriptors[name] = propDesc;
-      });
-
-      propertyDescriptors = _.merge(propertyDescriptors, selfPropertyDescriptors);
-      propertyDescriptors = _.sortKeysBy(propertyDescriptors);
-
-      let desc = new ItemDescriptor({
-        name: itemDescriptorName,
-        xmlDefinition: $itemDefinition,
-        properties: propertyDescriptors
-      });
-    //  console.timeEnd(itemDescriptorName);
-      BDA_REPOSITORY.PERF_MONITOR.cumul('buildItemDescriptor');
-      return desc;
-    },
-
-    getRepositoryAsync: function(path, callback) {
-      logTrace('getRepositoryAsync', path);
-      let repository = BDA_REPOSITORY.repositories[path];
-      if (_.isNil(repository)) {
-        processRepositoryXmlDef("definitionFiles",
-          ($xmlDef) => {
-
-            repository = BDA_REPOSITORY.getRepository($xmlDef, path);
-            callback(repository);
-          }, path)
-
-      } else {
-        callback(repository)
-      }
-    },
-
-    getRepository: function($xmlDef, repositoryPath) {
-      logTrace('getRepository', repositoryPath);
-      let repository = BDA_REPOSITORY.repositories[repositoryPath];
-      if (_.isNil(repository)) {
-        repository = new Repository({
-          path: repositoryPath,
-          xmlDefinition: $xmlDef
-        })
-        BDA_REPOSITORY.repositories[repositoryPath] = repository;
-      }
-      return repository;
-    },
-
-
-    showXMLAsTab: function(rawXml, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
-      let xmlContent = sanitizeXml(rawXml);
-
-      console.time('showXMLAsTab_new');
-      if (_.isEmpty(repositoryPath)) {
-        repositoryPath = getCurrentComponentPath();
-      }
-      let repository = BDA_REPOSITORY.getRepository($xmlDef, repositoryPath);
-      let parsedResult = BDA_REPOSITORY.parseXmlResult(xmlContent, repository, rawXml);
-
-      let items = parsedResult.items;
-      let logs = parsedResult.logs;
-
-      BDA_REPOSITORY.renderResultSection(items, repository, $outputDiv, isItemTree);
-
-      //  if (isItemTree) {
-      BDA_REPOSITORY.createSpeedbar_new($outputDiv);
-      //}
-
-      BDA_REPOSITORY.PERF_MONITOR.log();
-      console.timeEnd('showXMLAsTab_new');
-      return logs;
-    },
-
-    renderResultSection: function(items, repository, $outputDiv, isItemTree) {
-       console.time('renderResultSection');
-      // now render the result section
-      $outputDiv.append("<div class='prop_attr prop_attr_red'>R</div> : read-only " +
-        "<div class='prop_attr prop_attr_green'>D</div> : derived " +
-        "<div class='prop_attr prop_attr_blue'>E</div> : export is false," +
-        '&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i> : Link to other Repository,' +
-        '&nbsp;<span class="default">grey</span> : default value');
-
-      // show all button
-      let showAll = $('<button>Show All <i class="fa fa-expand" aria-hidden="true"></i></button>');
-      let hideAll = $('<button>Collapse All <i class="fa fa-compress" aria-hidden="true"></i></button>');
-
-      showAll.on('click', function() {
-        $('.property')
-          .removeClass('show-short')
-          .addClass('show-long');
-        $(this).hide();
-        hideAll.show();
-      })
-
-      hideAll.on('click', function() {
-        $('.property')
-          .addClass('show-short')
-          .removeClass('show-long');
-        $(this).hide();
-        showAll.show();
-      }).hide();
-
-
-      $outputDiv.append($('<p></p>').append(showAll).append(hideAll));
-
-      if (isItemTree) {
-        $('<button>Show speedbar</button></p>')
-          .on('click', () => $('#speedbar').fadeIn(200))
-          .appendTo($outputDiv);
-      }
-
-
-      BDA_REPOSITORY.formatTabResult(repository, items, $outputDiv);
-       console.timeEnd('renderResultSection');
-
-    },
-
-    parseXhrResult: function(xhrResult, repositoryPath, callback) {
-
-      BDA_REPOSITORY.getRepositoryAsync(repositoryPath, (repository) => {
-        try {
-          logTrace('parseXhrResult', repositoryPath, xhrResult);
-          var rawXml = $('<div>' + xhrResult + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
-          let xmlContent = sanitizeXml(rawXml);
-          let result = BDA_REPOSITORY.parseXmlResult(xmlContent, repository, rawXml);
-          result.repository = repository;
-          logTrace('parseXhrResult result:', result);
-          callback(result);
-        } catch (e) {
-          console.error(e);
-        }
-      })
-
-    },
-
-    parseXmlResult: function(xmlContent, repository, rawXml) {
-      console.time('parseXmlResult');
-      try {
-
-        var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
-        var $xml = $(xmlDoc);
-        var rawXmlDoc = $($.parseXML("<xml>" + rawXml + "</xml>"));
-        var $addItems = $xml.find("add-item");
-        let items = BDA_REPOSITORY.parseXmlAsObjects($addItems, repository, rawXmlDoc);
-        let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
-        console.timeEnd('parseXmlResult');
-        return {
-          items: items,
-          logs: logs
-        }
-      } catch (e) {
-        console.error(e);
-        console.timeEnd('parseXmlResult');
-      }
-
-    },
-    getExecutionLogs: function(xmlContent) {
-      var log = $("<xml>" + xmlContent + "</xml>")
-        .children()
-        .remove()
-        .end()
-        .text()
-        .trim();
-      return log;
-    },
-
-    getChunkSize: function() {
-      let chunkSize = 1;
-      var splitObj = BDA_STORAGE.getStoredSplitObj();
-      // activeSplit == don't split - don't ask me why this name...
-      if (_.isNil(splitObj) || !!splitObj.activeSplit) {
-        chunkSize = Number.MAX_SAFE_INTEGER;
-      } else {
-        chunkSize = parseInt(splitObj.splitValue);
-      }
-      if (chunkSize < 1) {
-        chunkSize = 1; // safety
-      }
-      return chunkSize;
-    },
-
-    formatTabResult: function(repository, repositoryItems, result) {
-      console.time('formatTabResult');
-      try {
-        let itemsByType = _.groupBy(repositoryItems, repoItem => !_.isNil(repoItem.itemDescriptor) ? repoItem.itemDescriptor.name : null);
-        let nbItemDescriptors = _.keys(itemsByType).length;
-        let res = $(BDA_REPOSITORY.templates.resultHeader.format(repositoryItems.length, nbItemDescriptors))
-
-        var chunkSize = BDA_REPOSITORY.getChunkSize();
-
-        // for each property, only display it if it'si not empty in one result
-        let renderContext = {}
-        _(itemsByType)
-          .each((items, itemDescName) => {
-            let desc = repository.getItemDescriptor(itemDescName);
-            renderContext[itemDescName] = {};
-            _.each(desc.properties, property => {
-              try {
-                renderContext[itemDescName][property.name] = _.some(items, item => item.hasValueFor(property.name));
-
-              } catch (e) {
-                console.err('error finding render context for: itemDescName,items, property', itemDescName, items, property);
-              }
-            })
-          });
-
-
-        // for each group of item by descriptor, split in chunks of same descriptor and max size 'chunkSize'
-        let chunks = _(itemsByType)
-          .map(group => _.chunk(group, chunkSize)) //split each group
-          .flatMap() //flatten the array of arrays
-          .value();
-
-
-        //now render each tab
-        let firstResult = _.chain(chunks)
-          .map(chunk => BDA_REPOSITORY.buildResultTable(chunk, renderContext, repository))
-          .filter(table => !_.isNil(table))
-          .map(table => {
-            table.appendTo(result)
-            return table;
-          })
-          .head().value();
-
-        return firstResult;
-
-      } catch (e) {
-        console.error(e);
-      }
-console.timeEnd('formatTabResult');
-    },
-
-    parseXmlAsObjects: function($addItems, repository, rawXmlDoc) {
-      BDA_REPOSITORY.PERF_MONITOR.start('parseXmlAsObjects');
-      let res =  $addItems.map(function() {
-        var currentItem = $(this);
-        var descriptorName = currentItem.attr("item-descriptor");
-        var id = currentItem.attr("id");
-        let itemDescriptor = repository.getItemDescriptor(descriptorName);
-        let rawXml;
-        if (!_.isNil(rawXmlDoc)) {
-          rawXml = rawXmlDoc.find('add-item[item-descriptor="{0}"][id="{1}"]'.format(descriptorName, id));
-        }
-        let repositoryItem = new RepositoryItem({
-          itemDescriptor: itemDescriptor,
-          id: id,
-          xmlDefinition: currentItem,
-          rawXml: rawXml.outerHTML()
-        })
-
-        currentItem.find('set-property').each(function() {
-          let currentProperty = $(this);
-          let propertyName = currentProperty.attr('name');
-          let propertyDescriptor;
-          if (!_.isNil(itemDescriptor)) {
-            propertyDescriptor = itemDescriptor.properties[propertyName];
-          }
-          let val = repositoryItem.values[propertyName];
-          if (_.isNil(val)) {
-            val = new PropertyValue(propertyDescriptor, currentProperty);
-            repositoryItem.values[propertyName] = val;
-          } else {
-            val.setValueFromXml(currentProperty);
-          }
-        })
-        logTrace('repoItem', repositoryItem);
-        return repositoryItem;
-      });
-      BDA_REPOSITORY.PERF_MONITOR.cumul('parseXmlAsObjects');
-      return res;
-    },
-
-    showNonEmptyLines: function(resultTable) {
-      resultTable.find('.item-line.hidden').each(function() {
-        let line = $(this);
-        let mustShow = _.some(line.find('.propertyValue').get(),
-          (elem) => !_.isEmpty($(elem).attr('data-raw'))
-        );
-        if (mustShow) {
-          line.removeClass('hidden');
-        }
-      })
-    },
-
-    buildResultTable: function(items, renderContext, repo) {
-      console.time('buildResultTable')
-      let res;
-      if (!_.isNil(items) && items.length > 0) {
-        let itemDescriptor = items[0].itemDescriptor;
-        let itemDescriptorName = itemDescriptor ? itemDescriptor.name : '';
-        let table = $(BDA_REPOSITORY.templates.resultTable.format(itemDescriptorName,repo.path));
-        let tableHead = $('<thead></thead>').appendTo(table);
-
-        let idLine = $('<tr class="id even"><th>{0}</th></tr>'.format(itemDescriptorName)).appendTo(tableHead);
-        _(items)
-          .map(item => $(BDA_REPOSITORY.templates.idCell.format(item.id, itemDescriptorName, repo.path)).data('repositoryItem', item))
-          .each((elem) => {
-            elem.appendTo(idLine)
-          });
-       
-
-        // let descLineElems = _(items).map((item) => BDA_REPOSITORY.templates.descriptorCell.format(itemDescriptorName, item.id)).join('');
-        // let descLine = $('<tr class="descriptor odd"><th>descriptor</th>{0}</tr>'.format(descLineElems)).appendTo(tableHead);
-
-        let tbody = $('<tbody></tbody>').appendTo(table);
-        //for each property, get 
-        let index = 1;
-        console.time('build all items');
-        _(itemDescriptor.properties)
-          .each((property) => {
-
-            // hiden lines that have all null values
-            let lineIsVisible = !!renderContext[itemDescriptor.name][property.name]
-
-            let line = $('<tr class="item-line {0} {1}" data-property="{2}"></tr>'.format(getEvenOddClass(index), lineIsVisible ? '' : 'hidden', property.name));
-
-            //build property name cell
-            // the following flags have been set on the repoItem level :
-            
-            let propertyNameCell = $('<th>{0}<span class="prop_name"></span></th>'.format(property.name)).appendTo(line);
-
-            let sampleItem = null
-
-            if(lineIsVisible){
-              sampleItem = _.find(items, item => !_.isNil(item.values[property.name]));
-              index++;
-            }
-
-
-            if (lineIsVisible && !_.isNil(sampleItem)) {
-              let sampleValue = sampleItem.values[property.name];
-              if (!!sampleValue.derived) {
-                propertyNameCell.append('<div class="prop_attr prop_attr_green">D</div>');
-                line.addClass('derived');
-              }
-              if (!!sampleValue.rdonly) {
-                propertyNameCell.append('<div class="prop_attr prop_attr_red">R</div>');
-                line.addClass('rdonly');
-              }
-              if (!!sampleValue.exportable) {
-                propertyNameCell.append('<div class="prop_attr prop_attr_blue">E</div>');
-                line.addClass('exportable');
-              }
-              if (property.isItem && !property.isItemOfSameRepository) {
-                propertyNameCell.append('&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i>');
-                line.addClass('other-repository');
-              }
-            }
-
-            // add all cells
-             //   console.time('build all cells');
-            let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem, repo,lineIsVisible));
-           // console.timeEnd('build all cells');
-            //console.time('append all cells');
-
-            _.each(cells, cell => cell.appendTo(line));
-            
-         //   console.timeEnd('append all cells');
-            line.appendTo(tbody);
-
-          });
-
-        //enable local collapse/expand
-        console.time('bind actions');
-        table
-        .on('click', '.actions .collapse', function() {
-          $(this).closest('.property').addClass('show-short').removeClass('show-long');
-        })
-        .on('click', '.actions .expand', function() {
-          $(this).closest('.property').removeClass('show-short').addClass('show-long');
-        })
-        .on('click', '.actions .start-edit', function() {
-          logInfo('click on start edit');
-          let $this = $(this);
-
-          let propertyElem = $this.closest('.property');
-         
-
-          if(_.isNil(propertyElem.attr('data-form-generated')) ){
-
-            try{
-
-              let dataTable = propertyElem.closest('.dataTable');
-              let line = propertyElem.closest('.item-line')
-
-              let itemName = dataTable.attr('data-descriptor');
-              let repositoryPath = dataTable.attr('data-repository');
-
-              let itemId = propertyElem.attr('data-id');
-              let propertyName = propertyElem.attr('data-property');
-
-
-              let val = propertyElem.find('.propertyValue').attr('data-raw');
-
-
-              BDA_REPOSITORY.addInlineEditForm(propertyElem, val, propertyName, itemName,itemId, repositoryPath);
-              propertyElem.attr('data-form-generated',true);
-
-            }catch(e){
-              console.error(e);
-            }
-
-
-          }
-
-          propertyElem.addClass('show-edit').find('.inline-input').focus();
-
-        })
-          .on('click','.id .reload-item', function() {
-            console.log('reloadItem')
-          let $this = $(this);
-          let property = $this.closest('.property');
-          let id = property.attr('data-id');
-          let item = property.attr('data-item');
-          let repoPath = property.attr('data-repository');
-          let parentTab = $this.closest('.dataTable');
-          $this.addClass('fa-spin');
-          BDA_REPOSITORY.reloadTab(id, item, repoPath, parentTab, () => {
-            $this.removeClass('fa-spin');
-            $.notify(
-              "Success: Reloaded {0} {1}".format(item, id), {
-                className: "success",
-                position: "top center",
-                autoHideDelay: 3000
-              }
-            );
-
-          });
-        })
-         .on('click','.id .copy-xml', function() {
-          copyToClipboard($(this).closest('.property').data('repositoryItem').rawXml);
-        })
-         .on('click', '.id .close-elem',function() {
-          logTrace('close-elem', $(this));
-          BDA_REPOSITORY.closeTab($(this).closest('.property'));
-        })
-        console.timeEnd('bind actions');
-
-        console.timeEnd('build all items');
-        res = table;
-      }
-       console.timeEnd('buildResultTable')
-      return res;
-    },
-
-    buildPropertyValueCell: function(item, property, referencePropertyValue, repository, lineIsVisible) {
-       BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell');
-  //    console.time('buildPropertyValueCell ' + property.name);
-      let propertyValue = item.values[property.name];
-      logTrace('buildPropertyValueCell : propertyValue', propertyValue);
-      let val;
-      try {
-        val = propertyValue.value;
-      } catch (e) {
-        val = '';
-      }
-
-      let innerVal;
-      let long = false;
-      if (val.length <= BDA_REPOSITORY.CELL_MAX_LENGTH) {
-        innerVal = BDA_REPOSITORY.templates.shortPropertyCell;
-      } else {
-        long = true;
-        let short = val.substr(0, BDA_REPOSITORY.CELL_MAX_LENGTH) + ' ...';
-        innerVal = BDA_REPOSITORY.templates.longPropertyCell.format(short);
-      }
-
-      res = $(BDA_REPOSITORY.templates.propertyCell.format(innerVal, item.id, property.name));
-      if (long) {
-        res.addClass('toggable');
-      }
-      if (propertyValue && propertyValue.isDefault) {
-        res.addClass('default');
-      }
-
-
-      // for id of other items, load sub item on click
-      let longCell = res.find('.propertyValue');
-      longCell.attr('data-raw', val);
-
-      if (lineIsVisible && property.isItem) {
-
-        BDA_REPOSITORY.buildLinkToOtherItem(longCell, val, property);
-
-      } else {
-        longCell.append(val);
-      }
-
-      // if (lineIsVisible && !_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
-      //   BDA_REPOSITORY.addInlineEditFormFromObjects(res, val, property, item, repository);
-      // }
-       BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell');
-      // console.timeEnd('buildPropertyValueCell ' + property.name);
-      return res;
-    },
-
-    buildLinkToOtherItem: function(longCell, val, property) {
-      BDA_REPOSITORY.PERF_MONITOR.start('buildLinkToOtherItem');
-      // handle map types
-      let ids = _(val)
-        .split(',')
-        .map(sPair => _.split(sPair, '='))
-        .map(pairArray => {
-          if (pairArray.length >= 2) {
-            return {
-              id: pairArray[1].trim(),
-              key: pairArray[0].trim()
-            }
-          } else if (pairArray.length == 1) {
-            return {
-              id: pairArray[0].trim()
-            }
-          } else {
-            return null;
-          }
-
-        })
-        .filter(elem => !_.isNil(elem))
-        .value();
-
-      _(ids)
-        .map(elem => {
-          let cell = $('<span class="clickable_property loadable_property {1}">{0}</span>'.format(elem.id, property.isItemOfSameRepository ? '' : 'newpage'))
-            .on('click', function() {
-
-            if (property.isItemOfSameRepository) {
-              let $this = $(this);
-              try {
-                //find the item if same id
-                // load the result in the parent section (repo/itemtree/dashscreen)
-                let outputDiv = $this.closest('.rqlResultContainer');
-                let selector = '.idCell[data-id="{0}"]'.format(elem.id);
-                let resultTable = outputDiv.find(selector);
-                // if the result already exists, just scroll to it
-                if (resultTable.length > 0) {
-                  resultTable.scrollTo();
-                  resultTable.find('[data-id="{0}"]'.format(elem.id)).flash(); //flash the whole tab
+        return desc;
+    }
+
+    var ItemDescriptor = function(data) {
+        this.properties = {}; //PropertyDescriptor
+        this.name;
+        this.xmlDefinition;
+        _.merge(this, data);
+
+    }
+    var PropertyDescriptor = function($xmlDefinition, repository) {
+        this.xmlDefinition = $xmlDefinition;
+        if (this.xmlDefinition) {
+            this.name = this.xmlDefinition.attr('name');
+            this.type = this.xmlDefinition.attr('type');
+            this.itemType = this.xmlDefinition.attr('item-type');
+            this.otherRepositoryPath = this.xmlDefinition.attr('repository');
+            this.componentItemType = this.xmlDefinition.attr('component-item-type');
+
+            if (!!this.itemType || !!this.componentItemType) {
+                this.isItem = true;
+                this.isItemOfSameRepository = _.isNil(this.otherRepositoryPath);
+                if (this.isItemOfSameRepository) {
+                    this.itemRepository = repository.path;
                 } else {
-                  let $property = $this.parent().parent();
-                  $property.addClass('loading');
-                  let endLoadingFc = () => {
-                    $property.removeClass('loading');
-                  };
-                  BDA_REPOSITORY.loadSubItem(elem.id, property.itemType, property.itemRepository, outputDiv, null, null, endLoadingFc);
+                    this.itemRepository = this.otherRepositoryPath;
                 }
-              } catch (e) {
-                console.error(e)
-              }
-
-            } else {
-              //create a form that will post to a new tab
-              try {
-
-                var xmlText = BDA_REPOSITORY.templates.printItem.format(property.itemType, elem.id);
-                let form = $('<form  action="/dyn/admin/nucleus{0}/" method="POST" target="_blank"><textarea name="xmltext" ></textarea><input value="Enter" type="submit"></form>'.format(property.itemRepository));
-                form
-                  .appendTo('body')
-                  .find('textarea')
-                  .val(xmlText)
-                  .end()
-                  .submit()
-                  .remove();
-
-              } catch (e) {
-                console.error(e);
-              }
+                this.isMulti = !!this.componentItemType;
+                if (!!this.componentItemType) {
+                    this.itemType = this.componentItemType; //simplify by using one property
+                }
             }
-          });
-          return {
-            key: elem.key,
-            cell: cell
-          }
+        }
+    }
 
-        })
-        .each((elem, idx) => {
-          if (!_.isNil(elem.key)) {
-            longCell.append('{0} = '.format(elem.key));
-          }
-          longCell.append(elem.cell)
-          if (idx < ids.length - 1) {
-            longCell.append(' , ');
-          }
-        });
-        BDA_REPOSITORY.PERF_MONITOR.cumul('buildLinkToOtherItem');
-    },
+    var RepositoryItem = function(data) {
+        this.itemDescriptor;
+        this.id;
+        this.repository;
+        this.values = {}; // PropertyValue
+        _.merge(this, data);
 
-    addInlineEditFormFromObjects: function(output, val, property, item, repository) {
-      BDA_REPOSITORY.addInlineEditForm(output,val,property.name,item.id,repository.path);
-    },
+        // init default values
+        if (!_.isNil(this.itemDescriptor)) {
+            _(this.itemDescriptor.properties)
+                .filter(propDesc => !_.isEmpty(propDesc.defaultValue))
+                .each(propDesc => {
+                    this.values[propDesc.name] = new PropertyValue(propDesc);
+                });
+        }
 
-    addInlineEditForm: function(output, val, propertyName, itemName,itemId, repositoryPath) {
-      BDA_REPOSITORY.PERF_MONITOR.start('addInlineEditForm');
-      logInfo('addInlineEditForm',arguments);
-      try {
+    }
+    RepositoryItem.prototype.hasValueFor = function(propertyName) {
+        return !_.isNil(this.values[propertyName]) && !_.isEmpty(this.values[propertyName].value)
+    }
 
-        let form = $('<form class="edit"></form>');
-        let input = $('<textarea class="inline-input" rows="1"></input>').val(val);
-        input.appendTo(form);
-        input.on('blur', function() {
+    var PropertyValue = function(descriptor, xmlValue) {
+        this.descriptor = descriptor;
+        this.xmlValue = xmlValue;
+        if (!_.isNil(xmlValue)) {
+            this.setValueFromXml(xmlValue)
+        } else if (!_.isNil(descriptor)) {
+            this.value = descriptor.defaultValue;
+            this.isDefault = true;
+        }
+        this.isDefault;
+        // get attribues from the xml result, not the descriptor
+        if (!_.isNil(this.xmlValue)) {
+            this.rdonly = this.xmlValue.attr('rdonly');
+            this.derived = this.xmlValue.attr('derived');
+            this.exportable = this.xmlValue.attr('exportable');
+        }
+    }
+    PropertyValue.prototype.setValueFromXml = function(xmlValue) {
+        this.value = xmlValue.text();
+        this.isDefault = false;
+    }
+    "use scrict";
+    var BDA_REPOSITORY = {
 
-          try {
+        repositories: {},
 
-            let newVal = input.val();
-            if (newVal === val) {
-              input.closest('.property').removeClass('show-edit');
-              return; // exit if no change
-            }
-            var xmlText = BDA_REPOSITORY.templates.editProperty.format(itemName, itemId, propertyName, newVal);
-            let highlighted = $('<div class="xml"><pre><code></code></pre></div>');
-            highlighted.find('code').text(xmlText);
-            highlighted.each(function(i, block) {
-              hljs.highlightBlock(block);
-            })
+        CELL_MAX_LENGTH: 23,
 
-            $('body').bdaAlert({
-              msg: 'You are about to execute this query : \n {0}'.format(highlighted.html()),
-              options: [{
-                label: 'Confirm',
-                _callback: function() {
-                  BDA_REPOSITORY.executeQuery('', xmlText, repositoryPath,
-                    (result) => {
-                      try {
-                        var xmlContent = $('<div>' + result + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
-                        let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
+        PERF_MONITOR: null,
 
-                        let parentTab = input.closest('.dataTable');
-                        BDA_REPOSITORY.reloadTab(itemId,itemName, repositoryPath, parentTab, () => {
+        MAP_SEPARATOR: "=",
+        LIST_SEPARATOR: ",",
+        descriptorTableSelector: "table:eq(0)",
+        repositoryViewSelector: "h2:contains('Examine the Repository, Control Debugging')",
+        cacheUsageSelector: "h2:contains('Cache usage statistics')",
+        propertiesSelector: "h1:contains('Properties')",
+        eventSetsSelector: "h1:contains('Event Sets')",
+        methodsSelector: "h1:contains('Methods')",
+        resultsSelector: "h2:contains('Results:')",
+        errorsSelector1: "p:contains('Errors:')",
+        errorsSelector2: "code:contains('*** Query:')",
+        defaultItemByTab: "10",
+        nbItemReceived: 0,
+        itemTree: new Map(),
+        defaultDescriptor: {
+            "OrderRepository": "order",
+            "CsrRepository": "returnRequest",
+            "ProfileAdapterRepository": "user",
+            "ProductCatalog": "sku",
+            "InventoryRepository": "inventory",
+            "PriceLists": "price"
+        },
+        xmlDefinitionMaxSize: 150000, // 150 Ko
+        queryEditor: null,
+        descriptorList: null,
+        isRepositoryPage: false,
+        hasErrors: false,
+        hasResults: false,
+        templates: {
+            printItem: '<print-item item-descriptor="{0}" id="{1}"/>',
+            queryItems: '<query-items item-descriptor="{0}">\n{1}\n</query-items>',
+            resultHeader: '<p class="nbResults"> {0} items in {1} descriptor(s)</p>',
+            resultTable: '<table class="dataTable" data-descriptor="{0}" data-repository="{1}"></table>',
+            idCell: '<td class="property idCell" data-identifier="id_{0}_{1}" data-id="{0}" data-item="{1}" data-repository="{2}" >' +
+                '<div class="flex-wrapper">' +
+                '<div class="value-elem">{0}</div>' +
+                '<span class="actions">' +
+                '<i class="fa fa-refresh action reload-item" aria-hidden="true"></i>' +
+                '<i class="fa fa-code action copy-xml" aria-hidden="true"></i>' +
+                '<i class="fa fa-close action close-elem" aria-hidden="true"></i>' +
+                '</div>' +
+                '</span>' +
+                '</div>' +
+                '</td>',
+            descriptorCell: '<td data-id="{1}">{0}</td>',
+            propertyCell: '<td data-property="{2}" data-id="{1}" class="property show-short"><div class="flex-wrapper">' +
+                '{0}' +
+                '<span class="actions">' +
+                '<i class="fa fa-edit action start-edit" aria-hidden="true"></i>' +
+                '<i class="fa fa-compress action collapse" aria-hidden="true"></i>' +
+                '<i class="fa fa-expand action expand" aria-hidden="true"></i>' +
+                '<i class="fa fa-spinner fa-spin passive-loading-icon" aria-hidden="true"></i>' +
+                '</span>' +
+                '</div></td>',
+            shortPropertyCell: '<div class="value-elem propertyValue"></div>',
+            longPropertyCell: '<span class="value-elem long propertyValue"></span><span class="value-elem short">{0}</span>',
+            editProperty: '<update-item item-descriptor="{0}" id="{1}">\n    <set-property name="{2}"><![CDATA[{3}]]></set-property>\n</update-item>'
 
-                          $.notify(
-                            "Success: \n{0}".format(logs), {
-                              className: "success",
-                              position: "top center",
-                              autoHideDelay: 5000
 
-                            }
-                          );
+        },
+        cmAutocomplete: {
+            tags: {
+                '!top': ['add-item', 'query-items', 'print-item', 'remove-item'],
+                '!attrs': {},
+                'toto': {
 
-                        });
-
-                      } catch (e) {
-                        console.error(e);
-                      }
-
+                },
+                'add-item': {
+                    attrs: {
+                        'id': null,
+                        'item-descriptor': null
                     },
-                    (jqXHR, textStatus, errorThrown) => {
-                      $.notify(
-                        "Error during call: {0}.".format(errorThrown), {
-                          className: "error",
-                          position: "top center",
-                          autoHide: false
-                        }
-                      );
+                    children: ['set-property']
+                },
+                'print-item': {
+                    attrs: {
+                        'id': null,
+                        'item-descriptor': null
+                    },
+                    children: []
+                },
+                'remove-item': {
+                    attrs: {
+                        'id': null,
+                        'item-descriptor': null
+                    },
+                    children: ['set-property']
+                },
+                'query-items': {
+                    attrs: {
+                        'item-descriptor': null,
+                        'id-only': ['true', 'false']
+                    },
+                    children: []
+                },
+                'set-property': {
+                    attrs: {
+                        name: null
+                    },
+                    children: []
+                }
+            },
+        },
+        CACHE_STAT_TITLE_REGEXP: /item-descriptor=(.*) cache-mode=(.*)( cache-locality=(.*))?/,
+        edgesToIgnore: ["order", "relationships", "orderRef"],
+
+        build: function() {
+            console.time("bdaRepository");
+            BDA_REPOSITORY.isRepositoryPage = BDA_REPOSITORY.isRepositoryPageFct();
+            BDA_REPOSITORY.hasErrors = BDA_REPOSITORY.hasErrorsFct();
+            BDA_REPOSITORY.hasResults = BDA_REPOSITORY.hasResultsFct(BDA_REPOSITORY.hasErrors);
+            logTrace("isRepositoryPage : " + BDA_REPOSITORY.isRepositoryPage + " Page has results : " + BDA_REPOSITORY.hasResults + ". Page has errors : " + BDA_REPOSITORY.hasErrors);
+            // Setup repository page
+            if (BDA_REPOSITORY.isRepositoryPage)
+                BDA_REPOSITORY.setupRepositoryPage();
+            console.timeEnd("bdaRepository");
+        },
+
+        isRepositoryPageFct: function() {
+            return $("h2:contains('Run XML Operation Tags on the Repository')").length > 0;
+        },
+
+        setupRepositoryPage: function() {
+            // Move RQL editor to the top of the page
+
+            console.time('preparePage');
+
+            BDA_REPOSITORY.PERF_MONITOR = new PerformanceMonitor(true);
+            BDA_REPOSITORY.PERF_MONITOR.reset();
+
+            $(BDA_REPOSITORY.descriptorTableSelector).attr("id", "descriptorTable");
+
+            //save the native form in variable before adding more forms with the showRQLResults methods (inline forms)
+            BDA_REPOSITORY.initialForm = $("form:eq(1)");
+
+            $("<div id='RQLEditor'></div>").insertBefore("h2:first");
+            $("<div id='RQLResults'></div>").insertBefore("#RQLEditor");
+            if (BDA_REPOSITORY.hasErrors)
+                BDA_REPOSITORY.showRqlErrors();
+            if (BDA_REPOSITORY.hasResults && !BDA_REPOSITORY.hasErrors){
+              setTimeout(function() {
+                
+                BDA_REPOSITORY.showRQLResults();
+              }, 300);
+            }
+
+            BDA_REPOSITORY.initialForm
+                .appendTo("#RQLEditor")
+                .attr("id", "RQLForm");
+            var $children = $("#RQLForm").children();
+            $("#RQLForm").empty().append($children);
+            $("textarea[name=xmltext]").attr("id", "xmltext");
+
+            var actionSelect = "<select id='RQLAction' class='js-example-basic-single' style='width:170px'>" + " <optgroup label='Empty queries'>" + "<option value='print-item'>print-item</option>" + "<option value='query-items'>query-items</option>" + "<option value='remove-item'>remove-item</option>" + "<option value='add-item'>add-item</option>" + "<option value='update-item'>update-item</option>" + "</optgroup>" + " <optgroup label='Predefined queries'>" + "<option value='all'>query-items ALL</option>" + "<option value='last_10_ordered'>query-items last 10 order by id</option>" + "<option value='last_10'>query-items last 10</option>" + "</optgroup>" + "</select>";
+
+            $("<div id='RQLToolbar'></div>").append("<div> Action : " + actionSelect + " <span id='editor'>" + "<span id='itemIdField' >ids : <input type='text' id='itemId' placeholder='Id1,Id2,Id3' /></span>" + "<span id='itemDescriptorField' > descriptor :  <select id='itemDescriptor' class='itemDescriptor' >" + BDA_REPOSITORY.getDescriptorOptions() + "</select></span>" + "<span id='idOnlyField' style='display: none;'><label for='idOnly'>&nbsp;id only : </label><input type='checkbox' id='idOnly'></input></span>" + "</span>" + BDA_REPOSITORY.getsubmitButton() + "</div>")
+                .insertBefore("#RQLEditor textarea")
+                .after("<div id='RQLText'></div>");
+
+            $("#xmltext").appendTo("#RQLText");
+            $("#RQLText").after("<div id='tabs'>" + "<ul id='navbar'>" + "<li id='propertiesTab' class='selected'>Properties</li>" + "<li id='queriesTab'>Stored Queries</li>" + "</ul>" + "<div id='storedQueries'><i>No stored query for this repository</i></div>" + "<div id='descProperties'><i>Select a descriptor to see his properties</i></i></div>" + "</div>");
+
+            $("#RQLForm input[type=submit]").remove();
+
+            var splitObj = BDA_STORAGE.getStoredSplitObj();
+            var itemByTab = BDA_REPOSITORY.defaultItemByTab;
+            var isChecked = false;
+            if (splitObj) {
+                itemByTab = splitObj.splitValue;
+                isChecked = splitObj.activeSplit;
+            }
+            var checkboxSplit = "<input type='checkbox' id='noSplit' ";
+            if (isChecked)
+                checkboxSplit += " checked ";
+            checkboxSplit += "/> don't split.";
+
+            $("#tabs").after("<div id='RQLSave'>" + "<div style='display:inline-block;width:200px'><button id='clearQuery' type='button'>Clear <i class='fa fa-ban fa-x'></i></button></div>" + "<div style='display:inline-block;width:530px'>Split tab every :  <input type='text' value='" + itemByTab + "' id='splitValue'> items. " + checkboxSplit + "</div>" + "<button type='submit' id='RQLSubmit'>Enter <i class='fa fa-play fa-x'></i></button>" + "</div>" + "<div><input placeholder='Name this query' type='text' id='queryLabel'>&nbsp;<button type='button' id='saveQuery'>Save <i class='fa fa-save fa-x'></i></button></div>");
+            console.timeEnd('preparePage');
+
+            console.time('showQueryList');
+            BDA_REPOSITORY.showQueryList();
+            console.timeEnd('showQueryList');
+
+            console.time('setupItemTreeForm');
+            BDA_REPOSITORY.setupItemTreeForm();
+            console.timeEnd('setupItemTreeForm');
+
+            console.time('setupItemDescriptorTable');
+            BDA_REPOSITORY.setupItemDescriptorTable();
+            console.timeEnd('setupItemDescriptorTable');
+
+            console.time('setupPropertiesTables');
+            BDA_REPOSITORY.setupPropertiesTables();
+            console.timeEnd('setupPropertiesTables');
+
+            var defaultDescriptor = BDA_REPOSITORY.defaultDescriptor[getComponentNameFromPath(getCurrentComponentPath())];
+            if (defaultDescriptor !== undefined)
+                BDA_REPOSITORY.showItemPropertyList(defaultDescriptor);
+
+            // Default tab position
+            $("#descProperties").css("display", "inline-block");
+            $("#storedQueries").css("display", "none");
+
+            $("#queriesTab").click(function() {
+                logTrace("show stored queries");
+                $("#descProperties").css("display", "none");
+                $("#storedQueries").css("display", "inline-block");
+                $(this).addClass("selected");
+                $("#propertiesTab").removeClass("selected");
+            });
+
+            $("#propertiesTab").click(function() {
+                logTrace("show properties");
+                $("#descProperties").css("display", "inline-block");
+                $("#storedQueries").css("display", "none");
+                $(this).addClass("selected");
+                $("#queriesTab").removeClass("selected");
+
+            });
+
+            $("#RQLAction").change(function() {
+                var action = $(this).val();
+                logTrace("Action change : " + action);
+                if (action == "print-item")
+                    BDA_REPOSITORY.getPrintItemEditor();
+                else if (action == "query-items")
+                    BDA_REPOSITORY.getQueryItemsEditor();
+                else if (action == "remove-item")
+                    BDA_REPOSITORY.getRemoveItemEditor();
+                else if (action == "add-item")
+                    BDA_REPOSITORY.getAddItemEditor();
+                else if (action == "update-item")
+                    BDA_REPOSITORY.getUpdateItemEditor();
+                else
+                    BDA_REPOSITORY.getQueryItemsEditor();
+            });
+
+            $("#RQLSubmit").click(function() {
+                BDA_REPOSITORY.submitRQLQuery(false);
+            });
+
+            $("#RQLGo").click(function() {
+                BDA_REPOSITORY.submitRQLQuery(true);
+            });
+
+            $("#RQLAdd").click(function() {
+                var query = BDA_REPOSITORY.getRQLQuery();
+                BDA_REPOSITORY.addToQueryEditor(query);
+            });
+
+            $("#saveQuery").click(function() {
+                if (BDA_REPOSITORY.getQueryEditorValue().trim().length > 0 && $("#queryLabel").val().trim().length > 0) {
+                    BDA_STORAGE.storeRQLQuery($("#queryLabel").val().trim(), BDA_REPOSITORY.getQueryEditorValue().trim());
+                    BDA_REPOSITORY.showQueryList();
+                }
+            });
+
+            $("#clearQuery").click(function() {
+                BDA_REPOSITORY.setQueryEditorValue("");
+            });
+
+            // Hide other sections
+            var toggleObj = BDA_STORAGE.getToggleObj();
+
+            var repositoryView = "<a href='javascript:void(0)' id='showMoreRepositoryView' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreRepositoryView) + "</a>";
+            var cacheUsage = "&nbsp;<a href='javascript:void(0)' id='showMoreCacheUsage' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreCacheUsage) + "</a>";
+            var properties = "&nbsp;<a href='javascript:void(0)' id='showMoreProperties' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreProperties) + "</a>";
+            var eventSets = "&nbsp;<a href='javascript:void(0)' id='showMoreEventsSets' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreEventsSets) + "</a>";
+            var methods = "&nbsp;<a href='javascript:void(0)' id='showMoreMethods' class='showMore'>" + BDA_REPOSITORY.getToggleLabel(toggleObj.showMoreMethods) + "</a>";
+
+            // Auto hide Repository View
+            $(BDA_REPOSITORY.repositoryViewSelector).append(repositoryView);
+
+            if (toggleObj.hasOwnProperty("showMoreRepositoryView") && toggleObj.showMoreRepositoryView == 0)
+                BDA_REPOSITORY.toggleRepositoryView();
+            $("#showMoreRepositoryView").click(function() {
+                BDA_REPOSITORY.toggleRepositoryView();
+            });
+
+            //setup cache section before hidding it
+            BDA_REPOSITORY.setupRepositoryCacheSection();
+
+            // Auto hide Cache usage
+            $(BDA_REPOSITORY.cacheUsageSelector).append(cacheUsage);
+            if (toggleObj.showMoreCacheUsage != 1)
+                BDA_REPOSITORY.toggleCacheUsage();
+            $("#showMoreCacheUsage").click(function() {
+                BDA_REPOSITORY.toggleCacheUsage();
+            });
+            // Auto hide Properties
+            $(BDA_REPOSITORY.propertiesSelector).append(properties);
+            if (toggleObj.showMoreProperties != 1)
+                BDA_REPOSITORY.toggleProperties();
+            $("#showMoreProperties").click(function() {
+                BDA_REPOSITORY.toggleProperties();
+            });
+            // Auto hide Events Sets
+            $(BDA_REPOSITORY.eventSetsSelector).append(eventSets);
+            if (toggleObj.showMoreEventsSets != 1)
+                BDA_REPOSITORY.toggleEventSets();
+            $("#showMoreEventsSets").click(function() {
+                BDA_REPOSITORY.toggleEventSets();
+            });
+            // Auto hide Methods
+            $(BDA_REPOSITORY.methodsSelector).append(methods);
+            if (toggleObj.showMoreMethods != 1)
+                BDA_REPOSITORY.toggleMethods();
+            $("#showMoreMethods").click(function() {
+                BDA_REPOSITORY.toggleMethods();
+            });
+
+            // console.time('setupEditableTable');
+            // BDA_REPOSITORY.setupEditableTable();
+            // console.timeEnd('setupEditableTable');
+            console.time('initCodeMirror');
+            BDA_REPOSITORY.queryEditor = BDA_REPOSITORY.initCodeMirror(true);
+            console.timeEnd('initCodeMirror');
+
+            console.time('initSelect2');
+
+            // Init select2 plugin
+            $("#RQLAction").select2({
+                width: "style",
+                containerCssClass: 'bda-repository',
+                dropdownCssClass: 'bda-repository',
+                minimumResultsForSearch: -1
+            });
+
+            $(".itemDescriptor").select2({
+                placeholder: "Select a descriptor",
+                allowClear: false,
+                width: "element",
+                containerCssClass: 'bda-repository',
+                dropdownCssClass: 'bda-repository',
+                matcher: function(params, data) {
+                    // If there are no search terms, return all of the data
+                    if ($.trim(params) === '') {
+                        return data;
+                    }
+                    data = data.toUpperCase();
+                    params = params.toUpperCase();
+                    // `params.term` should be the term that is used for searching
+                    // `data.text` is the text that is displayed for the data object
+                    if (data.indexOf(params) != -1)
+                        return true;
+                    return false;
+                }
+            });
+
+            $("#itemDescriptor").on("select2-selecting", function(e) {
+                BDA_REPOSITORY.showItemPropertyList(e.val);
+            });
+
+            console.timeEnd('initSelect2');
+
+
+        },
+
+        initCodeMirror: function(autocomplete) {
+
+            var editor;
+            if (autocomplete) {
+
+                //inner functions for auto-complete
+                //taken from CM XML hint demo
+                //tryed to define them elsewhere but it broke the completion...
+                function completeAfter(cm, pred) {
+                    var cur = cm.getCursor();
+                    if (!pred || pred()) setTimeout(function() {
+                        if (!cm.state.completionActive)
+                            cm.showHint({
+                                completeSingle: false
+                            });
+                    }, 100);
+                    return CodeMirror.Pass;
+                }
+
+                function completeIfAfterLt(cm) {
+                    return completeAfter(cm, function() {
+                        var cur = cm.getCursor();
+                        return cm.getRange(CodeMirror.Pos(cur.line, cur.ch - 1), cur) == "<";
                     });
                 }
-              }, {
-                label: 'Cancel'
-              }]
+
+                function completeIfInTag(cm) {
+                    return completeAfter(cm, function() {
+                        var tok = cm.getTokenAt(cm.getCursor());
+                        if (tok.type == "string" && (!/['"]/.test(tok.string.charAt(tok.string.length - 1)) || tok.string.length == 1)) return false;
+                        var inner = CodeMirror.innerMode(cm.getMode(), tok.state).state;
+                        return inner.tagName;
+                    });
+                }
+
+
+                // Init code mirror
+                editor = CodeMirror.fromTextArea(document.getElementById("xmltext"), {
+                    lineNumbers: false,
+                    mode: 'xml',
+                    extraKeys: {
+                        "'<'": completeAfter,
+                        "'/'": completeIfAfterLt,
+                        "' '": completeIfInTag,
+                        "'='": completeIfInTag,
+                        "Ctrl-Space": "autocomplete"
+                    },
+                    hintOptions: {
+                        schemaInfo: tags
+                    }
+                });
+
+                // HACK
+                // on FF + greasemonkey, the hint is not updated when it's already open
+                // mostly working, yet a bit clunky
+                if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+                    CodeMirror.on(editor, "cursorActivity", function(cm, object) {
+                        if (cm.state.completionActive) {
+                            cm.showHint({
+                                completeSingle: false
+                            });
+                        }
+                    })
+                }
+            } else {
+
+                // Init code mirror
+                editor = CodeMirror.fromTextArea(document.getElementById("xmltext"), {
+                    lineNumbers: false,
+                });
+
+            }
+            return editor;
+        },
+
+        setupEditableTable: function() {
+            $('body').on('click', '.dataTable .fa-pencil-square-o', function(item) {
+                var $target = $(item.target).parent();
+                $target.html('<input type="text" value="' + $target.text().replace(/●/g, ' ') + '"/>');
+                var $input = $($target.children()[0]);
+                $input.focus().blur(function(item) {
+                    var $target = $(item.target);
+                    var $table = $target.parents(".dataTable");
+                    var descriptor = $table.attr("data-descriptor");
+                    var itemId = $target.parent().attr("data-id");
+                    var propertyName = $target.parent().attr("data-property");
+                    if (propertyName == "id" || propertyName == "descriptor") {
+                        $input.parent().html($input.val());
+                        $.notify(
+                            "You can't change value of id or descriptor this way.", {
+                                position: "top center",
+                                className: "error"
+                            }
+                        );
+                        return;
+                    }
+                    logTrace(itemId + " " + descriptor + " " + $target.val() + " " + propertyName);
+                    var query = '<update-item id="' + itemId + '" item-descriptor="' + descriptor + '">\n' + '  <set-property name="' + propertyName + '"><![CDATA[' + $target.val() + ']]>' + '</set-property>\n</update-item>';
+                    var initialValue = $input.attr("value");
+                    if (confirm('You are about to execute this query : \n' + query)) {
+                        jQuery.post(document.location.href, 'xmltext=' + query, function(res) {
+                            var $res = $(res);
+                            var errorsSelector1 = "Errors:";
+                            if ($res.text().indexOf(errorsSelector1) != -1) {
+                                var errorMsg = $res.find("code").text().trim();
+                                $.notify(
+                                    "Error : " + errorMsg, {
+                                        position: "top left",
+                                        className: "error",
+                                        autoHide: true,
+                                        autoHideDelay: 15000
+                                    }
+                                );
+                                $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + initialValue); // reset inital value
+                            } else {
+                                $.notify(
+                                    "Value succesfully changed", {
+                                        position: "top center",
+                                        className: "success"
+                                    }
+                                );
+                            }
+                            $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + $input.val());
+                        });
+                    } else
+                        $input.parent().html('<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + initialValue); // reset inital value
+                });
             });
-          } catch (e) {
-            console.error(e);
-          }
 
-        })
-        output.append(form);
-      } catch (e) {
-        console.error(e);
-      }
-      BDA_REPOSITORY.PERF_MONITOR.cumul('addInlineEditForm');
+        },
 
-    },
-    closeTab: function(idCell, container) {
-      try {
-        logTrace('closetab', idCell);
-        let tab = idCell.closest('.dataTable');
-        tab.find('[data-id="{0}"]'.format(idCell.attr('data-id'))).remove();
-        //if last item remove tab
-        let tabSize = tab.find('.idCell').length;
-        let container = tab.closest('.rqlResultContainer');
-        BDA_REPOSITORY.reloadSpeedBar(container);
-        if (tabSize == 0) {
-          tab.remove();
-        }
-      } catch (e) {
-        console.error(e);
-      }
+        addToQueryEditor: function(query) {
+            var editor = BDA_REPOSITORY.queryEditor;
+            var editorCursor = editor.getCursor();
+            if (editorCursor.ch !== 0)
+                editor.setCursor(editor.getCursor().line + 1, 0);
 
-    },
+            BDA_REPOSITORY.queryEditor.replaceSelection(query);
+        },
 
-    findTabToAppendTo: function(itemDescriptorName, outputDiv) {
-      let dataTables = outputDiv.find('.dataTable[data-descriptor="{0}"]'.format(itemDescriptorName));
-      var max = BDA_REPOSITORY.getChunkSize();
-      let res;
-      logTrace('dataTables', dataTables);
-      dataTables.each(function(idx, table) {
-        let $table = $(table);
-        logTrace('table', $table);
-        if ($table.find('.idCell').length < max) {
-          res = $table;
-        }
-      })
-      return res;
-    },
+        setupPropertiesTables: function() {
+            if ($("a[name=showProperties]").length > 0) {
+                $("a[name=showProperties]").next().attr("id", "propertiesTable");
+                $("#propertiesTable").find("tr:nth-child(odd)").addClass("odd");
+            }
+        },
 
-    appendToDataTable: function(id, itemDescriptorName, repositoryPath, dataTable, tempResult, cb) {
-      let propertySelector = '.property[data-id="{0}"]'.format(id);
-      tempResult.find(propertySelector).each(function() {
-        let $this = $(this);
-        let propertyName = $this.attr('data-property');
-        dataTable.find('.item-line[data-property="{0}"]'.format(propertyName)).append($this);
-      })
+        setupItemDescriptorTable: function() {
+            var descriptors = BDA_REPOSITORY.getDescriptorList();
+            var componentURI = window.location.pathname;
+            var splitValue = 20;
+            var html = "<p>" + descriptors.length + " descriptors available.</p>";
+            html += "<div>";
+            for (var i = 0; i != descriptors.length; i++) {
+                if (i === 0 || i % splitValue === 0) {
+                    html += "<table class='descriptorTable'>";
+                    html += "<th>Descriptor</th>";
+                    html += "<th>View</th>";
+                    html += "<th>Debug</th>";
+                }
+                if (i % 2 === 0)
+                    html += "<tr class='even'>";
+                else
+                    html += "<tr class='odd'>";
+                var isDebugEnable = false;
+                if ($("a[href='" + componentURI + "?action=clriddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors']").length > 0)
+                    isDebugEnable = true;
+                html += "<td class='descriptor'>" + descriptors[i] + "</td>";
+                html += "<td><a class='btn-desc' href='" + componentURI + "?action=seetmpl&itemdesc=" + descriptors[i] + "#showProperties'>Properties</a>";
+                html += "&nbsp;<a class='btn-desc' class='btn-desc' href='" + componentURI + "?action=seenamed&itemdesc=" + descriptors[i] + "#namedQuery'>Named queries</a></td>";
 
-      //  update the data
-      let idSelector = '.idCell[data-id="{0}"]'.format(id, itemDescriptorName);
-      dataTable.find('tr.id').append(tempResult.find(idSelector));
-      BDA_REPOSITORY.showNonEmptyLines(dataTable);
-      if (cb) {
-        cb();
-      }
-    },
+                html += "<td>";
+                if (isDebugEnable)
+                    html += "<a class='btn-desc red' href='" + componentURI + "?action=clriddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors'>Disable</a>";
+                else {
+                    html += "<a class='btn-desc' href='" + componentURI + "?action=setiddbg&itemdesc=" + descriptors[i] + "#listItemDescriptors'>Enable</a>";
+                    html += "&nbsp;<a class='btn-desc' href='" + componentURI + "?action=dbgprops&itemdesc=" + descriptors[i] + "#debugProperties'>Edit</a>";
+                }
+                html += "</td>";
+                html += "</tr>";
+                if (i !== 0 && ((i + 1) % splitValue === 0 || i + 1 === descriptors.length))
+                    html += "</table>";
+            }
+            html += "</div>";
+            html += "<div style='clear:both' />";
 
-    reloadTab: function(id, itemDescriptorName, repositoryPath, parentTab, cb) {
-      if (_.isNil(repositoryPath)) {
-        repositoryPath = getCurrentComponentPath();
-      }
-      BDA_REPOSITORY.executePrintItem('', itemDescriptorName, id, repositoryPath,
-        function(result) {
-          BDA_REPOSITORY.parseXhrResult(result, repositoryPath, (parsed) => {
+            $("#descriptorTable").remove();
+            $(html).insertAfter("a[name='listItemDescriptors']");
+        },
+
+
+        showItemPropertyList: function(item) {
+            logTrace("showItemPropertyList");
+            var componentURI = window.location.pathname;
+            var url = componentURI + "?action=seetmpl&itemdesc=" + item + "#showProperties";
+            $.get(url, function(data) {
+                logTrace("Enter showItemPropertyList callback");
+                var $pTable = $(data).find("a[name='showProperties']").next();
+                $pTable.find('th:nth-child(2), td:nth-child(2),th:nth-child(4), td:nth-child(4),th:nth-child(5), td:nth-child(5),th:nth-child(6), td:nth-child(6)').remove();
+                $pTable.find("tr").each(function(index) {
+                    var $tr = $(this);
+                    $tr.find("td").each(function(i) {
+                        var $td = $(this);
+                        if (i === 0) {
+                            var content = $td.html();
+                            var req = /[\w\s']+\((\w+)\)$/i;
+                            content = content.replace(req, "<a class='itemPropertyBtn' href='javascript:void(0)'> $1 </a>");
+                            $td.html(content);
+                        } else if (i === 1)
+                            $td.text($td.text().replace("Class", ""));
+
+                    });
+                });
+                logTrace($pTable);
+                $("#descProperties")
+                    .empty()
+                    .append($pTable);
+
+                $('.itemPropertyBtn').click(function(item) {
+                    BDA_REPOSITORY.addToQueryEditor('<set-property name="' + $(this).text().trim() + '"><![CDATA[]]></set-property>\n');
+                });
+            });
+        },
+
+        hasResultsFct: function(hasErrors) {
+            return $(BDA_REPOSITORY.resultsSelector).length > 0;
+        },
+
+        hasErrorsFct: function() {
+            return $(BDA_REPOSITORY.errorsSelector1).length > 0 || $(BDA_REPOSITORY.errorsSelector2).length > 0;
+        },
+
+
+        getDescriptorList: function() {
+            if (BDA_REPOSITORY.descriptorList)
+                return BDA_REPOSITORY.descriptorList;
+            var descriptors = [];
+            $("#descriptorTable tr th:first-child:not([colspan])")
+                .sort(function(a, b) {
+                    return $(a).text().toLowerCase() > $(b).text().toLowerCase() ? 1 : -1;
+                }).each(function() {
+
+                    descriptors.push($(this).html().trim());
+                });
+            BDA_REPOSITORY.descriptorList = descriptors;
+            return descriptors;
+        },
+
+        getDescriptorOptions: function() {
+            var descriptorOptions = "";
+            var descriptors = BDA_REPOSITORY.getDescriptorList();
+            descriptorOptions = "";
+            var defaultDesc = BDA_REPOSITORY.defaultDescriptor[getComponentNameFromPath(getCurrentComponentPath())];
+            if (defaultDesc === undefined)
+                descriptorOptions = "<option></option>";
+            for (var i = 0; i != descriptors.length; i++) {
+                descriptorOptions += "<option value='" + descriptors[i] + "'";
+                if (defaultDesc === descriptors[i])
+                    descriptorOptions += "selected='selected'";
+                descriptorOptions += ">" + descriptors[i] + "</option>\n";
+            }
+            return descriptorOptions;
+        },
+
+        getsubmitButton: function() {
+            return "<button type='button' id='RQLAdd'>Add</button>" + "<button type='button' id='RQLGo'>Add & Enter <i class='fa fa-play fa-x'></i></button>";
+        },
+
+        getPrintItemEditor: function() {
+            $("#itemIdField").show();
+            $("#itemDescriptorField").show();
+            $("#idOnlyField").hide();
+        },
+
+        getAddItemEditor: function() {
+            $("#itemIdField").hide();
+            $("#itemDescriptorField").show();
+            $("#idOnlyField").hide();
+        },
+
+        getRemoveItemEditor: function() {
+            BDA_REPOSITORY.getPrintItemEditor();
+        },
+
+        getRemoveItemsEditor: function() {
+            BDA_REPOSITORY.getPrintItemEditor();
+        },
+
+        getUpdateItemEditor: function() {
+            BDA_REPOSITORY.getPrintItemEditor();
+        },
+
+        getQueryItemsEditor: function() {
+            $("#itemIdField").hide();
+            $("#itemDescriptorField").show();
+            $("#idOnlyField").show();
+        },
+
+        getMultiId: function() {
+            var ids = $("#itemId").val().trim();
+            if (ids.indexOf(",") != -1)
+                return ids.split(",");
+            return [ids];
+        },
+
+        getPrintItemQuery: function() {
+            var ids = BDA_REPOSITORY.getMultiId();
+            var descriptor = $("#itemDescriptor").val();
+            var query = "";
+            for (var i = 0; i != ids.length; i++)
+                query += "<print-item id=\"" + ids[i].trim() + "\" item-descriptor=\"" + descriptor + "\" />\n";
+            return query;
+        },
+
+        getRemoveItemQuery: function() {
+            var ids = BDA_REPOSITORY.getMultiId();
+            var descriptor = $("#itemDescriptor").val();
+            var query = "";
+            for (var i = 0; i != ids.length; i++)
+                query += "<remove-item id=\"" + ids[i].trim() + "\" item-descriptor=\"" + descriptor + "\" />\n";
+            return query;
+        },
+
+        getAddItemQuery: function() {
+            var descriptor = $("#itemDescriptor").val();
+            var query = "<add-item item-descriptor=\"" + descriptor + "\" >\n";
+            query += "  <set-property name=\"\"><![CDATA\[]]></set-property>\n";
+            query += "</add-item>\n";
+            return query;
+        },
+
+        getUpdateItemQuery: function() {
+            var descriptor = $("#itemDescriptor").val();
+            var ids = BDA_REPOSITORY.getMultiId();
+            var query = "";
+            for (var i = 0; i != ids.length; i++) {
+                query += "<update-item id=\"" + ids[i] + "\" item-descriptor=\"" + descriptor + "\" >\n";
+                query += "  <set-property name=\"\"><![CDATA\[]]></set-property>\n";
+                query += "</update-item>\n";
+            }
+            return query;
+        },
+
+        getQueryItemsQuery: function() {
+            var descriptor = $("#itemDescriptor").val();
+            var idOnly = $("#idOnly").prop('checked');
+            var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n\n";
+            query += "</query-items>\n";
+            return query;
+        },
+
+        getAllItemQuery: function() {
+            var descriptor = $("#itemDescriptor").val();
+            var idOnly = $("#idOnly").prop('checked');
+            var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
+            query += "ALL\n";
+            query += "</query-items>\n";
+            return query;
+        },
+
+        getLast10ItemQueryOrdered: function() {
+            var descriptor = $("#itemDescriptor").val();
+            var idOnly = $("#idOnly").prop('checked');
+            var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
+            query += "ALL ORDER BY ID DESC RANGE 0+10\n";
+            query += "</query-items>\n";
+            return query;
+        },
+
+
+        getLast10ItemQuery: function() {
+            var descriptor = $("#itemDescriptor").val();
+            var idOnly = $("#idOnly").prop('checked');
+            var query = "<query-items item-descriptor=\"" + descriptor + "\" id-only=\"" + idOnly + "\">\n";
+            query += "ALL RANGE 0+10\n";
+            query += "</query-items>\n";
+            return query;
+        },
+
+        getRQLQuery: function() {
+            var query = "";
+            var action = $("#RQLAction").val();
+            logTrace("getRQLQuery : " + action);
+            if (action == "print-item")
+                query = BDA_REPOSITORY.getPrintItemQuery();
+            else if (action == "query-items")
+                query = BDA_REPOSITORY.getQueryItemsQuery();
+            else if (action == "remove-item")
+                query = BDA_REPOSITORY.getRemoveItemQuery();
+            else if (action == "add-item")
+                query = BDA_REPOSITORY.getAddItemQuery();
+            else if (action == "update-item")
+                query = BDA_REPOSITORY.getUpdateItemQuery();
+            else if (action == "all")
+                query = BDA_REPOSITORY.getAllItemQuery();
+            else if (action == "last_10_ordered")
+                query = BDA_REPOSITORY.getLast10ItemQueryOrdered();
+            else if (action == "last_10")
+                query = BDA_REPOSITORY.getLast10ItemQuery();
+            return query;
+        },
+        submitRQLQuery: function(addText) {
+            if (addText) {
+                var query = BDA_REPOSITORY.getRQLQuery();
+                BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
+            }
+            BDA_REPOSITORY.sanitizeQuery();
+            BDA_STORAGE.storeSplitValue();
+            // set anchor to the result div
+            location.hash = '#RQLResults';
+            $("#RQLForm").submit();
+        },
+
+        sanitizeQuery: function() {
+            var query = BDA_REPOSITORY.getQueryEditorValue();
+            BDA_REPOSITORY.setQueryEditorValue(query.replace(/repository\=\".+\"/gi, ""));
+        },
+
+        setQueryEditorValue: function(value) {
+            BDA_REPOSITORY.queryEditor.getDoc().setValue(value);
+        },
+
+        getQueryEditorValue: function() {
+            return BDA_REPOSITORY.queryEditor.getDoc().getValue();
+        },
+
+        showTextField: function(baseId) {
+            baseId = BDA_REPOSITORY.sanitizeSelector(baseId);
+            $("#" + baseId).toggle();
+            $("#text_" + baseId).toggle();
+        },
+
+        // Escape '.', ':' in a jquery selector
+        sanitizeSelector: function(id) {
+            return id.replace(/(:|\.|\[|\]|,)/g, "\\$1");
+        },
+
+        purgeXml: function(xmlContent) {
+            var xmlStr = "";
+            var lines = xmlContent.split("\n");
+            for (var i = 0; i != lines.length; i++) {
+                var line = lines[i].trim();
+                if (!(line.substr(0, 1) == "<" && endsWith(line, ">")))
+                    xmlStr += line + "\n";
+            }
+            return xmlStr;
+        },
+
+
+        // Check if the given property contains id(s) with the given item descriptor
+        // Return an item descriptor name if the property is an ID,
+        // Return null if the property is not found,
+        // Return "FOUND_NOT_ID" is the property is found but is not an ID
+        isPropertyId: function(propertyName, $itemDesc) {
+            var isId = null;
+            var propertyFound = false;
+            $itemDesc.find("property[name=" + propertyName + "]").each(function() {
+                propertyFound = true;
+                var $property = $(this);
+                if ($property.attr("item-type") !== undefined && $property.attr("repository") === undefined)
+                    isId = $property.attr("item-type");
+                else if ($property.attr("component-item-type") !== undefined && $property.attr("repository") === undefined)
+                    isId = $property.attr("component-item-type");
+            });
+            if (propertyFound && isId === null)
+                return "FOUND_NOT_ID";
+            return isId;
+        },
+        // Check if the given property contains id(s) with the given repository definition
+        // Only ID from the current repository are take in account
+        // Return the item descriptor name if the type if an ID, null otherwise
+        isTypeId: function(propertyName, itemDesc, $xmlDef) {
+            var isId = null;
+            if ($xmlDef !== null) {
+                var $itemDesc = $xmlDef.find("item-descriptor[name='" + itemDesc + "']");
+                // First check in current item desc
+                isId = BDA_REPOSITORY.isPropertyId(propertyName, $itemDesc);
+                // In case we found the property but it's not an ID, we don't want to search in super-type
+                if (isId == "FOUND_NOT_ID")
+                    return null;
+                // In case we found the property and it's an ID
+                if (isId !== null)
+                    return isId;
+                // Now we check in each super-type item desc
+                var superType = $itemDesc.attr("super-type");
+                while (superType !== undefined && isId === null) {
+                    var $parentDesc = $xmlDef.find("item-descriptor[name='" + superType + "']");
+                    isId = BDA_REPOSITORY.isPropertyId(propertyName, $parentDesc);
+                    superType = $parentDesc.attr("super-type");
+                }
+                if (isId == "FOUND_NOT_ID")
+                    return null;
+            }
+            return isId;
+        },
+
+        // Parse the given repository ID into a tab, each index will contains an ID or a separator : "," or "="
+        parseRepositoryId: function(id) {
+            var idAsTab = [];
+            var tab = [];
+            // Case of simple ID
+            if (id.indexOf(BDA_REPOSITORY.MAP_SEPARATOR) == -1 && id.indexOf(BDA_REPOSITORY.LIST_SEPARATOR) === -1)
+                idAsTab.push(id);
+            // Case of a list of ID
+            else if (id.indexOf(BDA_REPOSITORY.MAP_SEPARATOR) == -1 && id.indexOf(BDA_REPOSITORY.LIST_SEPARATOR) !== -1) {
+                tab = id.split(BDA_REPOSITORY.LIST_SEPARATOR);
+                for (var i = 0; i != tab.length; i++) {
+                    if (i !== 0)
+                        idAsTab.push(BDA_REPOSITORY.LIST_SEPARATOR);
+                    idAsTab.push(tab[i]);
+                }
+            }
+            // Case of a Map of ID
+            else {
+                var mapEntries = id.split(BDA_REPOSITORY.LIST_SEPARATOR);
+                for (var a = 0; a != mapEntries.length; a++) {
+                    if (a !== 0)
+                        idAsTab.push(BDA_REPOSITORY.LIST_SEPARATOR);
+                    var mapValues = mapEntries[a].split(BDA_REPOSITORY.MAP_SEPARATOR);
+                    for (var b = 0; b != mapValues.length; b++) {
+                        if (b !== 0)
+                            idAsTab.push(BDA_REPOSITORY.MAP_SEPARATOR);
+                        idAsTab.push(mapValues[b]);
+                    }
+                }
+            }
+            return idAsTab;
+        },
+
+        renderProperty: function(curProp, propValue, itemId, isItemTree) {
+            var html = "";
+            var td = "<td data-property='" + curProp.name + "' data-id='" + itemId + "'>";
+            if (propValue !== null && propValue !== undefined) {
+                propValue = propValue.replace(/ /g, '●');
+                // Remove "_"
+                if (curProp.name == "descriptor")
+                    propValue = propValue.substr(1);
+                // propertyName_id
+                var base_id = curProp.name + "_" + itemId;
+
+                if (curProp.name == "id")
+                    html += "<td id='" + base_id + "'>" + propValue + "</td>";
+                // Hide long value
+                else if (propValue.length > 25) {
+                    var link_id = "link_" + base_id;
+                    var field_id = "text_" + base_id;
+                    propValue = "<a class='copyLink' href='javascript:void(0)' title='Show all' id='" + link_id + "' >" + "<span id='" + base_id + "'>" + BDA_REPOSITORY.escapeHTML(propValue.substr(0, 25)) + "..." + "</span></a><textarea class='copyField' id='" + field_id + "' readonly>" + propValue + "</textarea>";
+                    html += td + propValue + "</td>";
+                }
+                // Make IDs clickable
+                else if (curProp.isId === true) {
+                    propValue = BDA_REPOSITORY.parseRepositoryId(propValue);
+                    html += td;
+                    for (var b = 0; b != propValue.length; b++) {
+                        if (propValue[b] != BDA_REPOSITORY.MAP_SEPARATOR && propValue[b] != BDA_REPOSITORY.LIST_SEPARATOR) {
+                            if (isItemTree) // for item tree we create an anchor link
+                                html += "<a class='clickable_property' href='#id_" + propValue[b] + "'>" + propValue[b] + "</a>";
+                            else
+                                html += "<a class='clickable_property loadable_property' data-id='" + propValue[b] + "' data-descriptor='" + curProp.itemDesc + "'>" + propValue[b] + "</a>";
+                        } else
+                            html += propValue[b];
+                    }
+                    html += "</td>";
+                }
+                // descriptor, Read only and derived porperty are not editable
+                else if (curProp.name == "descriptor" || curProp.rdonly == "true" || curProp.derived == "true")
+                    html += "<td>" + propValue + "</td>";
+                else
+                    html += td + '<i class="fa fa-pencil-square-o" aria-hidden="true"></i>' + propValue + "</td>";
+            } else
+                html += td + '<i class="fa fa-pencil-square-o" aria-hidden="true"></i></td>';
+
+            return html;
+        },
+
+        renderTab: function(itemDesc, types, datas, tabId, isItemTree) {
+            var html = "";
+            html += "<table class='dataTable' data-descriptor='" + itemDesc.substr(1) + "' ";
+            if (isItemTree)
+                html += "id='" + tabId + "'";
+            html += ">";
+            for (var i = 0; i != types.length; i++) {
+                var curProp = types[i];
+                if (i % 2 === 0)
+                    html += "<tr class='even";
+                else
+                    html += "<tr class='odd";
+
+                if (curProp.name == "id")
+                    html += " id";
+                else if (curProp.name == "descriptor")
+                    html += " descriptor";
+
+                html += "'>";
+                html += "<th>" + curProp.name + "<span class='prop_name'>";
+                if (curProp.rdonly == "true")
+                    html += "<div class='prop_attr prop_attr_red'>R</div>";
+                if (curProp.derived == "true")
+                    html += "<div class='prop_attr prop_attr_green'>D</div>";
+                if (curProp.exportable == "true")
+                    html += "<div class='prop_attr prop_attr_blue'>E</div>";
+                html += "</span></th>";
+
+                for (var a = 0; a < datas.length; a++) {
+                    var propValue = datas[a][curProp.name];
+                    html += BDA_REPOSITORY.renderProperty(curProp, propValue, datas[a].id, isItemTree);
+                }
+                html += "</tr>";
+            }
+            html += "</table>";
+            return html;
+        },
+
+        getDescriptorAndDefaultValues: function(itemDescriptor, $xmlDef, descriptorAndDefaultValues) {
+            descriptorAndDefaultValues[itemDescriptor] = {};
+            var itemDefinition = $xmlDef.find("item-descriptor[name=" + itemDescriptor + "]");
+            var defaultProperties = $xmlDef.find("item-descriptor[name=" + itemDescriptor + "] property[default]");
+            if (itemDefinition !== undefined && itemDefinition.length > 0) {
+                var superType = itemDefinition[0].getAttribute("super-type");
+                defaultProperties = defaultProperties.toArray().concat($xmlDef.find("item-descriptor[name=" + superType + "] property[default]").toArray());
+            }
+            for (var defaultPropertiesIndex = 0; defaultPropertiesIndex < defaultProperties.length; defaultPropertiesIndex++) {
+                var defaultProperty = defaultProperties[defaultPropertiesIndex];
+                var defaultPropertyName = defaultProperty.getAttribute("name");
+                var defaultPropertyValue = defaultProperty.getAttribute("default");
+                descriptorAndDefaultValues[itemDescriptor][defaultPropertyName] = defaultPropertyValue;
+            }
+        },
+
+        //same as getDescriptorAndDefaultValues but using Objects
+        buildItemDescriptor: function(itemDescriptorName, $xmlDef, repository) {
+            BDA_REPOSITORY.PERF_MONITOR.start('buildItemDescriptor');
+            //  console.time(itemDescriptorName);
+            var $itemDefinition = $xmlDef.find('item-descriptor[name={0}]'.format(itemDescriptorName));
+
+            // first get properties from the parent, if it exists
+            var superType = $itemDefinition.attr("super-type");
+            let parent = null;
+            if (!_.isNil(superType)) {
+                parent = repository.getItemDescriptor(superType); //this will build parents by recursion if necessary
+            }
+            let propertyDescriptors = {};
+            if (!_.isNil(parent)) {
+                propertyDescriptors = parent.properties;
+            }
+
+            // then add current properties
+            var $properties = $itemDefinition.find('property');
+
+            var selfPropertyDescriptors = {};
+            $properties.each(function() {
+                let $prop = $(this);
+                let name = $prop.attr('name');
+                let propDesc = new PropertyDescriptor($prop, repository);
+                let defaultValue = $prop.attr('default');
+                if (!_.isNil(defaultValue)) {
+                    propDesc.defaultValue = defaultValue;
+                }
+                selfPropertyDescriptors[name] = propDesc;
+            });
+
+            propertyDescriptors = _.merge(propertyDescriptors, selfPropertyDescriptors);
+            propertyDescriptors = _.sortKeysBy(propertyDescriptors);
+
+            let desc = new ItemDescriptor({
+                name: itemDescriptorName,
+                xmlDefinition: $itemDefinition,
+                properties: propertyDescriptors
+            });
+            //  console.timeEnd(itemDescriptorName);
+            BDA_REPOSITORY.PERF_MONITOR.cumul('buildItemDescriptor');
+            return desc;
+        },
+
+        getRepositoryAsync: function(path, callback) {
+            logTrace('getRepositoryAsync', path);
+            let repository = BDA_REPOSITORY.repositories[path];
+            if (_.isNil(repository)) {
+                processRepositoryXmlDef("definitionFiles",
+                    ($xmlDef) => {
+
+                        repository = BDA_REPOSITORY.getRepository($xmlDef, path);
+                        callback(repository);
+                    }, path)
+
+            } else {
+                callback(repository)
+            }
+        },
+
+        getRepository: function($xmlDef, repositoryPath) {
+            logTrace('getRepository', repositoryPath);
+            let repository = BDA_REPOSITORY.repositories[repositoryPath];
+            if (_.isNil(repository)) {
+                repository = new Repository({
+                    path: repositoryPath,
+                    xmlDefinition: $xmlDef
+                })
+                BDA_REPOSITORY.repositories[repositoryPath] = repository;
+            }
+            return repository;
+        },
+
+
+        showXMLAsTab: function(rawXml, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
+            let xmlContent = sanitizeXml(rawXml);
+
+            console.time('showXMLAsTab_new');
+            if (_.isEmpty(repositoryPath)) {
+                repositoryPath = getCurrentComponentPath();
+            }
+            let repository = BDA_REPOSITORY.getRepository($xmlDef, repositoryPath);
+            let parsedResult = BDA_REPOSITORY.parseXmlResult(xmlContent, repository, rawXml);
+
+            let items = parsedResult.items;
+            let logs = parsedResult.logs;
+
+            BDA_REPOSITORY.renderResultSection(items, repository, $outputDiv, isItemTree);
+
+            //  if (isItemTree) {
+            BDA_REPOSITORY.createSpeedbar_new($outputDiv);
+            //}
+
+            BDA_REPOSITORY.PERF_MONITOR.log();
+            console.timeEnd('showXMLAsTab_new');
+            return logs;
+        },
+
+        renderResultSection: function(items, repository, $outputDiv, isItemTree) {
+            console.time('renderResultSection');
+            // now render the result section
+            $outputDiv.append("<div class='prop_attr prop_attr_red'>R</div> : read-only " +
+                "<div class='prop_attr prop_attr_green'>D</div> : derived " +
+                "<div class='prop_attr prop_attr_blue'>E</div> : export is false," +
+                '&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i> : Link to other Repository,' +
+                '&nbsp;<span class="default">grey</span> : default value');
+
+            // show all button
+            let showAll = $('<button>Show All <i class="fa fa-expand" aria-hidden="true"></i></button>');
+            let hideAll = $('<button>Collapse All <i class="fa fa-compress" aria-hidden="true"></i></button>');
+
+            showAll.on('click', function() {
+                $('.property')
+                    .removeClass('show-short')
+                    .addClass('show-long');
+                $(this).hide();
+                hideAll.show();
+            })
+
+            hideAll.on('click', function() {
+                $('.property')
+                    .addClass('show-short')
+                    .removeClass('show-long');
+                $(this).hide();
+                showAll.show();
+            }).hide();
+
+
+            $outputDiv.append($('<p></p>').append(showAll).append(hideAll));
+
+            if (isItemTree) {
+                $('<button>Show speedbar</button></p>')
+                    .on('click', () => $('#speedbar').fadeIn(200))
+                    .appendTo($outputDiv);
+            }
+
+
+            BDA_REPOSITORY.formatTabResult(repository, items, $outputDiv);
+            console.timeEnd('renderResultSection');
+
+        },
+
+        parseXhrResult: function(xhrResult, repositoryPath, callback) {
+
+            BDA_REPOSITORY.getRepositoryAsync(repositoryPath, (repository) => {
+                try {
+                    logTrace('parseXhrResult', repositoryPath, xhrResult);
+                    var rawXml = $('<div>' + xhrResult + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
+                    let xmlContent = sanitizeXml(rawXml);
+                    let result = BDA_REPOSITORY.parseXmlResult(xmlContent, repository, rawXml);
+                    result.repository = repository;
+                    logTrace('parseXhrResult result:', result);
+                    callback(result);
+                } catch (e) {
+                    console.error(e);
+                }
+            })
+
+        },
+
+        parseXmlResult: function(xmlContent, repository, rawXml) {
+            console.time('parseXmlResult');
+            try {
+
+                var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
+                var $xml = $(xmlDoc);
+                var rawXmlDoc = $($.parseXML("<xml>" + rawXml + "</xml>"));
+                var $addItems = $xml.find("add-item");
+                let items = BDA_REPOSITORY.parseXmlAsObjects($addItems, repository, rawXmlDoc);
+                let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
+                console.timeEnd('parseXmlResult');
+                return {
+                    items: items,
+                    logs: logs
+                }
+            } catch (e) {
+                console.error(e);
+                console.timeEnd('parseXmlResult');
+            }
+
+        },
+        getExecutionLogs: function(xmlContent) {
+            var log = $("<xml>" + xmlContent + "</xml>")
+                .children()
+                .remove()
+                .end()
+                .text()
+                .trim();
+            return log;
+        },
+
+        getChunkSize: function() {
+            let chunkSize = 1;
+            var splitObj = BDA_STORAGE.getStoredSplitObj();
+            // activeSplit == don't split - don't ask me why this name...
+            if (_.isNil(splitObj) || !!splitObj.activeSplit) {
+                chunkSize = Number.MAX_SAFE_INTEGER;
+            } else {
+                chunkSize = parseInt(splitObj.splitValue);
+            }
+            if (chunkSize < 1) {
+                chunkSize = 1; // safety
+            }
+            return chunkSize;
+        },
+
+        formatTabResult: function(repository, repositoryItems, result) {
+            console.time('formatTabResult');
+            try {
+                let itemsByType = _.groupBy(repositoryItems, repoItem => !_.isNil(repoItem.itemDescriptor) ? repoItem.itemDescriptor.name : null);
+                let nbItemDescriptors = _.keys(itemsByType).length;
+                let res = $(BDA_REPOSITORY.templates.resultHeader.format(repositoryItems.length, nbItemDescriptors))
+
+                var chunkSize = BDA_REPOSITORY.getChunkSize();
+
+                // for each property, only display it if it'si not empty in one result
+                let renderContext = {}
+                _(itemsByType)
+                    .each((items, itemDescName) => {
+                        let desc = repository.getItemDescriptor(itemDescName);
+                        renderContext[itemDescName] = {};
+                        _.each(desc.properties, property => {
+                            try {
+                                renderContext[itemDescName][property.name] = _.some(items, item => item.hasValueFor(property.name));
+
+                            } catch (e) {
+                                console.err('error finding render context for: itemDescName,items, property', itemDescName, items, property);
+                            }
+                        })
+                    });
+
+
+                // for each group of item by descriptor, split in chunks of same descriptor and max size 'chunkSize'
+                let chunks = _(itemsByType)
+                    .map(group => _.chunk(group, chunkSize)) //split each group
+                    .flatMap() //flatten the array of arrays
+                    .value();
+
+
+                //now render each tab
+                let firstResult = _.chain(chunks)
+                    .map(chunk => BDA_REPOSITORY.buildResultTable(chunk, renderContext, repository))
+                    .filter(table => !_.isNil(table))
+                    .map(table => {
+                        table.appendTo(result)
+                        return table;
+                    })
+                    .head().value();
+
+                return firstResult;
+
+            } catch (e) {
+                console.error(e);
+            }
+            console.timeEnd('formatTabResult');
+        },
+
+        parseXmlAsObjects: function($addItems, repository, rawXmlDoc) {
+            BDA_REPOSITORY.PERF_MONITOR.start('parseXmlAsObjects');
+            let res = $addItems.map(function() {
+                var currentItem = $(this);
+                var descriptorName = currentItem.attr("item-descriptor");
+                var id = currentItem.attr("id");
+                let itemDescriptor = repository.getItemDescriptor(descriptorName);
+                let rawXml;
+                if (!_.isNil(rawXmlDoc)) {
+                    rawXml = rawXmlDoc.find('add-item[item-descriptor="{0}"][id="{1}"]'.format(descriptorName, id));
+                }
+                let repositoryItem = new RepositoryItem({
+                    itemDescriptor: itemDescriptor,
+                    id: id,
+                    xmlDefinition: currentItem,
+                    rawXml: rawXml.outerHTML()
+                })
+
+                currentItem.find('set-property').each(function() {
+                    let currentProperty = $(this);
+                    let propertyName = currentProperty.attr('name');
+                    let propertyDescriptor;
+                    if (!_.isNil(itemDescriptor)) {
+                        propertyDescriptor = itemDescriptor.properties[propertyName];
+                    }
+                    let val = repositoryItem.values[propertyName];
+                    if (_.isNil(val)) {
+                        val = new PropertyValue(propertyDescriptor, currentProperty);
+                        repositoryItem.values[propertyName] = val;
+                    } else {
+                        val.setValueFromXml(currentProperty);
+                    }
+                })
+                logTrace('repoItem', repositoryItem);
+                return repositoryItem;
+            });
+            BDA_REPOSITORY.PERF_MONITOR.cumul('parseXmlAsObjects');
+            return res;
+        },
+
+        showNonEmptyLines: function(resultTable) {
+            resultTable.find('.item-line.hidden').each(function() {
+                let line = $(this);
+                let mustShow = _.some(line.find('.propertyValue').get(),
+                    (elem) => !_.isEmpty($(elem).attr('data-raw'))
+                );
+                if (mustShow) {
+                    line.removeClass('hidden');
+                }
+            })
+        },
+
+        buildResultTable: function(items, renderContext, repo) {
+            console.time('buildResultTable')
+            let res;
+            if (!_.isNil(items) && items.length > 0) {
+                let itemDescriptor = items[0].itemDescriptor;
+                let itemDescriptorName = itemDescriptor ? itemDescriptor.name : '';
+                let table = $(BDA_REPOSITORY.templates.resultTable.format(itemDescriptorName, repo.path));
+                let tableHead = $('<thead></thead>').appendTo(table);
+
+                let idLine = $('<tr class="id even"><th>{0}</th></tr>'.format(itemDescriptorName)).appendTo(tableHead);
+                _(items)
+                    .map(item => $(BDA_REPOSITORY.templates.idCell.format(item.id, itemDescriptorName, repo.path)).data('repositoryItem', item))
+                    .each((elem) => {
+                        elem.appendTo(idLine)
+                    });
+
+
+                // let descLineElems = _(items).map((item) => BDA_REPOSITORY.templates.descriptorCell.format(itemDescriptorName, item.id)).join('');
+                // let descLine = $('<tr class="descriptor odd"><th>descriptor</th>{0}</tr>'.format(descLineElems)).appendTo(tableHead);
+
+                let tbody = $('<tbody></tbody>').appendTo(table);
+                //for each property, get 
+                let index = 1;
+                console.time('build all items');
+                _(itemDescriptor.properties)
+                    .each((property) => {
+
+                        // hiden lines that have all null values
+                        let lineIsVisible = !!renderContext[itemDescriptor.name][property.name]
+
+                        let line = $('<tr class="item-line {0} {1}" data-property="{2}"></tr>'.format(getEvenOddClass(index), lineIsVisible ? '' : 'hidden', property.name));
+
+                        //build property name cell
+                        // the following flags have been set on the repoItem level :
+
+                        let propertyNameCell = $('<th>{0}<span class="prop_name"></span></th>'.format(property.name)).appendTo(line);
+
+                        let sampleItem = null
+
+                        if (lineIsVisible) {
+                            sampleItem = _.find(items, item => !_.isNil(item.values[property.name]));
+                            index++;
+                        }
+
+
+                        if (lineIsVisible && !_.isNil(sampleItem)) {
+                            let sampleValue = sampleItem.values[property.name];
+                            if (!!sampleValue.derived) {
+                                propertyNameCell.append('<div class="prop_attr prop_attr_green">D</div>');
+                                line.addClass('derived');
+                            }
+                            if (!!sampleValue.rdonly) {
+                                propertyNameCell.append('<div class="prop_attr prop_attr_red">R</div>');
+                                line.addClass('rdonly');
+                            }
+                            if (!!sampleValue.exportable) {
+                                propertyNameCell.append('<div class="prop_attr prop_attr_blue">E</div>');
+                                line.addClass('exportable');
+                            }
+                            if (property.isItem && !property.isItemOfSameRepository) {
+                                propertyNameCell.append('&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i>');
+                                line.addClass('other-repository');
+                            }
+                        }
+
+                        // add all cells
+                        //   console.time('build all cells');
+                        let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem, repo, lineIsVisible));
+                        // console.timeEnd('build all cells');
+                        //console.time('append all cells');
+
+                        _.each(cells, cell => cell.appendTo(line));
+
+                        //   console.timeEnd('append all cells');
+                        line.appendTo(tbody);
+
+                    });
+
+                //enable local collapse/expand
+                console.time('bind actions');
+                table
+                    .on('click', '.actions .collapse', function() {
+                        $(this).closest('.property').addClass('show-short').removeClass('show-long');
+                    })
+                    .on('click', '.actions .expand', function() {
+                        $(this).closest('.property').removeClass('show-short').addClass('show-long');
+                    })
+                    .on('click', '.actions .start-edit', function() {
+                        BDA_REPOSITORY.onEdit($(this));
+
+                    })
+                    .on('click', '.id .reload-item', function() {
+                        BDA_REPOSITORY.onReload(this);
+                    })
+                    .on('click', '.id .copy-xml', function() {
+                        copyToClipboard($(this).closest('.property').data('repositoryItem').rawXml);
+                    })
+                    .on('click', '.id .close-elem', function() {
+                        logTrace('close-elem', $(this));
+                        BDA_REPOSITORY.closeTab($(this).closest('.property'));
+                    })
+                console.timeEnd('bind actions');
+
+                console.timeEnd('build all items');
+                res = table;
+            }
+            console.timeEnd('buildResultTable')
+            return res;
+        },
+
+        buildPropertyValueCell: function(item, property, referencePropertyValue, repository, lineIsVisible) {
+            BDA_REPOSITORY.PERF_MONITOR.start('buildPropertyValueCell');
+            //    console.time('buildPropertyValueCell ' + property.name);
+            let propertyValue = item.values[property.name];
+            logTrace('buildPropertyValueCell : propertyValue', propertyValue);
+            let val;
+            try {
+                val = propertyValue.value;
+            } catch (e) {
+                val = '';
+            }
+
+            let innerVal;
+            let long = false;
+            if (val.length <= BDA_REPOSITORY.CELL_MAX_LENGTH) {
+                innerVal = BDA_REPOSITORY.templates.shortPropertyCell;
+            } else {
+                long = true;
+                let short = val.substr(0, BDA_REPOSITORY.CELL_MAX_LENGTH) + ' ...';
+                innerVal = BDA_REPOSITORY.templates.longPropertyCell.format(short);
+            }
+
+            res = $(BDA_REPOSITORY.templates.propertyCell.format(innerVal, item.id, property.name));
+            if (long) {
+                res.addClass('toggable');
+            }
+            if (propertyValue && propertyValue.isDefault) {
+                res.addClass('default');
+            }
+
+
+            // for id of other items, load sub item on click
+            let longCell = res.find('.propertyValue');
+            longCell.attr('data-raw', val);
+
+            if (lineIsVisible && property.isItem) {
+
+                BDA_REPOSITORY.buildLinkToOtherItem(longCell, val, property);
+
+            } else {
+                longCell.append(val);
+            }
+
+            // if (lineIsVisible && !_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
+            //   BDA_REPOSITORY.addInlineEditFormFromObjects(res, val, property, item, repository);
+            // }
+            BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell');
+            // console.timeEnd('buildPropertyValueCell ' + property.name);
+            return res;
+        },
+
+        onReload: function(elem) {
+            console.log('reloadItem')
+            let $this = $(elem);
+            let property = $this.closest('.property');
+            let id = property.attr('data-id');
+            let item = property.attr('data-item');
+            let repoPath = property.attr('data-repository');
+            let parentTab = $this.closest('.dataTable');
+            $this.addClass('fa-spin');
+            BDA_REPOSITORY.reloadTab(id, item, repoPath, parentTab, () => {
+                $this.removeClass('fa-spin');
+                $.notify(
+                    "Success: Reloaded {0} {1}".format(item, id), {
+                        className: "success",
+                        position: "top center",
+                        autoHideDelay: 3000
+                    }
+                );
+
+            });
+        },
+
+        onEdit: function($this) {
+            logInfo('click on start edit');
+
+            let propertyElem = $this.closest('.property');
+
+
+            if (_.isNil(propertyElem.attr('data-form-generated'))) {
+
+                try {
+
+                    let dataTable = propertyElem.closest('.dataTable');
+                    let line = propertyElem.closest('.item-line')
+
+                    let itemName = dataTable.attr('data-descriptor');
+                    let repositoryPath = dataTable.attr('data-repository');
+
+                    let itemId = propertyElem.attr('data-id');
+                    let propertyName = propertyElem.attr('data-property');
+
+
+                    let val = propertyElem.find('.propertyValue').attr('data-raw');
+
+
+                    BDA_REPOSITORY.addInlineEditForm(propertyElem, val, propertyName, itemName, itemId, repositoryPath);
+                    propertyElem.attr('data-form-generated', true);
+
+                } catch (e) {
+                    console.error(e);
+                }
+
+
+            }
+
+            propertyElem.addClass('show-edit').find('.inline-input').focus();
+        },
+
+        buildLinkToOtherItem: function(longCell, val, property) {
+            BDA_REPOSITORY.PERF_MONITOR.start('buildLinkToOtherItem');
+            // handle map types
+            let ids = _(val)
+                .split(',')
+                .map(sPair => _.split(sPair, '='))
+                .map(pairArray => {
+                    if (pairArray.length >= 2) {
+                        return {
+                            id: pairArray[1].trim(),
+                            key: pairArray[0].trim()
+                        }
+                    } else if (pairArray.length == 1) {
+                        return {
+                            id: pairArray[0].trim()
+                        }
+                    } else {
+                        return null;
+                    }
+
+                })
+                .filter(elem => !_.isNil(elem))
+                .value();
+
+            _(ids)
+                .map(elem => {
+                    let cell = $('<span class="clickable_property loadable_property {1}">{0}</span>'.format(elem.id, property.isItemOfSameRepository ? '' : 'newpage'))
+                        .on('click', function() {
+
+                            if (property.isItemOfSameRepository) {
+                                let $this = $(this);
+                                try {
+                                    //find the item if same id
+                                    // load the result in the parent section (repo/itemtree/dashscreen)
+                                    let outputDiv = $this.closest('.rqlResultContainer');
+                                    let selector = '.idCell[data-id="{0}"]'.format(elem.id);
+                                    let resultTable = outputDiv.find(selector);
+                                    // if the result already exists, just scroll to it
+                                    if (resultTable.length > 0) {
+                                        resultTable.scrollTo();
+                                        resultTable.find('[data-id="{0}"]'.format(elem.id)).flash(); //flash the whole tab
+                                    } else {
+                                        let $property = $this.parent().parent();
+                                        $property.addClass('loading');
+                                        let endLoadingFc = () => {
+                                            $property.removeClass('loading');
+                                        };
+                                        BDA_REPOSITORY.loadSubItem(elem.id, property.itemType, property.itemRepository, outputDiv, null, null, endLoadingFc);
+                                    }
+                                } catch (e) {
+                                    console.error(e)
+                                }
+
+                            } else {
+                                //create a form that will post to a new tab
+                                try {
+
+                                    var xmlText = BDA_REPOSITORY.templates.printItem.format(property.itemType, elem.id);
+                                    let form = $('<form  action="/dyn/admin/nucleus{0}/" method="POST" target="_blank"><textarea name="xmltext" ></textarea><input value="Enter" type="submit"></form>'.format(property.itemRepository));
+                                    form
+                                        .appendTo('body')
+                                        .find('textarea')
+                                        .val(xmlText)
+                                        .end()
+                                        .submit()
+                                        .remove();
+
+                                } catch (e) {
+                                    console.error(e);
+                                }
+                            }
+                        });
+                    return {
+                        key: elem.key,
+                        cell: cell
+                    }
+
+                })
+                .each((elem, idx) => {
+                    if (!_.isNil(elem.key)) {
+                        longCell.append('{0} = '.format(elem.key));
+                    }
+                    longCell.append(elem.cell)
+                    if (idx < ids.length - 1) {
+                        longCell.append(' , ');
+                    }
+                });
+            BDA_REPOSITORY.PERF_MONITOR.cumul('buildLinkToOtherItem');
+        },
+
+        addInlineEditFormFromObjects: function(output, val, property, item, repository) {
+            BDA_REPOSITORY.addInlineEditForm(output, val, property.name, item.id, repository.path);
+        },
+
+        addInlineEditForm: function(output, val, propertyName, itemName, itemId, repositoryPath) {
+            BDA_REPOSITORY.PERF_MONITOR.start('addInlineEditForm');
+            logInfo('addInlineEditForm', arguments);
+            try {
+
+                let form = $('<form class="edit"></form>');
+                let input = $('<textarea class="inline-input" rows="1"></input>').val(val);
+                input.appendTo(form);
+                input.on('blur', function() {
+
+                    try {
+
+                        let newVal = input.val();
+                        if (newVal === val) {
+                            input.closest('.property').removeClass('show-edit');
+                            return; // exit if no change
+                        }
+                        var xmlText = BDA_REPOSITORY.templates.editProperty.format(itemName, itemId, propertyName, newVal);
+                        let highlighted = $('<div class="xml"><pre><code></code></pre></div>');
+                        highlighted.find('code').text(xmlText);
+                        highlighted.each(function(i, block) {
+                            hljs.highlightBlock(block);
+                        })
+
+                        $('body').bdaAlert({
+                            msg: 'You are about to execute this query : \n {0}'.format(highlighted.html()),
+                            options: [{
+                                label: 'Confirm',
+                                _callback: function() {
+                                    BDA_REPOSITORY.executeQuery('', xmlText, repositoryPath,
+                                        (result) => {
+                                            try {
+                                                var xmlContent = $('<div>' + result + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
+                                                let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
+
+                                                let parentTab = input.closest('.dataTable');
+                                                BDA_REPOSITORY.reloadTab(itemId, itemName, repositoryPath, parentTab, () => {
+
+                                                    $.notify(
+                                                        "Success: \n{0}".format(logs), {
+                                                            className: "success",
+                                                            position: "top center",
+                                                            autoHideDelay: 5000
+
+                                                        }
+                                                    );
+
+                                                });
+
+                                            } catch (e) {
+                                                console.error(e);
+                                            }
+
+                                        },
+                                        (jqXHR, textStatus, errorThrown) => {
+                                            $.notify(
+                                                "Error during call: {0}.".format(errorThrown), {
+                                                    className: "error",
+                                                    position: "top center",
+                                                    autoHide: false
+                                                }
+                                            );
+                                        });
+                                }
+                            }, {
+                                label: 'Cancel'
+                            }]
+                        });
+                    } catch (e) {
+                        console.error(e);
+                    }
+
+                })
+                output.append(form);
+            } catch (e) {
+                console.error(e);
+            }
+            BDA_REPOSITORY.PERF_MONITOR.cumul('addInlineEditForm');
+
+        },
+        closeTab: function(idCell, container) {
+            try {
+                logTrace('closetab', idCell);
+                let tab = idCell.closest('.dataTable');
+                tab.find('[data-id="{0}"]'.format(idCell.attr('data-id'))).remove();
+                //if last item remove tab
+                let tabSize = tab.find('.idCell').length;
+                let container = tab.closest('.rqlResultContainer');
+                BDA_REPOSITORY.reloadSpeedBar(container);
+                if (tabSize == 0) {
+                    tab.remove();
+                }
+            } catch (e) {
+                console.error(e);
+            }
+
+        },
+
+        findTabToAppendTo: function(itemDescriptorName, outputDiv) {
+            let dataTables = outputDiv.find('.dataTable[data-descriptor="{0}"]'.format(itemDescriptorName));
+            var max = BDA_REPOSITORY.getChunkSize();
+            let res;
+            logTrace('dataTables', dataTables);
+            dataTables.each(function(idx, table) {
+                let $table = $(table);
+                logTrace('table', $table);
+                if ($table.find('.idCell').length < max) {
+                    res = $table;
+                }
+            })
+            return res;
+        },
+
+        appendToDataTable: function(id, itemDescriptorName, repositoryPath, dataTable, tempResult, cb) {
+            let propertySelector = '.property[data-id="{0}"]'.format(id);
+            tempResult.find(propertySelector).each(function() {
+                let $this = $(this);
+                let propertyName = $this.attr('data-property');
+                dataTable.find('.item-line[data-property="{0}"]'.format(propertyName)).append($this);
+            })
+
+            //  update the data
+            let idSelector = '.idCell[data-id="{0}"]'.format(id, itemDescriptorName);
+            dataTable.find('tr.id').append(tempResult.find(idSelector));
+            BDA_REPOSITORY.showNonEmptyLines(dataTable);
+            if (cb) {
+                cb();
+            }
+        },
+
+        reloadTab: function(id, itemDescriptorName, repositoryPath, parentTab, cb) {
+            if (_.isNil(repositoryPath)) {
+                repositoryPath = getCurrentComponentPath();
+            }
+            BDA_REPOSITORY.executePrintItem('', itemDescriptorName, id, repositoryPath,
+                function(result) {
+                    BDA_REPOSITORY.parseXhrResult(result, repositoryPath, (parsed) => {
+
+                        try {
+
+                            let tempResult = $('<div></div>');
+                            BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, tempResult);
+
+                            let propertySelector = '.property[data-id="{0}"]'.format(id);
+                            tempResult.find(propertySelector).each(function() {
+                                let $this = $(this);
+                                let propertyName = $this.attr('data-property');
+                                parentTab.find(propertySelector + '[data-property="{0}"]'.format(propertyName)).replaceWith(this);
+                            })
+
+                            //  update the data
+                            let idSelector = '.idCell[data-identifier="id_{0}_{1}"]'.format(id, itemDescriptorName);
+                            parentTab.find(idSelector).replaceWith(tempResult.find(idSelector));
+
+                            parentTab.find('[data-id="{0}"]'.format(id)).flash();
+
+                            BDA_REPOSITORY.showNonEmptyLines(parentTab);
+
+                            if (cb) {
+                                cb();
+                            }
+                        } catch (e) {
+                            console.error(e);
+                        }
+
+                    })
+                },
+
+                function(jqXHR, textStatus, errorThrown) {
+                    $.notify(
+                        "Error during call: " + errorThrown + ".", {
+                            className: "error",
+                            position: "top center"
+                        }
+                    );
+
+                })
+        },
+
+        // load sub item with an ajax call
+        loadSubItem: function(id, itemDescriptorName, repositoryPath, $outputDiv, cbSuccess, cbErr, cbEnd) {
+            if (_.isNil(repositoryPath)) {
+                repositoryPath = getCurrentComponentPath();
+            }
+
+            // : function(domain, itemDescriptor, id, repository, callback, errCallback) {
+            BDA_REPOSITORY.executePrintItem('', itemDescriptorName, id, repositoryPath,
+                function(result) {
+                    BDA_REPOSITORY.parseXhrResult(result, repositoryPath, (parsed) => {
+
+                        let temp = $('<div></div>');
+
+                        let top = BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, temp);
+                        //use the itemDescriptor from the result, not the query (ex payment group vs creditCard)
+
+                        let resultDescriptorName = _.first(parsed.items).itemDescriptor.name;
+                        let targetTab = BDA_REPOSITORY.findTabToAppendTo(resultDescriptorName, $outputDiv);
+                        if (_.isNil(targetTab) || targetTab.length === 0) {
+                            temp.children().appendTo($outputDiv);
+                        } else {
+                            BDA_REPOSITORY.appendToDataTable(id, resultDescriptorName, repositoryPath, targetTab, temp);
+                            top = targetTab;
+                        }
+
+                        BDA_REPOSITORY.reloadSpeedBar($outputDiv);
+                        if (top) {
+                            top.scrollTo();
+                            top.find('[data-id="{0}"]'.format(id)).flash();
+                        }
+                        if (cbSuccess) {
+                            cbSuccess();
+                        }
+                        if (cbEnd) {
+                            cbEnd();
+                        }
+                    });
+                },
+                function(jqXHR, textStatus, errorThrown) {
+                    $.notify(
+                        "Error during call: " + errorThrown + ".", {
+                            className: "error",
+                            position: "top center"
+                        }
+                    );
+                    if (cbErr) {
+                        cbErr();
+                    }
+                    if (cbEnd) {
+                        cbEnd();
+                    }
+                }
+            )
+        },
+
+        oldShowXMLAsTab: function(xmlContent, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
+
+
+            console.time("oldShowXMLAsTab");
+            var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
+            var $xml = $(xmlDoc);
+            var $addItems = $xml.find("add-item");
+            var types = {};
+            var datas = [];
+            var nbTypes = 0;
+            var typesNames = {};
+
+            var log = $("<xml>" + xmlContent + "</xml>")
+                .children()
+                .remove()
+                .end()
+                .text()
+                .trim();
+
+            var descriptorAndDefaultValues = {};
+            if ($xmlDef != null) {
+                for (var i = 0; i < $addItems.length; i++) {
+                    var itemDescriptor = $addItems[i].getAttribute("item-descriptor");
+
+                    if (descriptorAndDefaultValues.hasOwnProperty(itemDescriptor) === false) {
+                        BDA_REPOSITORY.getDescriptorAndDefaultValues(itemDescriptor, $xmlDef, descriptorAndDefaultValues);
+                    }
+                    for (var defaultPropertyName in descriptorAndDefaultValues[itemDescriptor]) {
+                        var exists = $($addItems[i]).find("[name=" + defaultPropertyName + "]").length;
+                        if (exists == 0) {
+                            $addItems[i].innerHTML += '<set-property name="' + defaultPropertyName + '"><![CDATA[' + descriptorAndDefaultValues[itemDescriptor][defaultPropertyName] + ']]></set-property>';
+                        }
+                    }
+                }
+            }
+
+
+            $addItems.each(function() {
+                var curItemDesc = "_" + $(this).attr("item-descriptor");
+                if (!types[curItemDesc])
+                    types[curItemDesc] = [];
+                if (!typesNames[curItemDesc])
+                    typesNames[curItemDesc] = [];
+                if (!datas[curItemDesc]) {
+                    datas[curItemDesc] = [];
+                    nbTypes++;
+                }
+                var curData = {};
+
+                $(this).find("set-property").each(function(index) {
+                    var $curProp = $(this);
+                    curData[$curProp.attr("name")] = $curProp.text();
+                    var type = {};
+                    type.name = $curProp.attr("name");
+                    if ($.inArray(type.name, typesNames[curItemDesc]) == -1) {
+                        type.rdonly = $curProp.attr("rdonly");
+                        type.derived = $curProp.attr("derived");
+                        type.exportable = $curProp.attr("exportable");
+                        var typeItemDesc = BDA_REPOSITORY.isTypeId(type.name, curItemDesc.substr(1), $xmlDef);
+                        if (typeItemDesc === null)
+                            type.isId = false;
+                        else {
+                            type.isId = true;
+                            type.itemDesc = typeItemDesc;
+                        }
+                        types[curItemDesc].push(type);
+                        typesNames[curItemDesc].push(type.name);
+                    }
+                });
+                if ($.inArray("descriptor", typesNames[curItemDesc]) == -1) {
+                    var typeDescriptor = {};
+                    typeDescriptor.name = "descriptor";
+                    types[curItemDesc].unshift(typeDescriptor);
+                    typesNames[curItemDesc].push("descriptor");
+                }
+                if ($.inArray("id", typesNames[curItemDesc]) == -1) {
+                    var typeId = {};
+                    typeId.name = "id";
+                    types[curItemDesc].unshift(typeId);
+                    typesNames[curItemDesc].push("id");
+                }
+                curData.descriptor = curItemDesc;
+                curData.id = $(this).attr("id");
+                datas[curItemDesc].push(curData);
+            });
+            var html = "<p class='nbResults'>" + $addItems.length + " items in " + nbTypes + " descriptor(s)</p>";
+            var splitValue;
+            var splitObj = BDA_STORAGE.getStoredSplitObj();
+            if (splitObj === undefined || splitObj === null || splitObj.activeSplit === true)
+                splitValue = 0;
+            else
+                splitValue = parseInt(splitObj.splitValue);
+            for (var itemDesc in datas) {
+                if (splitValue === 0)
+                    splitValue = datas[itemDesc].length;
+                var nbTab = 0;
+                if (datas[itemDesc].length <= splitValue) {
+                    html += BDA_REPOSITORY.renderTab(itemDesc, types[itemDesc], datas[itemDesc], itemDesc.substr(1), isItemTree);
+                } else {
+                    while ((splitValue * nbTab) < datas[itemDesc].length) {
+                        var start = splitValue * nbTab;
+                        var end = start + splitValue;
+                        if (end > datas[itemDesc].length)
+                            end = datas[itemDesc].length;
+                        var subDatas = datas[itemDesc].slice(start, end);
+                        html += BDA_REPOSITORY.renderTab(itemDesc, types[itemDesc], subDatas, itemDesc + "_" + nbTab, isItemTree);
+                        nbTab++;
+                    }
+                }
+            }
+            $outputDiv.append(html);
+            $outputDiv.prepend("<div class='prop_attr prop_attr_red'>R</div> : read-only " + "<div class='prop_attr prop_attr_green'>D</div> : derived " + "<div class='prop_attr prop_attr_blue'>E</div> : export is false");
+
+            if ($(".copyField").length > 0) {
+                // reuse $outputDiv in case we have several results set on the page (RQL query + get item tool)
+                $outputDiv.find("p.nbResults").append("<br><a href='javascript:void(0)' class='showFullTextLink'>Show full text</a>");
+                $outputDiv.find(".showFullTextLink").click(function() {
+                    console.time("showFullText");
+                    $(".copyField").each(function() {
+                        $(this).parent().html($(this).html());
+                    });
+                    console.timeEnd("showFullText");
+                    $(this).hide();
+                });
+            }
+
+            if (_.isNil(loadSubItemCb)) {
+                $outputDiv.find(".loadable_property").click(BDA_REPOSITORY.showLoadSubItemAlert);
+
+            } else {
+                $outputDiv.find(".loadable_property").click(loadSubItemCb);
+            }
+
+            if (isItemTree)
+                BDA_REPOSITORY.createSpeedbar();
+
+            console.timeEnd("oldShowXMLAsTab");
+            return log;
+        },
+
+        showLoadSubItemAlert: function() {
+            logTrace('click on loadable');
+            var $elm = $(this);
+            var id = $elm.attr("data-id");
+            var itemDesc = $elm.attr("data-descriptor");
+            var query = "<print-item id='" + id + "' item-descriptor='" + itemDesc + "' />\n";
+
+            $('body').bdaAlert({
+                msg: 'You are about to add this query and reload the page: \n' + query,
+                options: [{
+                    label: 'Add & Reload',
+                    _callback: function() {
+                        BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
+                        $("#RQLForm").submit();
+                    }
+                }, {
+                    label: 'Just Add',
+                    _callback: function() {
+                        BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
+                    }
+                }, {
+                    label: 'Cancel'
+                }]
+            });
+        },
+
+        showRQLLog: function(log, error) {
+            logTrace("Execution log : " + log);
+            if (log && log.length > 0) {
+                $("<h3>Execution log</h3><div id='RQLLog'></div>").insertAfter("#RQLResults");
+                var cleanLog = log.replace(/\n{2,}/g, '\n').replace(/------ /g, "").trim();
+                $("#RQLLog").html(cleanLog);
+            }
+            if (error)
+                $("#RQLLog").addClass("error");
+        },
+
+        showRQLResults: function() {
+            logTrace("Start showRQLResults");
+            // Add 'show raw xml' link
+            var html = "<p>" + "<a href='javascript:void(0)' id='rawXmlLink'>Show raw xml</a>" + "</p>\n";
+            html += "<p id='rawXml'></p>";
+            $("#RQLResults").addClass('rqlResultContainer').append(html);
+
+            var xmlContent = $(BDA_REPOSITORY.resultsSelector).next().text().trim();
+            // xmlContent = sanitizeXml(xmlContent); //sanitize later
+
+            BDA_REPOSITORY.PERF_MONITOR.reset();
+            BDA_REPOSITORY.PERF_MONITOR.start('processRepositoryXmlDef');
+            processRepositoryXmlDef("definitionFiles", function($xmlDef) {
+                BDA_REPOSITORY.PERF_MONITOR.cumul('processRepositoryXmlDef');
+                var log = BDA_REPOSITORY.showXMLAsTab(xmlContent, $xmlDef, $("#RQLResults"), false);
+                BDA_REPOSITORY.showRQLLog(log, false);
+                // Move raw xml
+                $(BDA_REPOSITORY.resultsSelector).next().appendTo("#rawXml");
+                $(BDA_REPOSITORY.resultsSelector).remove();
+
+                $("#rawXmlLink").click(function() {
+                    BDA_REPOSITORY.toggleRawXml();
+                    var xmlSize = $("#rawXml pre").html().length;
+                    logTrace("raw XML size : " + xmlSize);
+                    logTrace("XML max size : " + BDA_REPOSITORY.xmlDefinitionMaxSize);
+                    if (xmlSize < BDA_REPOSITORY.xmlDefinitionMaxSize) {
+                        $('#rawXml').each(function(i, block) {
+                            hljs.highlightBlock(block);
+                        });
+                    } else {
+                        // Check if button already exists
+                        if ($("#xmlHighlight").length === 0) {
+                            $("<p id='xmlHighlight' />")
+                                .html("The XML result is big, to avoid slowing down the page, XML highlight have been disabled. " + "<br> <button id='xmlHighlightBtn'>Highlight XML now</button> <small>(takes few seconds)</small>")
+                                .prependTo($("#rawXml"));
+                            $("#xmlHighlightBtn").click(function() {
+                                $('#rawXml pre').each(function(i, block) {
+                                    hljs.highlightBlock(block);
+                                });
+                            });
+                        }
+                    }
+                });
+
+                $(".copyLink").click(function() {
+                    BDA_REPOSITORY.showTextField($(this).attr("id").replace("link_", ""));
+                });
+            });
+        },
+
+        showRqlErrors: function() {
+            var error = "";
+            if ($(BDA_REPOSITORY.errorsSelector1).length > 0) {
+                logTrace("Case of error  : 1");
+                error = $(BDA_REPOSITORY.errorsSelector1).next().text();
+                $(BDA_REPOSITORY.resultsSelector).next().remove();
+                $(BDA_REPOSITORY.resultsSelector).remove();
+                $(BDA_REPOSITORY.errorsSelector1).next().remove();
+                $(BDA_REPOSITORY.errorsSelector1).remove();
+            } else {
+                logTrace("Case of error  : 2");
+                error = $(BDA_REPOSITORY.errorsSelector2).text();
+            }
+            error = BDA_REPOSITORY.purgeXml(error);
+            BDA_REPOSITORY.showRQLLog(error, true);
+        },
+
+        escapeHTML: function(s) {
+            return String(s).replace(/&(?!\w+;)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+        },
+
+        propertiesDef: function(hljs) {
+            logTrace("propertiesDef");
+            return {
+                case_insensitive: true,
+                contains: [{
+                    className: 'comment',
+                    begin: '#',
+                    end: '$'
+                }, {
+                    className: 'setting',
+                    begin: '^[a-z0-9\\[\\]_-]+[ \\t]*=[ \\t]*',
+                    end: '$',
+                    contains: [{
+                        className: 'value',
+                        endsWithParent: true,
+                        keywords: 'on off true false yes no',
+                        contains: [hljs.QUOTE_STRING_MODE, hljs.NUMBER_MODE],
+                        relevance: 0
+                    }]
+                }]
+            };
+        },
+
+        //--- Item Tree functions ------------------------------------------------------------------------
+
+        setupItemTreeForm: function() {
+            $("<div id='itemTree' />").insertAfter("#RQLEditor");
+            var $itemTree = $("#itemTree");
+            $itemTree.append("<h2>Get Item Tree</h2>");
+            $itemTree.append("<p>This tool will recursively retrieve items and print the result with the chosen output." + "<br> For example, if you give an order ID in the form below, you will get all shipping groups, payment groups, commerceItems, priceInfo... of the given order" + "<br><b> Be careful when using this tool on a live instance ! Set a low max items value.</b></p>");
+
+            $itemTree.append("<div id='itemTreeForm'>" + "id : <input type='text' id='itemTreeId' /> &nbsp;" + "descriptor :  <span id='itemTreeDescriptorField' ><select id='itemTreeDesc' class='itemDescriptor' >" + BDA_REPOSITORY.getDescriptorOptions() + "</select></span>" + "max items : <input type='text' id='itemTreeMax' value='50' /> &nbsp;<br><br>" + "output format :  <select id='itemTreeOutput'>" + "<option value='HTMLtab'>HTML tab</option>" + "<option value='addItem'>add-item XML</option>" + "<option value='removeItem'>remove-item XML</option>" + "<option value='printItem'>print-item XML</option>" + "<option value='tree'>Tree (experimental)</option>" + "</select>&nbsp;" + "<input type='checkbox' id='printRepositoryAttr' /><label for='printRepositoryAttr'>Print attribute : </label>" + "<pre style='margin:0; display:inline;'>repository='" + getCurrentComponentPath() + "'</pre> <br><br>" + "<button id='itemTreeBtn'>Enter <i class='fa fa-play fa-x'></i></button>" + "</div>");
+            $itemTree.append("<div id='itemTreeInfo' />");
+            $itemTree.append("<div id='itemTreeResult' class='rqlResultContainer' />");
+            $("#itemTreeBtn").click(function() {
+                var descriptor = $("#itemTreeDesc").val();
+                var id = $("#itemTreeId").val().trim();
+                var maxItem = parseInt($("#itemTreeMax").val());
+                var outputType = $("#itemTreeOutput").val();
+                var printRepoAttr = $("#printRepositoryAttr").is(':checked');
+                logTrace("max item : " + maxItem);
+                BDA_REPOSITORY.getItemTree(id, descriptor, maxItem, outputType, printRepoAttr);
+            });
+
+        },
+
+        getSubItems: function(items, $xmlDef, maxItem, outputType, printRepoAttr) {
+            var nbItem = BDA_REPOSITORY.itemTree.size;
+            logTrace("maxItem : " + maxItem + ", nbItem : " + nbItem);
+
+            // Ensure that getSubItems is not call more than maxItem times
+            if (nbItem >= maxItem) {
+                logTrace("max Item (" + maxItem + ") reached, stopping recursion");
+                return;
+            }
+
+            var xmlText = "";
+            for (var batchSize = 0; batchSize != items.length; batchSize++) {
+                // Don"t ask for more items than limit
+                if ((BDA_REPOSITORY.nbItemReceived + batchSize) >= maxItem)
+                    break;
+                xmlText += "<print-item id='" + items[batchSize].id + "' item-descriptor='" + items[batchSize].desc + "' />\n";
+            }
+            logTrace(xmlText);
+            logTrace("batch size : " + batchSize);
+            // Only request if the batchSize contains something
+            if (batchSize > 0) {
+                $.ajax({
+                    type: "POST",
+                    url: document.URL,
+                    data: {
+                        xmltext: xmlText
+                    },
+                    success: function(result, status, jqXHR) {
+
+                        var rawItemsXml = $(result).find("code").html();
+                        // remove first 2 lines
+                        var tab = rawItemsXml.split("\n");
+                        tab.splice(0, 2);
+                        rawItemsXml = tab.join("\n").trim();
+                        // unescape HTML
+                        rawItemsXml = "<xml>" + rawItemsXml.replace(/&lt;/g, "<").replace(/&gt;/g, ">") + "</xml>";
+
+                        var xmlDoc = jQuery.parseXML(rawItemsXml);
+                        BDA_REPOSITORY.nbItemReceived += $(xmlDoc).find("add-item").length;
+                        $("#itemTreeInfo").html("<p>" + BDA_REPOSITORY.nbItemReceived + " items retrieved</p>");
+
+                        var subItems = [];
+                        $(xmlDoc).find("add-item").each(function() {
+                            var $itemXml = $(this);
+                            var itemId = $itemXml.attr("id");
+                            if (BDA_REPOSITORY.itemTree.get(itemId) === undefined) {
+                                var rawItemXml = $itemXml[0].outerHTML;
+                                BDA_REPOSITORY.itemTree.set(itemId, rawItemXml);
+                                var descriptor = $itemXml.attr("item-descriptor");
+                                var $itemDesc = $xmlDef.find("item-descriptor[name=" + descriptor + "]");
+                                var superType = $itemDesc.attr("super-type");
+                                while (superType !== undefined) {
+                                    var $parentDesc = $xmlDef.find("item-descriptor[name=" + $itemDesc.attr("super-type") + "]");
+                                    $itemDesc = $itemDesc.add($parentDesc);
+                                    superType = $parentDesc.attr("super-type");
+                                }
+                                // One to One relation
+                                $itemDesc.find('property[item-type]')
+                                    .each(function(index, elm) {
+                                        var $elm = $(elm);
+                                        var subProperty = $elm.attr("name");
+                                        var subId = $itemXml.find("set-property[name=" + subProperty + "]").text();
+                                        if ($elm.attr("repository") === undefined && subId.length > 0) {
+                                            // avoid infinite recursion
+                                            if (BDA_REPOSITORY.itemTree.get(subId) === undefined) {
+                                                subItems.push({
+                                                    'id': subId,
+                                                    'desc': $elm.attr("item-type")
+                                                });
+                                            }
+                                        }
+                                    });
+
+                                // One to Many relation with list, array or map
+                                $itemDesc.find('property[component-item-type]')
+                                    .each(function(index, elm) {
+                                        var $elm = $(elm);
+                                        var subProperty = $elm.attr("name");
+                                        var subId = $itemXml.find("set-property[name=" + subProperty + "]").text();
+                                        if ($elm.attr("repository") === undefined && subId.length > 0) {
+                                            var desc = $elm.attr("component-item-type");
+                                            var ids = BDA_REPOSITORY.parseRepositoryId(subId);
+                                            for (var i = 0; i != ids.length; i++) {
+                                                // avoid infinite recursion
+                                                if (ids[i] !== BDA_REPOSITORY.MAP_SEPARATOR && ids[i] !== BDA_REPOSITORY.LIST_SEPARATOR && BDA_REPOSITORY.itemTree.get(ids[i]) === undefined)
+                                                    subItems.push({
+                                                        'id': ids[i],
+                                                        'desc': desc
+                                                    });
+                                            }
+                                        }
+                                    });
+                            }
+                        });
+
+                        logTrace(subItems.length + " items to retrieved in next request. Limit reach : " + (BDA_REPOSITORY.nbItemReceived >= maxItem));
+                        if (subItems.length > 0 && BDA_REPOSITORY.nbItemReceived < maxItem)
+                            BDA_REPOSITORY.getSubItems(subItems, $xmlDef, maxItem, outputType, printRepoAttr);
+                        else
+                            BDA_REPOSITORY.renderItemTreeTab(outputType, printRepoAttr, $xmlDef, maxItem);
+                    },
+                });
+            } else
+                logTrace("Request is empty, nothing to do.");
+        },
+
+        getItemTree: function(id, descriptor, maxItem, outputType, printRepoAttr) {
+            logTrace("getItemTree - start");
+            // reset divs
+            $("#itemTreeResult").empty();
+            $("#itemTreeInfo").empty();
+
+            if (!id) {
+                $("#itemTreeInfo").html("<p>Please provide a valid ID</p>");
+                return;
+            }
+
+            console.time("getItemTree");
+            console.time("retrieveItem");
+            // Get XML definition of the repository
+            $("#itemTreeInfo").html("<p>Getting XML definition of this repository...</p>");
+            var $xmlDef = processRepositoryXmlDef("definitionFiles", function($xmlDef) {
+                if (!$xmlDef) {
+                    $("#itemTreeInfo").html("<p>Unable to parse XML definition of this repository !</p>");
+                    return;
+                }
+                logTrace("descriptor : " + $xmlDef.find("item-descriptor").length);
+                // get tree
+                BDA_REPOSITORY.itemTree = new Map();
+                BDA_REPOSITORY.nbItemReceived = 0;
+                BDA_REPOSITORY.getSubItems([{
+                    'id': id,
+                    'desc': descriptor
+                }], $xmlDef, maxItem, outputType, printRepoAttr);
+            });
+        },
+
+        renderItemTreeTab: function(outputType, printRepoAttr, $xmlDef, maxItem) {
+            console.timeEnd("retrieveItem");
+            logTrace("Render item tree tab : " + outputType);
+
+            //  If the max item is reached before recursion ended, we notify the user
+            if (BDA_REPOSITORY.nbItemReceived >= maxItem) {
+                $.notify(
+                    "Item tree stopped because the maximum items limit was reached : " + maxItem + ".", {
+                        className: "warn",
+                        position: "top center"
+                    }
+                );
+            }
+
+            $("#itemTreeInfo").empty();
+            $("#itemTreeResult").empty();
+            var res = "";
+            if (outputType !== "HTMLtab" && outputType != "tree") {
+                logTrace("Render copy button");
+                $("#itemTreeInfo").append("<input type='button' id='itemTreeCopyButton' value='Copy result to clipboard'></input>");
+                $('#itemTreeCopyButton').click(function() {
+                    copyToClipboard($('#itemTreeResult').text());
+                });
+            }
+            if (outputType == "addItem") {
+                BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+                    if (printRepoAttr) {
+                        var xmlDoc = jQuery.parseXML(data);
+                        var $itemXml = $(xmlDoc).find("add-item");
+                        $itemXml.attr("repository", getCurrentComponentPath());
+                        res += $itemXml[0].outerHTML;
+                    } else
+                        res += data;
+                    res += "\n\n";
+                }, BDA_REPOSITORY.itemTree);
+                res = "<import-items>\n" + res + "\n</import-items>";
+                $("#itemTreeResult").append("<pre />");
+                $("#itemTreeResult pre").text(res);
+            } else if (outputType == "HTMLtab") {
+                BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+                    res += data;
+                }, BDA_REPOSITORY.itemTree);
+                BDA_REPOSITORY.showXMLAsTab(res, $xmlDef, $("#itemTreeResult"), true);
+            } else if (outputType == "removeItem" || outputType == "printItem") {
+                BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+                    var xmlDoc = jQuery.parseXML(data);
+                    var $itemXml = $(xmlDoc).find("add-item");
+                    res += "<";
+                    if (outputType == "removeItem")
+                        res += "remove-item";
+                    else
+                        res += "print-item";
+                    res += ' id="' + $itemXml.attr("id") + '" item-descriptor="' + $itemXml.attr("item-descriptor") + "\"";
+                    if (printRepoAttr)
+                        res += " repository='" + getCurrentComponentPath() + "'";
+                    res += ' />\n';
+                }, BDA_REPOSITORY.itemTree);
+
+                $("#itemTreeResult").append("<pre />");
+                $("#itemTreeResult pre").text(res);
+            } else if (outputType == "tree") {
+                BDA_REPOSITORY.renderAsTree($xmlDef);
+            }
+
+            console.timeEnd("getItemTree");
+        },
+
+        renderAsTree: function($xmlDef) {
+            logTrace("render as tree");
+            console.time('renderAsTree.setup');
+            var nodes = new vis.DataSet();
+            var edges = new vis.DataSet();
+            var legends = new Map();
+            var descById = new Map();
+            var itemIdToVisId = {};
+            var i = 0;
+            BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+                itemIdToVisId[id] = i;
+                i++;
+            });
+
+            BDA_REPOSITORY.itemTree.forEach(function(data, id) {
+                var xmlDoc = $.parseXML("<xml>" + data + "</xml>");
+                var $xml = $(xmlDoc);
+                var $addItem = $xml.find("add-item").first();
+                var itemDesc = $addItem.attr("item-descriptor");
+                var itemId = $addItem.attr("id");
+
+                $addItem.children().each(function(index) {
+                    var $this = $(this);
+                    var propertyName = $this.attr("name");
+                    var propertyValue = $this.text();
+                    if (BDA_REPOSITORY.edgesToIgnore.indexOf(propertyName) === -1) {
+                        var isId = BDA_REPOSITORY.isTypeId(propertyName, itemDesc, $xmlDef)
+                        if (isId != null && isId != "FOUND_NOT_ID") {
+                            var idAsTab = BDA_REPOSITORY.parseRepositoryId(propertyValue);
+                            for (var i = 0; i != idAsTab.length; i++) {
+                                if (idAsTab[i] != "," && idAsTab[i] != "=") {
+                                    edges.add({
+                                        from: itemIdToVisId[itemId],
+                                        to: itemIdToVisId[idAsTab[i]],
+                                        arrows: 'to',
+                                        title: propertyName
+                                    });
+                                }
+                            }
+                        }
+                    }
+                });
+
+                var nodeColor = colorToCss(stringToColour(itemDesc));
+                nodes.add({
+                    id: itemIdToVisId[itemId],
+                    label: itemDesc + "\n" + itemId,
+                    color: nodeColor,
+                    shape: 'box'
+                });
+                legends.set(itemDesc, nodeColor);
+
+                if (descById.get(itemDesc))
+                    descById.get(itemDesc).push(itemId);
+                else
+                    descById.set(itemDesc, [itemId]);
+            });
+            console.timeEnd('renderAsTree.setup');
+            // Create popup
+            $("#itemTreeResult").empty()
+                .append("<div class='popup_block' id='treePopup'>" + "<div><a href='javascript:void(0)' class='close'><i class='fa fa-times'></i></a></div>" + "<div id='treeLegend'></div>" + "<div class='flexContainer'>" + "<div id='treeInfo'></div>" + "<div id='treeContainer'></div>" + "</div>" + "</div>");
+            $("#treePopup .close").click(function() {
+                logTrace("click on close");
+                $("#treePopup").hide();
+            });
+
+            // Setup legend
+            legends.forEach(function(value, key) {
+                $("#treeLegend").append("<div class='legend' style='background-color:" + value + "' id='" + key + "'>" + key + "</div>");
+            });
+
+            logTrace("Number for nodes : " + nodes.length);
+            logTrace("Number for edges : " + edges.length);
+
+            $("#treePopup").show();
+            console.time('renderAsTree.render');
+
+            // Create the network
+            var data = {
+                nodes: nodes,
+                edges: edges
+            };
+
+            var options = {
+                physics: {
+                    stabilization: false
+                },
+                edges: {
+                    smooth: true
+                },
+                nodes: {
+                    font: {
+                        color: "#FFFFFF"
+                    }
+                }
+            };
+
+            var container = document.getElementById('treeContainer');
+            var network = new vis.Network(container, data, options);
+            console.timeEnd('renderAsTree.render')
+
+            network.on("click", function(params) {
+                params.event = "[original event]";
+                if (params.nodes && params.nodes.length == 1) {
+                    $("#treeInfo").empty();
+                    var visId = params.nodes[0];
+                    var itemId = null;
+                    logTrace("Click on " + visId);
+                    // Find itemId from visID
+                    for (var id in itemIdToVisId) {
+                        if (visId === itemIdToVisId[id]) {
+                            itemId = id;
+                            break;
+                        }
+                    }
+                    logTrace("itemId : " + itemId);
+                    logTrace(BDA_REPOSITORY.itemTree.get(itemId));
+                    BDA_REPOSITORY.showXMLAsTab(BDA_REPOSITORY.itemTree.get(itemId), null, $("#treeInfo"), false);
+                    logTrace($("#treeInfo").html());
+                    $("#treeInfo").show();
+                }
+            });
+
+            $(".legend").click(function() {
+                // This feature is disabled for now.
+                return;
+                logTrace("click on legend");
+                var id = $(this).attr('id');
+                logTrace(id);
+                var ids = descById.get(id);
+                var nodesAndEdgesToHide = {};
+                for (var i = 0; i != ids.length; i++) {
+                    nodesAndEdgesToHide = BDA_REPOSITORY.findNodesAndEdgesToHide(ids[i], network, edges, nodes);
+
+                    // Foreach nodesAndEdgesToHide.nodes
+                    for (var a = 0; a != nodesAndEdgesToHide.nodes.length; a++) {
+                        nodes.update([{
+                            id: nodesAndEdgesToHide.nodes[a],
+                            hidden: true
+                        }]);
+                    }
+                    // Foreach nodesAndEdgesToHide.edges
+                    for (var a = 0; a != nodesAndEdgesToHide.edges.length; a++) {
+                        edges.update([{
+                            id: nodesAndEdgesToHide.edges[a],
+                            hidden: true
+                        }]);
+                    }
+                }
+            });
+        },
+
+        findNodesAndEdgesToHide: function(id, network, edges, nodes) {
+            logTrace("findNodesAndEdgesToHide for ID : " + id);
+            var nodesAndEdgesToHide = {};
+            nodesAndEdgesToHide.nodes = BDA_REPOSITORY.findOrphanSon(id, network, edges, nodes, [id]);
+            nodesAndEdgesToHide.edges = [];
+            for (var i = 0; i != nodesAndEdgesToHide.nodes.length; i++) {
+                nodesAndEdgesToHide.edges = nodesAndEdgesToHide.edges.concat(network.getConnectedEdges(nodesAndEdgesToHide.nodes[i]));
+            }
+            logTrace("nodesAndEdgesToHide.nodes : ");
+            logTrace(nodesAndEdgesToHide.nodes);
+            logTrace("nodesAndEdgesToHide.edges : ");
+            logTrace(nodesAndEdgesToHide.edges);
+            return nodesAndEdgesToHide;
+        },
+
+        findOrphanSon: function(id, network, edges, nodes, orphanSons) {
+            logTrace("About to find orphan for node : " + id);
+            edges.forEach(function(elm) {
+                //logTrace(elm);
+                if (elm.from == id) {
+                    var isOrphan = true;
+                    var connectedEdges = network.getConnectedEdges(elm.to);
+
+                    for (var i = 0; i != connectedEdges.length; i++) {
+                        var edge = edges.get(connectedEdges[i]);
+                        logTrace("connectedEdge - from : " + edge.to + " - " + edge.from);
+                        if (edge.to == elm.to && edge.from != id) {
+                            isOrphan = false;
+                            break;
+                        }
+                    }
+                    if (isOrphan && orphanSons.indexOf(elm.to) === -1) {
+                        logTrace(elm.to + " is a new orphan son of node : " + id);
+                        orphanSons.push(elm.to);
+                        BDA_REPOSITORY.findOrphanSon(elm.to, network, edges, nodes, orphanSons);
+                    }
+                }
+            });
+            return orphanSons;
+        },
+
+
+        createSpeedbar_new: function(resultElem) {
+            logTrace('createSpeedbar_new')
+            try {
+
+                let speedbar = $('<div class="speedbar"><div class="widget"><i class="fa fa-times close"></i><p>Quick links :</p><ul></ul></div></div>');
+                speedbar.find('.close').on('click', () => {
+                    speedbar.fadeOut(200);
+                })
+
+                let list = speedbar.find('ul');
+                resultElem.find(".dataTable").each(function(index) {
+                    var $tab = $(this);
+                    var id = $tab.attr("id");
+                    var descriptor = $tab.attr('data-descriptor');
+
+                    var nbItem = $tab.find("td").length / $tab.find("tr").length;
+                    let elem = $("<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<span class='clickable_property'>" + descriptor + "</span> (" + nbItem + ")</li>");
+                    elem.on('click', () => $tab.scrollTo());
+                    list.append(elem);
+                });
+                speedbar.prependTo(resultElem);
+
+                let container = $(resultElem);
+
+                let widget = speedbar.find('.widget');
+                let initialTop = container.offset().top;
+                var initialBot = initialTop + container.height();
+                $(window).scroll(function() {
+                    var windowTop = $(window).scrollTop();
+                    if (initialTop < windowTop && initialBot > windowTop) {
+                        widget.addClass('sticky-top-100');
+                    } else {
+                        widget.removeClass('sticky-top-100');
+                    }
+                });
+
+            } catch (e) {
+                console.error(e);
+            }
+
+        },
+
+        reloadSpeedBar: function(resultElem) {
+            resultElem.find('.speedbar').remove();
+            BDA_REPOSITORY.createSpeedbar_new(resultElem);
+        },
+
+        createSpeedbar: function() {
+            var speedBarHtml = "<a class='close' href='javascript:void(0)'><i class='fa fa-times'></i></a><p>Quick links :</p><ul>";
+            $("#itemTreeResult .dataTable").each(function(index) {
+                var $tab = $(this);
+                var id = $tab.attr("id");
+                var name = id;
+                if (id.indexOf("_") != -1) {
+                    var tab = id.split("_");
+                    name = tab[1];
+                }
+                var nbItem = $tab.find("td").length / $tab.find("tr").length;
+                speedBarHtml += "<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<a href='#" + id + "'>" + name.trim() + " (" + nbItem + ")</a></li>";
+            });
+            speedBarHtml += "</ul>";
+            $("#itemTreeInfo").append("<div id='speedbar'><div id='widget' class='sticky'>" + speedBarHtml + "</div></div>");
+            $('#speedbar .close').click(function() {
+                $("#speedbar").fadeOut(200);
+            });
+            var stickyTop = $('.sticky').offset().top;
+            $(window).scroll(function() { // scroll event
+                var windowTop = $(window).scrollTop();
+                if (stickyTop < windowTop)
+                    $('.sticky').css({
+                        position: 'fixed',
+                        top: 100
+                    });
+                else
+                    $('.sticky').css('position', 'static');
+            });
+        },
+
+
+        showQueryList: function() {
+            var html = "";
+            // fix delete query : the index used to delete was not correct
+            // we need to keep original index
+            var rqlQueries = BDA_STORAGE.getStoredRQLQueries();
+            var currComponentName = getComponentNameFromPath(getCurrentComponentPath());
+            var nbQuery = 0;
+            if (rqlQueries && rqlQueries.length > 0) {
+                html += "<ul>";
+                for (var i = 0; i != rqlQueries.length; i++) {
+                    var storeQuery = rqlQueries[i];
+                    if (!storeQuery.hasOwnProperty("repo") || storeQuery.repo == currComponentName) {
+                        var escapedQuery = $("<div>").text(storeQuery.query).html();
+                        html += "<li class='savedQuery'>";
+                        html += "<a href='javascript:void(0)'>" + storeQuery.name + "</a>";
+                        html += "<span id='previewQuery" + i + "'class='previewQuery'>";
+                        html += "<i class='fa fa-eye'></i>";
+                        html += "</span>";
+                        html += "<span id='deleteQuery" + i + "'class='deleteQuery'>";
+                        html += "<i class='fa fa-trash-o'></i>";
+                        html += "</span>";
+                        html += "<span id='queryView" + i + "'class='queryView'>";
+                        html += "<pre>" + escapedQuery + "</pre>";
+                        html += "</span>";
+                        html += "</li>";
+                        nbQuery++;
+                    }
+                }
+                html += "</ul>";
+                if (nbQuery > 0)
+                    $("#storedQueries").html(html);
+            }
+
+            // $('#storedQueries .queryView').each(function(i, block) {
+            //   hljs.highlightBlock(block);
+            // });
+
+            $(".savedQuery").on('click', 'a', function() {
+                logTrace("click on query : " + $(this).find("a").html());
+                BDA_REPOSITORY.printStoredQuery($(this).find("a").html());
+            });
+
+            $(".previewQuery").on('click', function() {
+
+                try {
+
+
+                    let block = $(this).parent("li").find("span.queryView").each(function(i, block) {
+                        hljs.highlightBlock(block);
+                    });
+
+                    $('body').bdaAlert({
+                        msg: block.html(),
+                        width: '900px',
+                        options: [{
+                            label: 'OK'
+                        }]
+                    });
+                } catch (e) {
+                    console.error(e);
+                }
+
+
+            });
+
+            $(".deleteQuery")
+                .click(function() {
+                    var index = this.id.replace("deleteQuery", "");
+                    logTrace("Delete query #" + index);
+                    logTrace(BDA_STORAGE.deleteRQLQuery);
+                    BDA_STORAGE.deleteRQLQuery(index);
+                    BDA_REPOSITORY.reloadQueryList();
+                });
+        },
+
+        purgeRQLQuery: function(rqlQueries) {
+            // Purge query
+            var purgedRqlQueries = [];
+            for (var i = 0; i != rqlQueries.length; i++) {
+                var query = rqlQueries[i];
+                if (!query.hasOwnProperty("repo") || query.repo == getComponentNameFromPath(getCurrentComponentPath())) {
+                    purgedRqlQueries.push(rqlQueries[i]);
+                }
+            }
+            return purgedRqlQueries;
+        },
+
+        reloadQueryList: function() {
+            $("#storedQueries").empty();
+            BDA_REPOSITORY.showQueryList();
+        },
+
+        printStoredQuery: function(name) {
+            logTrace("printStoredQuery : " + name);
+            var rqlQueries = BDA_STORAGE.getStoredRQLQueries();
+            logTrace(rqlQueries);
+            if (rqlQueries) {
+                for (var i = 0; i != rqlQueries.length; i++) {
+                    if (rqlQueries[i].name == name)
+                        BDA_REPOSITORY.setQueryEditorValue(rqlQueries[i].query + "\n");
+                }
+            }
+        },
+
+        getToggleLabel: function(state) {
+            if (state == 1)
+                return "Show less...";
+            return "Show more...";
+        },
+
+        toggleShowLabel: function(contentDisplay, selector) {
+            if (contentDisplay == "none")
+                $(selector).html("Show more...");
+            else
+                $(selector).html("Show less...");
+        },
+
+        toggleCacheUsage: function() {
+            var $cacheUsage = $(BDA_REPOSITORY.cacheUsageSelector);
+            $cacheUsage.next().toggle().next().toggle();
+            BDA_REPOSITORY.toggleShowLabel($cacheUsage.next().css("display"), "#showMoreCacheUsage");
+            BDA_STORAGE.storeToggleState("showMoreCacheUsage", $cacheUsage.next().css("display"));
+        },
+
+        toggleRepositoryView: function() {
+            $(BDA_REPOSITORY.repositoryViewSelector).next().toggle().next().toggle();
+            BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.repositoryViewSelector).next().css("display"), "#showMoreRepositoryView");
+            BDA_STORAGE.storeToggleState("showMoreRepositoryView", $(BDA_REPOSITORY.repositoryViewSelector).next().css("display"));
+        },
+
+        toggleProperties: function() {
+            $(BDA_REPOSITORY.propertiesSelector).next().toggle();
+            BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.propertiesSelector).next().css("display"), "#showMoreProperties");
+            BDA_STORAGE.storeToggleState("showMoreProperties", $(BDA_REPOSITORY.propertiesSelector).next().css("display"));
+        },
+
+        toggleEventSets: function() {
+            $(BDA_REPOSITORY.eventSetsSelector).next().toggle();
+            BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.eventSetsSelector).next().css("display"), "#showMoreEventsSets");
+            BDA_STORAGE.storeToggleState("showMoreEventsSets", $(BDA_REPOSITORY.eventSetsSelector).next().css("display"));
+        },
+
+        toggleMethods: function() {
+            $(BDA_REPOSITORY.methodsSelector).next().toggle();
+            BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.methodsSelector).next().css("display"), "#showMoreMethods");
+            BDA_STORAGE.storeToggleState("showMoreMethods", $(BDA_REPOSITORY.methodsSelector).next().css("display"));
+        },
+
+        toggleRawXml: function() {
+            $("#rawXml").toggle();
+            if ($("#rawXml").css("display") == "none")
+                $("#rawXmlLink").html("show raw XML");
+            else
+                $("#rawXmlLink").html("hide raw XML");
+        },
+
+        // simply handles an ajax call to a repository and parse the result
+        // xmltext : full xml text
+        // repository : only the strict nucleus path
+        // callback : take 1 param :  object {item: array of add-items, head}
+        executeQuery: function(domain, xmltext, repository, callback, errCallback) {
+
+            if (isNull(domain)) {
+                domain = "";
+            }
+            var url = '{0}/dyn/admin/nucleus/{1}/'.format(domain, repository);
+
+            $.ajax({
+                type: "POST",
+                url: url,
+                data: {
+                    xmltext: xmltext
+                },
+                success: function(result, status, jqXHR) {
+
+                    //check for errors
+                    try {
+
+                        let errors = BDA_REPOSITORY.getErrors(result);
+
+                        var rawItemsXml;
+
+                        if (_.isEmpty(errors)) {
+                            rawItemsXml = $(result).find("code").html();
+                            if (_.isEmpty(rawItemsXml)) {
+                                errors = "Null response";
+                            }
+                        }
+
+                        if (_.isEmpty(errors)) {
+                            callback(result);
+                        } else {
+                            errCallback(null, 'Execution Error', errors);
+                        }
+
+                    } catch (e) {
+                        console.error(e);
+                    }
+
+
+                },
+                error: function(jqXHR, textStatus, errorThrown) {
+                    if (!isNull(errCallback)) {
+                        errCallback(jqXHR, textStatus, errorThrown);
+                    }
+                }
+            });
+        },
+
+        getErrors: function(res) {
+
+            var $res = $(res);
+            var errorsSelector1 = "Errors:";
+            let errorMsg = null;
+            if ($res.text().indexOf(errorsSelector1) != -1) {
+                errorMsg = $res.find("code").text().trim();
+            }
+
+            return errorMsg;
+        },
+
+        executePrintItem: function(domain, itemDescriptor, id, repository, callback, errCallback) {
+            var xmlText = BDA_REPOSITORY.templates.printItem.format(itemDescriptor, id);
+            BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
+        },
+
+        executeQueryItems: function(domain, itemDescriptor, query, repository, callback, errCallback) {
+            var xmlText = BDA_REPOSITORY.templates.queryItems.format(itemDescriptor, query);
+            BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
+        },
+
+        previewRql: function(queryType, values) {
+            let xmlText;
+            switch (queryType) {
+                case 'print':
+                    xmlText = BDA_REPOSITORY.templates.printItem.format(values.itemDescriptor, values.id);
+                    break;
+                case 'query':
+                    xmlText = BDA_REPOSITORY.templates.queryItems.format(values.itemDescriptor, values.text);
+                    break;
+                default:
+                    xmlText = values.text
+
+            }
+            return xmlText;
+        },
+
+        setupRepositoryCacheSection: function() {
 
             try {
 
-              let tempResult = $('<div></div>');
-              BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, tempResult);
+                console.time("setupRepositoryCacheSection");
 
-              let propertySelector = '.property[data-id="{0}"]'.format(id);
-              tempResult.find(propertySelector).each(function() {
-                let $this = $(this);
-                let propertyName = $this.attr('data-property');
-                parentTab.find(propertySelector + '[data-property="{0}"]'.format(propertyName)).replaceWith(this);
-              })
-
-              //  update the data
-              let idSelector = '.idCell[data-identifier="id_{0}_{1}"]'.format(id, itemDescriptorName);
-              parentTab.find(idSelector).replaceWith(tempResult.find(idSelector));
-
-              parentTab.find('[data-id="{0}"]'.format(id)).flash();
-
-              BDA_REPOSITORY.showNonEmptyLines(parentTab);
-
-              if (cb) {
-                cb();
-              }
-            } catch (e) {
-              console.error(e);
-            }
-
-          })
-        },
-
-        function(jqXHR, textStatus, errorThrown) {
-          $.notify(
-            "Error during call: " + errorThrown + ".", {
-              className: "error",
-              position: "top center"
-            }
-          );
-
-        })
-    },
-
-    // load sub item with an ajax call
-    loadSubItem: function(id, itemDescriptorName, repositoryPath, $outputDiv, cbSuccess, cbErr, cbEnd) {
-      if (_.isNil(repositoryPath)) {
-        repositoryPath = getCurrentComponentPath();
-      }
-
-      // : function(domain, itemDescriptor, id, repository, callback, errCallback) {
-      BDA_REPOSITORY.executePrintItem('', itemDescriptorName, id, repositoryPath,
-        function(result) {
-          BDA_REPOSITORY.parseXhrResult(result, repositoryPath, (parsed) => {
-
-            let temp = $('<div></div>');
-
-            let top = BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, temp);
-            //use the itemDescriptor from the result, not the query (ex payment group vs creditCard)
-
-            let resultDescriptorName = _.first(parsed.items).itemDescriptor.name;
-            let targetTab = BDA_REPOSITORY.findTabToAppendTo(resultDescriptorName, $outputDiv);
-            if (_.isNil(targetTab) || targetTab.length === 0) {
-              temp.children().appendTo($outputDiv);
-            } else {
-              BDA_REPOSITORY.appendToDataTable(id, resultDescriptorName, repositoryPath, targetTab, temp);
-              top = targetTab;
-            }
-
-            BDA_REPOSITORY.reloadSpeedBar($outputDiv);
-            if (top) {
-              top.scrollTo();
-              top.find('[data-id="{0}"]'.format(id)).flash();
-            }
-            if (cbSuccess) {
-              cbSuccess();
-            }
-            if (cbEnd) {
-              cbEnd();
-            }
-          });
-        },
-        function(jqXHR, textStatus, errorThrown) {
-          $.notify(
-            "Error during call: " + errorThrown + ".", {
-              className: "error",
-              position: "top center"
-            }
-          );
-          if (cbErr) {
-            cbErr();
-          }
-          if (cbEnd) {
-            cbEnd();
-          }
-        }
-      )
-    },
-
-    oldShowXMLAsTab: function(xmlContent, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
+                //global css setups to aid further customisation
+                var $cacheUsage = $(this.cacheUsageSelector);
+                var $cacheTable = $cacheUsage.next().next().find('table');
+                BDA_REPOSITORY.$cacheTable = $cacheTable;
+                $cacheTable.addClass('cache').removeAttr('border'); //remove border - will be handled by css
 
 
-      console.time("oldShowXMLAsTab");
-      var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
-      var $xml = $(xmlDoc);
-      var $addItems = $xml.find("add-item");
-      var types = {};
-      var datas = [];
-      var nbTypes = 0;
-      var typesNames = {};
+                //move the header in a thead
+                var $header = $cacheTable.find('tr').first();
+                $header.detach();
+                var $thead = $('<thead></thead>').prependTo($cacheTable).append($header);
 
-      var log = $("<xml>" + xmlContent + "</xml>")
-        .children()
-        .remove()
-        .end()
-        .text()
-        .trim();
-
-      var descriptorAndDefaultValues = {};
-      if ($xmlDef != null) {
-        for (var i = 0; i < $addItems.length; i++) {
-          var itemDescriptor = $addItems[i].getAttribute("item-descriptor");
-
-          if (descriptorAndDefaultValues.hasOwnProperty(itemDescriptor) === false) {
-            BDA_REPOSITORY.getDescriptorAndDefaultValues(itemDescriptor, $xmlDef, descriptorAndDefaultValues);
-          }
-          for (var defaultPropertyName in descriptorAndDefaultValues[itemDescriptor]) {
-            var exists = $($addItems[i]).find("[name=" + defaultPropertyName + "]").length;
-            if (exists == 0) {
-              $addItems[i].innerHTML += '<set-property name="' + defaultPropertyName + '"><![CDATA[' + descriptorAndDefaultValues[itemDescriptor][defaultPropertyName] + ']]></set-property>';
-            }
-          }
-        }
-      }
-
-
-      $addItems.each(function() {
-        var curItemDesc = "_" + $(this).attr("item-descriptor");
-        if (!types[curItemDesc])
-          types[curItemDesc] = [];
-        if (!typesNames[curItemDesc])
-          typesNames[curItemDesc] = [];
-        if (!datas[curItemDesc]) {
-          datas[curItemDesc] = [];
-          nbTypes++;
-        }
-        var curData = {};
-
-        $(this).find("set-property").each(function(index) {
-          var $curProp = $(this);
-          curData[$curProp.attr("name")] = $curProp.text();
-          var type = {};
-          type.name = $curProp.attr("name");
-          if ($.inArray(type.name, typesNames[curItemDesc]) == -1) {
-            type.rdonly = $curProp.attr("rdonly");
-            type.derived = $curProp.attr("derived");
-            type.exportable = $curProp.attr("exportable");
-            var typeItemDesc = BDA_REPOSITORY.isTypeId(type.name, curItemDesc.substr(1), $xmlDef);
-            if (typeItemDesc === null)
-              type.isId = false;
-            else {
-              type.isId = true;
-              type.itemDesc = typeItemDesc;
-            }
-            types[curItemDesc].push(type);
-            typesNames[curItemDesc].push(type.name);
-          }
-        });
-        if ($.inArray("descriptor", typesNames[curItemDesc]) == -1) {
-          var typeDescriptor = {};
-          typeDescriptor.name = "descriptor";
-          types[curItemDesc].unshift(typeDescriptor);
-          typesNames[curItemDesc].push("descriptor");
-        }
-        if ($.inArray("id", typesNames[curItemDesc]) == -1) {
-          var typeId = {};
-          typeId.name = "id";
-          types[curItemDesc].unshift(typeId);
-          typesNames[curItemDesc].push("id");
-        }
-        curData.descriptor = curItemDesc;
-        curData.id = $(this).attr("id");
-        datas[curItemDesc].push(curData);
-      });
-      var html = "<p class='nbResults'>" + $addItems.length + " items in " + nbTypes + " descriptor(s)</p>";
-      var splitValue;
-      var splitObj = BDA_STORAGE.getStoredSplitObj();
-      if (splitObj === undefined || splitObj === null || splitObj.activeSplit === true)
-        splitValue = 0;
-      else
-        splitValue = parseInt(splitObj.splitValue);
-      for (var itemDesc in datas) {
-        if (splitValue === 0)
-          splitValue = datas[itemDesc].length;
-        var nbTab = 0;
-        if (datas[itemDesc].length <= splitValue) {
-          html += BDA_REPOSITORY.renderTab(itemDesc, types[itemDesc], datas[itemDesc], itemDesc.substr(1), isItemTree);
-        } else {
-          while ((splitValue * nbTab) < datas[itemDesc].length) {
-            var start = splitValue * nbTab;
-            var end = start + splitValue;
-            if (end > datas[itemDesc].length)
-              end = datas[itemDesc].length;
-            var subDatas = datas[itemDesc].slice(start, end);
-            html += BDA_REPOSITORY.renderTab(itemDesc, types[itemDesc], subDatas, itemDesc + "_" + nbTab, isItemTree);
-            nbTab++;
-          }
-        }
-      }
-      $outputDiv.append(html);
-      $outputDiv.prepend("<div class='prop_attr prop_attr_red'>R</div> : read-only " + "<div class='prop_attr prop_attr_green'>D</div> : derived " + "<div class='prop_attr prop_attr_blue'>E</div> : export is false");
-
-      if ($(".copyField").length > 0) {
-        // reuse $outputDiv in case we have several results set on the page (RQL query + get item tool)
-        $outputDiv.find("p.nbResults").append("<br><a href='javascript:void(0)' class='showFullTextLink'>Show full text</a>");
-        $outputDiv.find(".showFullTextLink").click(function() {
-          console.time("showFullText");
-          $(".copyField").each(function() {
-            $(this).parent().html($(this).html());
-          });
-          console.timeEnd("showFullText");
-          $(this).hide();
-        });
-      }
-
-      if (_.isNil(loadSubItemCb)) {
-        $outputDiv.find(".loadable_property").click(BDA_REPOSITORY.showLoadSubItemAlert);
-
-      } else {
-        $outputDiv.find(".loadable_property").click(loadSubItemCb);
-      }
-
-      if (isItemTree)
-        BDA_REPOSITORY.createSpeedbar();
-
-      console.timeEnd("oldShowXMLAsTab");
-      return log;
-    },
-
-    showLoadSubItemAlert: function() {
-      logTrace('click on loadable');
-      var $elm = $(this);
-      var id = $elm.attr("data-id");
-      var itemDesc = $elm.attr("data-descriptor");
-      var query = "<print-item id='" + id + "' item-descriptor='" + itemDesc + "' />\n";
-
-      $('body').bdaAlert({
-        msg: 'You are about to add this query and reload the page: \n' + query,
-        options: [{
-          label: 'Add & Reload',
-          _callback: function() {
-            BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
-            $("#RQLForm").submit();
-          }
-        }, {
-          label: 'Just Add',
-          _callback: function() {
-            BDA_REPOSITORY.setQueryEditorValue(BDA_REPOSITORY.getQueryEditorValue() + query);
-          }
-        }, {
-          label: 'Cancel'
-        }]
-      });
-    },
-
-    showRQLLog: function(log, error) {
-      logTrace("Execution log : " + log);
-      if (log && log.length > 0) {
-        $("<h3>Execution log</h3><div id='RQLLog'></div>").insertAfter("#RQLResults");
-        var cleanLog = log.replace(/\n{2,}/g, '\n').replace(/------ /g, "").trim();
-        $("#RQLLog").html(cleanLog);
-      }
-      if (error)
-        $("#RQLLog").addClass("error");
-    },
-
-    showRQLResults: function() {
-      logTrace("Start showRQLResults");
-      // Add 'show raw xml' link
-      var html = "<p>" + "<a href='javascript:void(0)' id='rawXmlLink'>Show raw xml</a>" + "</p>\n";
-      html += "<p id='rawXml'></p>";
-      $("#RQLResults").addClass('rqlResultContainer').append(html);
-
-      var xmlContent = $(BDA_REPOSITORY.resultsSelector).next().text().trim();
-      // xmlContent = sanitizeXml(xmlContent); //sanitize later
-
-      BDA_REPOSITORY.PERF_MONITOR.reset();
-      BDA_REPOSITORY.PERF_MONITOR.start('processRepositoryXmlDef');
-      processRepositoryXmlDef("definitionFiles", function($xmlDef) {
-         BDA_REPOSITORY.PERF_MONITOR.cumul('processRepositoryXmlDef');
-        var log = BDA_REPOSITORY.showXMLAsTab(xmlContent, $xmlDef, $("#RQLResults"), false);
-        BDA_REPOSITORY.showRQLLog(log, false);
-        // Move raw xml
-        $(BDA_REPOSITORY.resultsSelector).next().appendTo("#rawXml");
-        $(BDA_REPOSITORY.resultsSelector).remove();
-
-        $("#rawXmlLink").click(function() {
-          BDA_REPOSITORY.toggleRawXml();
-          var xmlSize = $("#rawXml pre").html().length;
-          logTrace("raw XML size : " + xmlSize);
-          logTrace("XML max size : " + BDA_REPOSITORY.xmlDefinitionMaxSize);
-          if (xmlSize < BDA_REPOSITORY.xmlDefinitionMaxSize) {
-            $('#rawXml').each(function(i, block) {
-              hljs.highlightBlock(block);
-            });
-          } else {
-            // Check if button already exists
-            if ($("#xmlHighlight").length === 0) {
-              $("<p id='xmlHighlight' />")
-                .html("The XML result is big, to avoid slowing down the page, XML highlight have been disabled. " + "<br> <button id='xmlHighlightBtn'>Highlight XML now</button> <small>(takes few seconds)</small>")
-                .prependTo($("#rawXml"));
-              $("#xmlHighlightBtn").click(function() {
-                $('#rawXml pre').each(function(i, block) {
-                  hljs.highlightBlock(block);
+                //mark the sub-headers
+                var index = 0;
+                $cacheTable.find('tr').each(function() {
+                    var $tr = $(this);
+                    //if header
+                    if ((index - 1) % 3 == 0) { //if sub-header
+                        //highlight per item
+                        $tr.addClass('odd cache-subheader');
+                    }
+                    index++;
                 });
-              });
+                var $tBody = $cacheTable.find('tbody:first');
+
+
+                BDA_REPOSITORY.setupCacheCollapse($header, $cacheTable);
+
+
+                //collapse all button
+                var $resetLink = $cacheUsage.next();
+                var $buttons = $('<div></div>').appendTo($resetLink);
+
+                var $expandAll = $('<button></button>', {
+                        id: 'cacheExpandAll',
+                        class: ' cache expand',
+                        value: 'expandAll',
+                        html: 'Expand All'
+                    })
+                    .bind('click', function() {
+                        $cacheTable.find('tr.cache-subheader.collapsed').each(BDA_REPOSITORY.toggleCacheLines);
+                    })
+                    .appendTo($buttons);
+
+                var $collapseAll = $('<button></button>', {
+                        id: 'collapseAll',
+                        class: 'cache collapse',
+                        value: 'collapseAll',
+                        html: 'Collapse All'
+                    })
+                    .on('click', function() {
+                        $cacheTable.find('tr.cache-subheader.expanded').each(BDA_REPOSITORY.toggleCacheLines);
+                    })
+                    .appendTo($buttons);
+
+                $collapseAll = $('<button></button>', {
+                        id: 'exportCSV',
+                        class: 'cache export',
+                        value: 'exportCSV',
+                        html: 'Export as CSV'
+                    })
+                    .on('click', function() {
+                        BDA_REPOSITORY.exportCacheStatsAsCSV();
+                    })
+                    .appendTo($buttons);
+
+                BDA_REPOSITORY.setupCacheTableHeaderFixed($header, $cacheTable);
+
+
+                //collapse all (after setup fixed header because we need full width)
+                $cacheTable.find('.cache-subheader').each(function() {
+                    $(this).addClass('collapsed')
+                        .next().css('display', 'none')
+                        .next().css('display', 'none');
+                });
+
+                console.timeEnd("setupRepositoryCacheSection");
+            } catch (err) {
+                console.error(err);
             }
-          }
-        });
 
-        $(".copyLink").click(function() {
-          BDA_REPOSITORY.showTextField($(this).attr("id").replace("link_", ""));
-        });
-      });
-    },
+        },
 
-    showRqlErrors: function() {
-      var error = "";
-      if ($(BDA_REPOSITORY.errorsSelector1).length > 0) {
-        logTrace("Case of error  : 1");
-        error = $(BDA_REPOSITORY.errorsSelector1).next().text();
-        $(BDA_REPOSITORY.resultsSelector).next().remove();
-        $(BDA_REPOSITORY.resultsSelector).remove();
-        $(BDA_REPOSITORY.errorsSelector1).next().remove();
-        $(BDA_REPOSITORY.errorsSelector1).remove();
-      } else {
-        logTrace("Case of error  : 2");
-        error = $(BDA_REPOSITORY.errorsSelector2).text();
-      }
-      error = BDA_REPOSITORY.purgeXml(error);
-      BDA_REPOSITORY.showRQLLog(error, true);
-    },
+        setupCacheCollapse: function($header, $cacheTable) {
 
-    escapeHTML: function(s) {
-      return String(s).replace(/&(?!\w+;)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-    },
+            var fullColSize = 23;
+            if (BDA.isOldDynamo) {
+                fullColSize = 18;
 
-    propertiesDef: function(hljs) {
-      logTrace("propertiesDef");
-      return {
-        case_insensitive: true,
-        contains: [{
-          className: 'comment',
-          begin: '#',
-          end: '$'
-        }, {
-          className: 'setting',
-          begin: '^[a-z0-9\\[\\]_-]+[ \\t]*=[ \\t]*',
-          end: '$',
-          contains: [{
-            className: 'value',
-            endsWithParent: true,
-            keywords: 'on off true false yes no',
-            contains: [hljs.QUOTE_STRING_MODE, hljs.NUMBER_MODE],
-            relevance: 0
-          }]
-        }]
-      };
-    },
+            }
 
-    //--- Item Tree functions ------------------------------------------------------------------------
 
-    setupItemTreeForm: function() {
-      $("<div id='itemTree' />").insertAfter("#RQLEditor");
-      var $itemTree = $("#itemTree");
-      $itemTree.append("<h2>Get Item Tree</h2>");
-      $itemTree.append("<p>This tool will recursively retrieve items and print the result with the chosen output." + "<br> For example, if you give an order ID in the form below, you will get all shipping groups, payment groups, commerceItems, priceInfo... of the given order" + "<br><b> Be careful when using this tool on a live instance ! Set a low max items value.</b></p>");
+            $cacheTable.find('.cache-subheader').each(function() {
+                var $tr = $(this);
 
-      $itemTree.append("<div id='itemTreeForm'>" + "id : <input type='text' id='itemTreeId' /> &nbsp;" + "descriptor :  <span id='itemTreeDescriptorField' ><select id='itemTreeDesc' class='itemDescriptor' >" + BDA_REPOSITORY.getDescriptorOptions() + "</select></span>" + "max items : <input type='text' id='itemTreeMax' value='50' /> &nbsp;<br><br>" + "output format :  <select id='itemTreeOutput'>" + "<option value='HTMLtab'>HTML tab</option>" + "<option value='addItem'>add-item XML</option>" + "<option value='removeItem'>remove-item XML</option>" + "<option value='printItem'>print-item XML</option>" + "<option value='tree'>Tree (experimental)</option>" + "</select>&nbsp;" + "<input type='checkbox' id='printRepositoryAttr' /><label for='printRepositoryAttr'>Print attribute : </label>" + "<pre style='margin:0; display:inline;'>repository='" + getCurrentComponentPath() + "'</pre> <br><br>" + "<button id='itemTreeBtn'>Enter <i class='fa fa-play fa-x'></i></button>" + "</div>");
-      $itemTree.append("<div id='itemTreeInfo' />");
-      $itemTree.append("<div id='itemTreeResult' class='rqlResultContainer' />");
-      $("#itemTreeBtn").click(function() {
-        var descriptor = $("#itemTreeDesc").val();
-        var id = $("#itemTreeId").val().trim();
-        var maxItem = parseInt($("#itemTreeMax").val());
-        var outputType = $("#itemTreeOutput").val();
-        var printRepoAttr = $("#printRepositoryAttr").is(':checked');
-        logTrace("max item : " + maxItem);
-        BDA_REPOSITORY.getItemTree(id, descriptor, maxItem, outputType, printRepoAttr);
-      });
+                //expand the cell width
+                var $td = $tr.find('td').first();
 
-    },
-
-    getSubItems: function(items, $xmlDef, maxItem, outputType, printRepoAttr) {
-      var nbItem = BDA_REPOSITORY.itemTree.size;
-      logTrace("maxItem : " + maxItem + ", nbItem : " + nbItem);
-
-      // Ensure that getSubItems is not call more than maxItem times
-      if (nbItem >= maxItem) {
-        logTrace("max Item (" + maxItem + ") reached, stopping recursion");
-        return;
-      }
-
-      var xmlText = "";
-      for (var batchSize = 0; batchSize != items.length; batchSize++) {
-        // Don"t ask for more items than limit
-        if ((BDA_REPOSITORY.nbItemReceived + batchSize) >= maxItem)
-          break;
-        xmlText += "<print-item id='" + items[batchSize].id + "' item-descriptor='" + items[batchSize].desc + "' />\n";
-      }
-      logTrace(xmlText);
-      logTrace("batch size : " + batchSize);
-      // Only request if the batchSize contains something
-      if (batchSize > 0) {
-        $.ajax({
-          type: "POST",
-          url: document.URL,
-          data: {
-            xmltext: xmlText
-          },
-          success: function(result, status, jqXHR) {
-
-            var rawItemsXml = $(result).find("code").html();
-            // remove first 2 lines
-            var tab = rawItemsXml.split("\n");
-            tab.splice(0, 2);
-            rawItemsXml = tab.join("\n").trim();
-            // unescape HTML
-            rawItemsXml = "<xml>" + rawItemsXml.replace(/&lt;/g, "<").replace(/&gt;/g, ">") + "</xml>";
-
-            var xmlDoc = jQuery.parseXML(rawItemsXml);
-            BDA_REPOSITORY.nbItemReceived += $(xmlDoc).find("add-item").length;
-            $("#itemTreeInfo").html("<p>" + BDA_REPOSITORY.nbItemReceived + " items retrieved</p>");
-
-            var subItems = [];
-            $(xmlDoc).find("add-item").each(function() {
-              var $itemXml = $(this);
-              var itemId = $itemXml.attr("id");
-              if (BDA_REPOSITORY.itemTree.get(itemId) === undefined) {
-                var rawItemXml = $itemXml[0].outerHTML;
-                BDA_REPOSITORY.itemTree.set(itemId, rawItemXml);
-                var descriptor = $itemXml.attr("item-descriptor");
-                var $itemDesc = $xmlDef.find("item-descriptor[name=" + descriptor + "]");
-                var superType = $itemDesc.attr("super-type");
-                while (superType !== undefined) {
-                  var $parentDesc = $xmlDef.find("item-descriptor[name=" + $itemDesc.attr("super-type") + "]");
-                  $itemDesc = $itemDesc.add($parentDesc);
-                  superType = $parentDesc.attr("super-type");
+                $td.attr('colspan', fullColSize); //extend to full with
+                //query cache line
+                var $queryCols = $tr.next().next().children('td');
+                if ($queryCols.length == 1) {
+                    $queryCols.attr('colspan', fullColSize);
                 }
-                // One to One relation
-                $itemDesc.find('property[item-type]')
-                  .each(function(index, elm) {
-                    var $elm = $(elm);
-                    var subProperty = $elm.attr("name");
-                    var subId = $itemXml.find("set-property[name=" + subProperty + "]").text();
-                    if ($elm.attr("repository") === undefined && subId.length > 0) {
-                      // avoid infinite recursion
-                      if (BDA_REPOSITORY.itemTree.get(subId) === undefined) {
-                        subItems.push({
-                          'id': subId,
-                          'desc': $elm.attr("item-type")
-                        });
-                      }
-                    }
-                  });
 
-                // One to Many relation with list, array or map
-                $itemDesc.find('property[component-item-type]')
-                  .each(function(index, elm) {
-                    var $elm = $(elm);
-                    var subProperty = $elm.attr("name");
-                    var subId = $itemXml.find("set-property[name=" + subProperty + "]").text();
-                    if ($elm.attr("repository") === undefined && subId.length > 0) {
-                      var desc = $elm.attr("component-item-type");
-                      var ids = BDA_REPOSITORY.parseRepositoryId(subId);
-                      for (var i = 0; i != ids.length; i++) {
-                        // avoid infinite recursion
-                        if (ids[i] !== BDA_REPOSITORY.MAP_SEPARATOR && ids[i] !== BDA_REPOSITORY.LIST_SEPARATOR && BDA_REPOSITORY.itemTree.get(ids[i]) === undefined)
-                          subItems.push({
-                            'id': ids[i],
-                            'desc': desc
-                          });
-                      }
+                //enhance the title line
+                var text = $td.find('b:contains("item-descriptor")').first().text();
+
+                var match = BDA_REPOSITORY.CACHE_STAT_TITLE_REGEXP.exec(text);
+                var newText = '';
+                var itemDesc = '',
+                    cacheMode = '',
+                    cacheLocality = '';
+                if (!isNull(match[1])) {
+                    itemDesc = match[1];
+                    newText += '<span> item-descriptor=<b>{0}</b>'.format(itemDesc);
+                }
+                if (!isNull(match[2])) {
+                    cacheMode = match[2];
+                    newText += '<span> cache-mode=<b>{0}</b>'.format(cacheMode);
+                }
+                if (!isNull(match[3])) {
+                    cacheLocality = match[3];
+                    newText += '<span> cache-locality=<b>{0}</b>'.format(cacheLocality);
+                }
+
+                //add as attr for easier handling
+                $tr.attr('data-item-desc', itemDesc)
+                    .attr('data-cache-mode', cacheMode)
+                    .attr('data-cache-locality', cacheLocality);
+
+                var $arrow = $('<span class="cacheArrow"><i class="up fa fa-arrow-right"></i></span>' + newText);
+                $td.html($arrow);
+
+                //collapse items
+                $tr.bind('click', BDA_REPOSITORY.toggleCacheLines);
+
+
+
+            });
+        },
+
+        setupCacheTableHeaderFixed: function($header, $cacheTable) {
+
+            traceTime('setupCacheTableHeaderFixed')
+
+            //make the header fixed with css
+            $cacheTable.addClass('fixed_headers');
+            logTrace('isOldDynamo ' + BDA.isOldDynamo)
+            if (BDA.isOldDynamo) {
+                $cacheTable.addClass('oldDynamo');
+            }
+
+            //clone the header
+
+            var $copy = $header.clone().addClass('sticky-header-copy');
+            $header.addClass('sticky-header-original');
+            $copy.insertAfter($header).hide();
+
+            var left = null;
+            var setupDone = false;
+            $(window).scroll(function() { // scroll event
+                var $window = $(window);
+                var windowTop = $window.scrollTop();
+                //get the value now because it changes on show/hide/collapse
+                var top = $cacheTable.offset().top;
+                var bot = top + $cacheTable.height();
+
+                try {
+
+                    if (top < windowTop && bot > windowTop) {
+                        $copy.addClass('sticky-top');
+                        var windowLeft = $window.scrollLeft();
+                        if (!setupDone) {
+                            left = $cacheTable.offset().left;
+                            BDA_REPOSITORY.setupCacheHeaderWidth($header, $copy);
+                            setupDone = true;
+                        }
+                        $copy.css('left', -windowLeft + left);
+                        $copy.show();
+                    } else {
+                        $copy.removeClass('sticky-top');
+                        $copy.css('left', 0);
+                        $copy.hide();
                     }
-                  });
-              }
+
+                } catch (e) {
+                    console.error(e);
+                }
+
+            });
+            traceTimeEnd('setupCacheTableHeaderFixed')
+
+        },
+
+        setupCacheHeaderWidth: function($header, $copy) {
+            traceTime('setupCacheHeaderWidth.getWidth')
+            //since we set all column with the same width we can use only the first cell as reference
+            var w = $('th:first', $header).width() + "px"; // .width() is very slow :(
+            //var w =first.width()
+            traceTimeEnd('setupCacheHeaderWidth.getWidth')
+
+            var $child;
+            traceTime('setupCacheHeaderWidth.setFixedWidth')
+            $copy.children('th').each(function(idx, child) {
+                $child = $(child);
+                $child.css({
+                    'max-width': w,
+                    'min-width': w,
+                })
+            });
+            traceTimeEnd('setupCacheHeaderWidth.setFixedWidth')
+
+        },
+
+        toggleCacheLines: function() {
+            var $tr = $(this);
+            $tr.toggleClass('collapsed')
+                .toggleClass('expanded');
+            $tr.next().toggle();
+            $tr.next().next().toggle();
+            rotateArrowQuarter($tr.find('.cacheArrow i'));
+        },
+
+        exportCacheStatsAsCSV: function() {
+            var data = [];
+            var line, $tr, $dataTr;
+            //header
+            data.push([
+                'Item Descriptor',
+                'Cache Mode',
+                'Cache locality',
+                'type',
+                'localEntries',
+                'externEntries',
+                'weakEntries',
+                'localCacheSize',
+                'usedRatio',
+                'totalHits',
+                'totalMisses',
+                'ratio',
+                'localHits',
+                'localMisses',
+                'externalHits',
+                'externalMisses',
+                'weakHits',
+                'weakMisses',
+                'cacheInvalidations',
+                'entryInvalidations',
+                'localCulls',
+                'localItemsCulled',
+                'localMaxCulled',
+                'weakCulls',
+                'weakItemsCulled',
+                'weakMaxCulled'
+            ]);
+
+            BDA_REPOSITORY.$cacheTable.find('tr.cache-subheader').each(function(idx, elem) {
+                $tr = $(elem);
+                line = [];
+                line.push($tr.attr('data-item-desc'));
+                line.push($tr.attr('data-cache-mode'));
+                line.push($tr.attr('data-cache-locality'));
+                line.push('item-cache');
+
+                $tr.next().children('td').each(function() {
+                    line.push($(this).text());
+                });
+
+                data.push(line);
+
+                var $queryTr = $tr.next().next();
+                var $cols = $queryTr.children('td');
+                if ($cols.length > 1) {
+                    //query caching available
+                    line = [];
+                    line.push($tr.attr('data-item-desc'));
+                    line.push($tr.attr('data-cache-mode'));
+                    line.push($tr.attr('data-cache-locality'));
+                    line.push('query-cache');
+
+                    $cols.each(function() {
+                        line.push($(this).text());
+                    });
+                    data.push(line);
+                }
             });
 
-            logTrace(subItems.length + " items to retrieved in next request. Limit reach : " + (BDA_REPOSITORY.nbItemReceived >= maxItem));
-            if (subItems.length > 0 && BDA_REPOSITORY.nbItemReceived < maxItem)
-              BDA_REPOSITORY.getSubItems(subItems, $xmlDef, maxItem, outputType, printRepoAttr);
-            else
-              BDA_REPOSITORY.renderItemTreeTab(outputType, printRepoAttr, $xmlDef, maxItem);
-          },
-        });
-      } else
-        logTrace("Request is empty, nothing to do.");
-    },
-
-    getItemTree: function(id, descriptor, maxItem, outputType, printRepoAttr) {
-      logTrace("getItemTree - start");
-      // reset divs
-      $("#itemTreeResult").empty();
-      $("#itemTreeInfo").empty();
-
-      if (!id) {
-        $("#itemTreeInfo").html("<p>Please provide a valid ID</p>");
-        return;
-      }
-
-      console.time("getItemTree");
-      console.time("retrieveItem");
-      // Get XML definition of the repository
-      $("#itemTreeInfo").html("<p>Getting XML definition of this repository...</p>");
-      var $xmlDef = processRepositoryXmlDef("definitionFiles", function($xmlDef) {
-        if (!$xmlDef) {
-          $("#itemTreeInfo").html("<p>Unable to parse XML definition of this repository !</p>");
-          return;
-        }
-        logTrace("descriptor : " + $xmlDef.find("item-descriptor").length);
-        // get tree
-        BDA_REPOSITORY.itemTree = new Map();
-        BDA_REPOSITORY.nbItemReceived = 0;
-        BDA_REPOSITORY.getSubItems([{
-          'id': id,
-          'desc': descriptor
-        }], $xmlDef, maxItem, outputType, printRepoAttr);
-      });
-    },
-
-    renderItemTreeTab: function(outputType, printRepoAttr, $xmlDef, maxItem) {
-      console.timeEnd("retrieveItem");
-      logTrace("Render item tree tab : " + outputType);
-
-      //  If the max item is reached before recursion ended, we notify the user
-      if (BDA_REPOSITORY.nbItemReceived >= maxItem) {
-        $.notify(
-          "Item tree stopped because the maximum items limit was reached : " + maxItem + ".", {
-            className: "warn",
-            position: "top center"
-          }
-        );
-      }
-
-      $("#itemTreeInfo").empty();
-      $("#itemTreeResult").empty();
-      var res = "";
-      if (outputType !== "HTMLtab" && outputType != "tree") {
-        logTrace("Render copy button");
-        $("#itemTreeInfo").append("<input type='button' id='itemTreeCopyButton' value='Copy result to clipboard'></input>");
-        $('#itemTreeCopyButton').click(function() {
-          copyToClipboard($('#itemTreeResult').text());
-        });
-      }
-      if (outputType == "addItem") {
-        BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-          if (printRepoAttr) {
-            var xmlDoc = jQuery.parseXML(data);
-            var $itemXml = $(xmlDoc).find("add-item");
-            $itemXml.attr("repository", getCurrentComponentPath());
-            res += $itemXml[0].outerHTML;
-          } else
-            res += data;
-          res += "\n\n";
-        }, BDA_REPOSITORY.itemTree);
-        res = "<import-items>\n" + res + "\n</import-items>";
-        $("#itemTreeResult").append("<pre />");
-        $("#itemTreeResult pre").text(res);
-      } else if (outputType == "HTMLtab") {
-        BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-          res += data;
-        }, BDA_REPOSITORY.itemTree);
-        BDA_REPOSITORY.showXMLAsTab(res, $xmlDef, $("#itemTreeResult"), true);
-      } else if (outputType == "removeItem" || outputType == "printItem") {
-        BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-          var xmlDoc = jQuery.parseXML(data);
-          var $itemXml = $(xmlDoc).find("add-item");
-          res += "<";
-          if (outputType == "removeItem")
-            res += "remove-item";
-          else
-            res += "print-item";
-          res += ' id="' + $itemXml.attr("id") + '" item-descriptor="' + $itemXml.attr("item-descriptor") + "\"";
-          if (printRepoAttr)
-            res += " repository='" + getCurrentComponentPath() + "'";
-          res += ' />\n';
-        }, BDA_REPOSITORY.itemTree);
-
-        $("#itemTreeResult").append("<pre />");
-        $("#itemTreeResult pre").text(res);
-      } else if (outputType == "tree") {
-        BDA_REPOSITORY.renderAsTree($xmlDef);
-      }
-
-      console.timeEnd("getItemTree");
-    },
-
-    renderAsTree: function($xmlDef) {
-      logTrace("render as tree");
-      console.time('renderAsTree.setup');
-      var nodes = new vis.DataSet();
-      var edges = new vis.DataSet();
-      var legends = new Map();
-      var descById = new Map();
-      var itemIdToVisId = {};
-      var i = 0;
-      BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-        itemIdToVisId[id] = i;
-        i++;
-      });
-
-      BDA_REPOSITORY.itemTree.forEach(function(data, id) {
-        var xmlDoc = $.parseXML("<xml>" + data + "</xml>");
-        var $xml = $(xmlDoc);
-        var $addItem = $xml.find("add-item").first();
-        var itemDesc = $addItem.attr("item-descriptor");
-        var itemId = $addItem.attr("id");
-
-        $addItem.children().each(function(index) {
-          var $this = $(this);
-          var propertyName = $this.attr("name");
-          var propertyValue = $this.text();
-          if (BDA_REPOSITORY.edgesToIgnore.indexOf(propertyName) === -1) {
-            var isId = BDA_REPOSITORY.isTypeId(propertyName, itemDesc, $xmlDef)
-            if (isId != null && isId != "FOUND_NOT_ID") {
-              var idAsTab = BDA_REPOSITORY.parseRepositoryId(propertyValue);
-              for (var i = 0; i != idAsTab.length; i++) {
-                if (idAsTab[i] != "," && idAsTab[i] != "=") {
-                  edges.add({
-                    from: itemIdToVisId[itemId],
-                    to: itemIdToVisId[idAsTab[i]],
-                    arrows: 'to',
-                    title: propertyName
-                  });
-                }
-              }
-            }
-          }
-        });
-
-        var nodeColor = colorToCss(stringToColour(itemDesc));
-        nodes.add({
-          id: itemIdToVisId[itemId],
-          label: itemDesc + "\n" + itemId,
-          color: nodeColor,
-          shape: 'box'
-        });
-        legends.set(itemDesc, nodeColor);
-
-        if (descById.get(itemDesc))
-          descById.get(itemDesc).push(itemId);
-        else
-          descById.set(itemDesc, [itemId]);
-      });
-      console.timeEnd('renderAsTree.setup');
-      // Create popup
-      $("#itemTreeResult").empty()
-        .append("<div class='popup_block' id='treePopup'>" + "<div><a href='javascript:void(0)' class='close'><i class='fa fa-times'></i></a></div>" + "<div id='treeLegend'></div>" + "<div class='flexContainer'>" + "<div id='treeInfo'></div>" + "<div id='treeContainer'></div>" + "</div>" + "</div>");
-      $("#treePopup .close").click(function() {
-        logTrace("click on close");
-        $("#treePopup").hide();
-      });
-
-      // Setup legend
-      legends.forEach(function(value, key) {
-        $("#treeLegend").append("<div class='legend' style='background-color:" + value + "' id='" + key + "'>" + key + "</div>");
-      });
-
-      logTrace("Number for nodes : " + nodes.length);
-      logTrace("Number for edges : " + edges.length);
-
-      $("#treePopup").show();
-      console.time('renderAsTree.render');
-
-      // Create the network
-      var data = {
-        nodes: nodes,
-        edges: edges
-      };
-
-      var options = {
-        physics: {
-          stabilization: false
-        },
-        edges: {
-          smooth: true
-        },
-        nodes: {
-          font: {
-            color: "#FFFFFF"
-          }
-        }
-      };
-
-      var container = document.getElementById('treeContainer');
-      var network = new vis.Network(container, data, options);
-      console.timeEnd('renderAsTree.render')
-
-      network.on("click", function(params) {
-        params.event = "[original event]";
-        if (params.nodes && params.nodes.length == 1) {
-          $("#treeInfo").empty();
-          var visId = params.nodes[0];
-          var itemId = null;
-          logTrace("Click on " + visId);
-          // Find itemId from visID
-          for (var id in itemIdToVisId) {
-            if (visId === itemIdToVisId[id]) {
-              itemId = id;
-              break;
-            }
-          }
-          logTrace("itemId : " + itemId);
-          logTrace(BDA_REPOSITORY.itemTree.get(itemId));
-          BDA_REPOSITORY.showXMLAsTab(BDA_REPOSITORY.itemTree.get(itemId), null, $("#treeInfo"), false);
-          logTrace($("#treeInfo").html());
-          $("#treeInfo").show();
-        }
-      });
-
-      $(".legend").click(function() {
-        // This feature is disabled for now.
-        return;
-        logTrace("click on legend");
-        var id = $(this).attr('id');
-        logTrace(id);
-        var ids = descById.get(id);
-        var nodesAndEdgesToHide = {};
-        for (var i = 0; i != ids.length; i++) {
-          nodesAndEdgesToHide = BDA_REPOSITORY.findNodesAndEdgesToHide(ids[i], network, edges, nodes);
-
-          // Foreach nodesAndEdgesToHide.nodes
-          for (var a = 0; a != nodesAndEdgesToHide.nodes.length; a++) {
-            nodes.update([{
-              id: nodesAndEdgesToHide.nodes[a],
-              hidden: true
-            }]);
-          }
-          // Foreach nodesAndEdgesToHide.edges
-          for (var a = 0; a != nodesAndEdgesToHide.edges.length; a++) {
-            edges.update([{
-              id: nodesAndEdgesToHide.edges[a],
-              hidden: true
-            }]);
-          }
-        }
-      });
-    },
-
-    findNodesAndEdgesToHide: function(id, network, edges, nodes) {
-      logTrace("findNodesAndEdgesToHide for ID : " + id);
-      var nodesAndEdgesToHide = {};
-      nodesAndEdgesToHide.nodes = BDA_REPOSITORY.findOrphanSon(id, network, edges, nodes, [id]);
-      nodesAndEdgesToHide.edges = [];
-      for (var i = 0; i != nodesAndEdgesToHide.nodes.length; i++) {
-        nodesAndEdgesToHide.edges = nodesAndEdgesToHide.edges.concat(network.getConnectedEdges(nodesAndEdgesToHide.nodes[i]));
-      }
-      logTrace("nodesAndEdgesToHide.nodes : ");
-      logTrace(nodesAndEdgesToHide.nodes);
-      logTrace("nodesAndEdgesToHide.edges : ");
-      logTrace(nodesAndEdgesToHide.edges);
-      return nodesAndEdgesToHide;
-    },
-
-    findOrphanSon: function(id, network, edges, nodes, orphanSons) {
-      logTrace("About to find orphan for node : " + id);
-      edges.forEach(function(elm) {
-        //logTrace(elm);
-        if (elm.from == id) {
-          var isOrphan = true;
-          var connectedEdges = network.getConnectedEdges(elm.to);
-
-          for (var i = 0; i != connectedEdges.length; i++) {
-            var edge = edges.get(connectedEdges[i]);
-            logTrace("connectedEdge - from : " + edge.to + " - " + edge.from);
-            if (edge.to == elm.to && edge.from != id) {
-              isOrphan = false;
-              break;
-            }
-          }
-          if (isOrphan && orphanSons.indexOf(elm.to) === -1) {
-            logTrace(elm.to + " is a new orphan son of node : " + id);
-            orphanSons.push(elm.to);
-            BDA_REPOSITORY.findOrphanSon(elm.to, network, edges, nodes, orphanSons);
-          }
-        }
-      });
-      return orphanSons;
-    },
-
-
-    createSpeedbar_new: function(resultElem) {
-      logTrace('createSpeedbar_new')
-      try {
-
-        let speedbar = $('<div class="speedbar"><div class="widget"><i class="fa fa-times close"></i><p>Quick links :</p><ul></ul></div></div>');
-        speedbar.find('.close').on('click', () => {
-          speedbar.fadeOut(200);
-        })
-
-        let list = speedbar.find('ul');
-        resultElem.find(".dataTable").each(function(index) {
-          var $tab = $(this);
-          var id = $tab.attr("id");
-          var descriptor = $tab.attr('data-descriptor');
-
-          var nbItem = $tab.find("td").length / $tab.find("tr").length;
-          let elem = $("<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<span class='clickable_property'>" + descriptor + "</span> (" + nbItem + ")</li>");
-          elem.on('click', () => $tab.scrollTo());
-          list.append(elem);
-        });
-        speedbar.prependTo(resultElem);
-
-        let container = $(resultElem);
-
-        let widget = speedbar.find('.widget');
-        let initialTop = container.offset().top;
-        var initialBot = initialTop + container.height();
-        $(window).scroll(function() {
-          var windowTop = $(window).scrollTop();
-          if (initialTop < windowTop && initialBot > windowTop) {
-            widget.addClass('sticky-top-100');
-          } else {
-            widget.removeClass('sticky-top-100');
-          }
-        });
-
-      } catch (e) {
-        console.error(e);
-      }
-
-    },
-
-    reloadSpeedBar: function(resultElem) {
-      resultElem.find('.speedbar').remove();
-      BDA_REPOSITORY.createSpeedbar_new(resultElem);
-    },
-
-    createSpeedbar: function() {
-      var speedBarHtml = "<a class='close' href='javascript:void(0)'><i class='fa fa-times'></i></a><p>Quick links :</p><ul>";
-      $("#itemTreeResult .dataTable").each(function(index) {
-        var $tab = $(this);
-        var id = $tab.attr("id");
-        var name = id;
-        if (id.indexOf("_") != -1) {
-          var tab = id.split("_");
-          name = tab[1];
-        }
-        var nbItem = $tab.find("td").length / $tab.find("tr").length;
-        speedBarHtml += "<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<a href='#" + id + "'>" + name.trim() + " (" + nbItem + ")</a></li>";
-      });
-      speedBarHtml += "</ul>";
-      $("#itemTreeInfo").append("<div id='speedbar'><div id='widget' class='sticky'>" + speedBarHtml + "</div></div>");
-      $('#speedbar .close').click(function() {
-        $("#speedbar").fadeOut(200);
-      });
-      var stickyTop = $('.sticky').offset().top;
-      $(window).scroll(function() { // scroll event
-        var windowTop = $(window).scrollTop();
-        if (stickyTop < windowTop)
-          $('.sticky').css({
-            position: 'fixed',
-            top: 100
-          });
-        else
-          $('.sticky').css('position', 'static');
-      });
-    },
-
-
-    showQueryList: function() {
-      var html = "";
-      // fix delete query : the index used to delete was not correct
-      // we need to keep original index
-      var rqlQueries = BDA_STORAGE.getStoredRQLQueries();
-      var currComponentName = getComponentNameFromPath(getCurrentComponentPath());
-      var nbQuery = 0;
-      if (rqlQueries && rqlQueries.length > 0) {
-        html += "<ul>";
-        for (var i = 0; i != rqlQueries.length; i++) {
-          var storeQuery = rqlQueries[i];
-          if (!storeQuery.hasOwnProperty("repo") || storeQuery.repo == currComponentName) {
-            var escapedQuery = $("<div>").text(storeQuery.query).html();
-            html += "<li class='savedQuery'>";
-            html += "<a href='javascript:void(0)'>" + storeQuery.name + "</a>";
-            html += "<span id='previewQuery" + i + "'class='previewQuery'>";
-            html += "<i class='fa fa-eye'></i>";
-            html += "</span>";
-            html += "<span id='deleteQuery" + i + "'class='deleteQuery'>";
-            html += "<i class='fa fa-trash-o'></i>";
-            html += "</span>";
-            html += "<span id='queryView" + i + "'class='queryView'>";
-            html += "<pre>" + escapedQuery + "</pre>";
-            html += "</span>";
-            html += "</li>";
-            nbQuery++;
-          }
-        }
-        html += "</ul>";
-        if (nbQuery > 0)
-          $("#storedQueries").html(html);
-      }
-
-      // $('#storedQueries .queryView').each(function(i, block) {
-      //   hljs.highlightBlock(block);
-      // });
-
-      $(".savedQuery").on('click', 'a', function() {
-        logTrace("click on query : " + $(this).find("a").html());
-        BDA_REPOSITORY.printStoredQuery($(this).find("a").html());
-      });
-
-      $(".previewQuery").on('click', function() {
-
-        try {
-
-
-          let block = $(this).parent("li").find("span.queryView").each(function(i, block) {
-            hljs.highlightBlock(block);
-          });
-
-          $('body').bdaAlert({
-            msg: block.html(),
-            width: '900px',
-            options: [{
-              label: 'OK'
-            }]
-          });
-        } catch (e) {
-          console.error(e);
-        }
-
-
-      });
-
-      $(".deleteQuery")
-        .click(function() {
-          var index = this.id.replace("deleteQuery", "");
-          logTrace("Delete query #" + index);
-          logTrace(BDA_STORAGE.deleteRQLQuery);
-          BDA_STORAGE.deleteRQLQuery(index);
-          BDA_REPOSITORY.reloadQueryList();
-        });
-    },
-
-    purgeRQLQuery: function(rqlQueries) {
-      // Purge query
-      var purgedRqlQueries = [];
-      for (var i = 0; i != rqlQueries.length; i++) {
-        var query = rqlQueries[i];
-        if (!query.hasOwnProperty("repo") || query.repo == getComponentNameFromPath(getCurrentComponentPath())) {
-          purgedRqlQueries.push(rqlQueries[i]);
-        }
-      }
-      return purgedRqlQueries;
-    },
-
-    reloadQueryList: function() {
-      $("#storedQueries").empty();
-      BDA_REPOSITORY.showQueryList();
-    },
-
-    printStoredQuery: function(name) {
-      logTrace("printStoredQuery : " + name);
-      var rqlQueries = BDA_STORAGE.getStoredRQLQueries();
-      logTrace(rqlQueries);
-      if (rqlQueries) {
-        for (var i = 0; i != rqlQueries.length; i++) {
-          if (rqlQueries[i].name == name)
-            BDA_REPOSITORY.setQueryEditorValue(rqlQueries[i].query + "\n");
-        }
-      }
-    },
-
-    getToggleLabel: function(state) {
-      if (state == 1)
-        return "Show less...";
-      return "Show more...";
-    },
-
-    toggleShowLabel: function(contentDisplay, selector) {
-      if (contentDisplay == "none")
-        $(selector).html("Show more...");
-      else
-        $(selector).html("Show less...");
-    },
-
-    toggleCacheUsage: function() {
-      var $cacheUsage = $(BDA_REPOSITORY.cacheUsageSelector);
-      $cacheUsage.next().toggle().next().toggle();
-      BDA_REPOSITORY.toggleShowLabel($cacheUsage.next().css("display"), "#showMoreCacheUsage");
-      BDA_STORAGE.storeToggleState("showMoreCacheUsage", $cacheUsage.next().css("display"));
-    },
-
-    toggleRepositoryView: function() {
-      $(BDA_REPOSITORY.repositoryViewSelector).next().toggle().next().toggle();
-      BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.repositoryViewSelector).next().css("display"), "#showMoreRepositoryView");
-      BDA_STORAGE.storeToggleState("showMoreRepositoryView", $(BDA_REPOSITORY.repositoryViewSelector).next().css("display"));
-    },
-
-    toggleProperties: function() {
-      $(BDA_REPOSITORY.propertiesSelector).next().toggle();
-      BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.propertiesSelector).next().css("display"), "#showMoreProperties");
-      BDA_STORAGE.storeToggleState("showMoreProperties", $(BDA_REPOSITORY.propertiesSelector).next().css("display"));
-    },
-
-    toggleEventSets: function() {
-      $(BDA_REPOSITORY.eventSetsSelector).next().toggle();
-      BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.eventSetsSelector).next().css("display"), "#showMoreEventsSets");
-      BDA_STORAGE.storeToggleState("showMoreEventsSets", $(BDA_REPOSITORY.eventSetsSelector).next().css("display"));
-    },
-
-    toggleMethods: function() {
-      $(BDA_REPOSITORY.methodsSelector).next().toggle();
-      BDA_REPOSITORY.toggleShowLabel($(BDA_REPOSITORY.methodsSelector).next().css("display"), "#showMoreMethods");
-      BDA_STORAGE.storeToggleState("showMoreMethods", $(BDA_REPOSITORY.methodsSelector).next().css("display"));
-    },
-
-    toggleRawXml: function() {
-      $("#rawXml").toggle();
-      if ($("#rawXml").css("display") == "none")
-        $("#rawXmlLink").html("show raw XML");
-      else
-        $("#rawXmlLink").html("hide raw XML");
-    },
-
-    // simply handles an ajax call to a repository and parse the result
-    // xmltext : full xml text
-    // repository : only the strict nucleus path
-    // callback : take 1 param :  object {item: array of add-items, head}
-    executeQuery: function(domain, xmltext, repository, callback, errCallback) {
-
-      if (isNull(domain)) {
-        domain = "";
-      }
-      var url = '{0}/dyn/admin/nucleus/{1}/'.format(domain, repository);
-
-      $.ajax({
-        type: "POST",
-        url: url,
-        data: {
-          xmltext: xmltext
-        },
-        success: function(result, status, jqXHR) {
-
-          //check for errors
-          try {
-
-            let errors = BDA_REPOSITORY.getErrors(result);
-
-            var rawItemsXml;
-
-            if (_.isEmpty(errors)) {
-              rawItemsXml = $(result).find("code").html();
-              if (_.isEmpty(rawItemsXml)) {
-                errors = "Null response";
-              }
+            var linesText = [];
+            for (var i = 0; i < data.length; i++) {
+                linesText.push(data[i].join(';'))
             }
 
-            if (_.isEmpty(errors)) {
-              callback(result);
-            } else {
-              errCallback(null, 'Execution Error', errors);
-            }
+            var csv = linesText.join('\n');
 
-          } catch (e) {
-            console.error(e);
-          }
+            copyToClipboard(csv);
 
-
-        },
-        error: function(jqXHR, textStatus, errorThrown) {
-          if (!isNull(errCallback)) {
-            errCallback(jqXHR, textStatus, errorThrown);
-          }
         }
-      });
-    },
-
-    getErrors: function(res) {
-
-      var $res = $(res);
-      var errorsSelector1 = "Errors:";
-      let errorMsg = null;
-      if ($res.text().indexOf(errorsSelector1) != -1) {
-        errorMsg = $res.find("code").text().trim();
-      }
-
-      return errorMsg;
-    },
-
-    executePrintItem: function(domain, itemDescriptor, id, repository, callback, errCallback) {
-      var xmlText = BDA_REPOSITORY.templates.printItem.format(itemDescriptor, id);
-      BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
-    },
-
-    executeQueryItems: function(domain, itemDescriptor, query, repository, callback, errCallback) {
-      var xmlText = BDA_REPOSITORY.templates.queryItems.format(itemDescriptor, query);
-      BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
-    },
-
-    previewRql: function(queryType, values) {
-      let xmlText;
-      switch (queryType) {
-        case 'print':
-          xmlText = BDA_REPOSITORY.templates.printItem.format(values.itemDescriptor, values.id);
-          break;
-        case 'query':
-          xmlText = BDA_REPOSITORY.templates.queryItems.format(values.itemDescriptor, values.text);
-          break;
-        default:
-          xmlText = values.text
-
-      }
-      return xmlText;
-    },
-
-    setupRepositoryCacheSection: function() {
-
-      try {
-
-        console.time("setupRepositoryCacheSection");
-
-        //global css setups to aid further customisation
-        var $cacheUsage = $(this.cacheUsageSelector);
-        var $cacheTable = $cacheUsage.next().next().find('table');
-        BDA_REPOSITORY.$cacheTable = $cacheTable;
-        $cacheTable.addClass('cache').removeAttr('border'); //remove border - will be handled by css
-
-
-        //move the header in a thead
-        var $header = $cacheTable.find('tr').first();
-        $header.detach();
-        var $thead = $('<thead></thead>').prependTo($cacheTable).append($header);
-
-        //mark the sub-headers
-        var index = 0;
-        $cacheTable.find('tr').each(function() {
-          var $tr = $(this);
-          //if header
-          if ((index - 1) % 3 == 0) { //if sub-header
-            //highlight per item
-            $tr.addClass('odd cache-subheader');
-          }
-          index++;
-        });
-        var $tBody = $cacheTable.find('tbody:first');
-
-
-        BDA_REPOSITORY.setupCacheCollapse($header, $cacheTable);
-
-
-        //collapse all button
-        var $resetLink = $cacheUsage.next();
-        var $buttons = $('<div></div>').appendTo($resetLink);
-
-        var $expandAll = $('<button></button>', {
-            id: 'cacheExpandAll',
-            class: ' cache expand',
-            value: 'expandAll',
-            html: 'Expand All'
-          })
-          .bind('click', function() {
-            $cacheTable.find('tr.cache-subheader.collapsed').each(BDA_REPOSITORY.toggleCacheLines);
-          })
-          .appendTo($buttons);
-
-        var $collapseAll = $('<button></button>', {
-            id: 'collapseAll',
-            class: 'cache collapse',
-            value: 'collapseAll',
-            html: 'Collapse All'
-          })
-          .on('click', function() {
-            $cacheTable.find('tr.cache-subheader.expanded').each(BDA_REPOSITORY.toggleCacheLines);
-          })
-          .appendTo($buttons);
-
-        $collapseAll = $('<button></button>', {
-            id: 'exportCSV',
-            class: 'cache export',
-            value: 'exportCSV',
-            html: 'Export as CSV'
-          })
-          .on('click', function() {
-            BDA_REPOSITORY.exportCacheStatsAsCSV();
-          })
-          .appendTo($buttons);
-
-        BDA_REPOSITORY.setupCacheTableHeaderFixed($header, $cacheTable);
-
-
-        //collapse all (after setup fixed header because we need full width)
-        $cacheTable.find('.cache-subheader').each(function() {
-          $(this).addClass('collapsed')
-            .next().css('display', 'none')
-            .next().css('display', 'none');
-        });
-
-        console.timeEnd("setupRepositoryCacheSection");
-      } catch (err) {
-        console.error(err);
-      }
-
-    },
-
-    setupCacheCollapse: function($header, $cacheTable) {
-
-      var fullColSize = 23;
-      if (BDA.isOldDynamo) {
-        fullColSize = 18;
-
-      }
-
-
-      $cacheTable.find('.cache-subheader').each(function() {
-        var $tr = $(this);
-
-        //expand the cell width
-        var $td = $tr.find('td').first();
-
-        $td.attr('colspan', fullColSize); //extend to full with
-        //query cache line
-        var $queryCols = $tr.next().next().children('td');
-        if ($queryCols.length == 1) {
-          $queryCols.attr('colspan', fullColSize);
-        }
-
-        //enhance the title line
-        var text = $td.find('b:contains("item-descriptor")').first().text();
-
-        var match = BDA_REPOSITORY.CACHE_STAT_TITLE_REGEXP.exec(text);
-        var newText = '';
-        var itemDesc = '',
-          cacheMode = '',
-          cacheLocality = '';
-        if (!isNull(match[1])) {
-          itemDesc = match[1];
-          newText += '<span> item-descriptor=<b>{0}</b>'.format(itemDesc);
-        }
-        if (!isNull(match[2])) {
-          cacheMode = match[2];
-          newText += '<span> cache-mode=<b>{0}</b>'.format(cacheMode);
-        }
-        if (!isNull(match[3])) {
-          cacheLocality = match[3];
-          newText += '<span> cache-locality=<b>{0}</b>'.format(cacheLocality);
-        }
-
-        //add as attr for easier handling
-        $tr.attr('data-item-desc', itemDesc)
-          .attr('data-cache-mode', cacheMode)
-          .attr('data-cache-locality', cacheLocality);
-
-        var $arrow = $('<span class="cacheArrow"><i class="up fa fa-arrow-right"></i></span>' + newText);
-        $td.html($arrow);
-
-        //collapse items
-        $tr.bind('click', BDA_REPOSITORY.toggleCacheLines);
-
-
-
-      });
-    },
-
-    setupCacheTableHeaderFixed: function($header, $cacheTable) {
-
-      traceTime('setupCacheTableHeaderFixed')
-
-      //make the header fixed with css
-      $cacheTable.addClass('fixed_headers');
-      logTrace('isOldDynamo ' + BDA.isOldDynamo)
-      if (BDA.isOldDynamo) {
-        $cacheTable.addClass('oldDynamo');
-      }
-
-      //clone the header
-
-      var $copy = $header.clone().addClass('sticky-header-copy');
-      $header.addClass('sticky-header-original');
-      $copy.insertAfter($header).hide();
-
-      var left = null;
-      var setupDone = false;
-      $(window).scroll(function() { // scroll event
-        var $window = $(window);
-        var windowTop = $window.scrollTop();
-        //get the value now because it changes on show/hide/collapse
-        var top = $cacheTable.offset().top;
-        var bot = top + $cacheTable.height();
-
-        try {
-
-          if (top < windowTop && bot > windowTop) {
-            $copy.addClass('sticky-top');
-            var windowLeft = $window.scrollLeft();
-            if (!setupDone) {
-              left = $cacheTable.offset().left;
-              BDA_REPOSITORY.setupCacheHeaderWidth($header, $copy);
-              setupDone = true;
-            }
-            $copy.css('left', -windowLeft + left);
-            $copy.show();
-          } else {
-            $copy.removeClass('sticky-top');
-            $copy.css('left', 0);
-            $copy.hide();
-          }
-
-        } catch (e) {
-          console.error(e);
-        }
-
-      });
-      traceTimeEnd('setupCacheTableHeaderFixed')
-
-    },
-
-    setupCacheHeaderWidth: function($header, $copy) {
-      traceTime('setupCacheHeaderWidth.getWidth')
-        //since we set all column with the same width we can use only the first cell as reference
-      var w = $('th:first', $header).width() + "px"; // .width() is very slow :(
-      //var w =first.width()
-      traceTimeEnd('setupCacheHeaderWidth.getWidth')
-
-      var $child;
-      traceTime('setupCacheHeaderWidth.setFixedWidth')
-      $copy.children('th').each(function(idx, child) {
-        $child = $(child);
-        $child.css({
-          'max-width': w,
-          'min-width': w,
-        })
-      });
-      traceTimeEnd('setupCacheHeaderWidth.setFixedWidth')
-
-    },
-
-    toggleCacheLines: function() {
-      var $tr = $(this);
-      $tr.toggleClass('collapsed')
-        .toggleClass('expanded');
-      $tr.next().toggle();
-      $tr.next().next().toggle();
-      rotateArrowQuarter($tr.find('.cacheArrow i'));
-    },
-
-    exportCacheStatsAsCSV: function() {
-      var data = [];
-      var line, $tr, $dataTr;
-      //header
-      data.push([
-        'Item Descriptor',
-        'Cache Mode',
-        'Cache locality',
-        'type',
-        'localEntries',
-        'externEntries',
-        'weakEntries',
-        'localCacheSize',
-        'usedRatio',
-        'totalHits',
-        'totalMisses',
-        'ratio',
-        'localHits',
-        'localMisses',
-        'externalHits',
-        'externalMisses',
-        'weakHits',
-        'weakMisses',
-        'cacheInvalidations',
-        'entryInvalidations',
-        'localCulls',
-        'localItemsCulled',
-        'localMaxCulled',
-        'weakCulls',
-        'weakItemsCulled',
-        'weakMaxCulled'
-      ]);
-
-      BDA_REPOSITORY.$cacheTable.find('tr.cache-subheader').each(function(idx, elem) {
-        $tr = $(elem);
-        line = [];
-        line.push($tr.attr('data-item-desc'));
-        line.push($tr.attr('data-cache-mode'));
-        line.push($tr.attr('data-cache-locality'));
-        line.push('item-cache');
-
-        $tr.next().children('td').each(function() {
-          line.push($(this).text());
-        });
-
-        data.push(line);
-
-        var $queryTr = $tr.next().next();
-        var $cols = $queryTr.children('td');
-        if ($cols.length > 1) {
-          //query caching available
-          line = [];
-          line.push($tr.attr('data-item-desc'));
-          line.push($tr.attr('data-cache-mode'));
-          line.push($tr.attr('data-cache-locality'));
-          line.push('query-cache');
-
-          $cols.each(function() {
-            line.push($(this).text());
-          });
-          data.push(line);
-        }
-      });
-
-      var linesText = [];
-      for (var i = 0; i < data.length; i++) {
-        linesText.push(data[i].join(';'))
-      }
-
-      var csv = linesText.join('\n');
-
-      copyToClipboard(csv);
-
+    };
+
+    // Reference to BDA_STORAGE
+    var BDA_STORAGE, BDA;
+
+    // Jquery plugin creation
+    $.fn.bdaRepository = function(theBDA) {
+        logTrace('Init plugin {0}'.format('bdaRepository'));
+        //settings = $.extend({}, defaults, options);
+        BDA = theBDA;
+        BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
+        BDA_REPOSITORY.build();
+        return this;
+    };
+
+    $.fn.bdaRepository.reloadQueryList = function() {
+        if (BDA_REPOSITORY.isRepositoryPage)
+            BDA_REPOSITORY.reloadQueryList();
+    };
+
+    $.fn.executePrintItem = function(domain, itemDescriptor, id, repository, callback, errCallback) {
+        BDA_REPOSITORY.executePrintItem(domain, itemDescriptor, id, repository, callback, errCallback);
+    };
+
+    $.fn.executeQueryItems = function(domain, itemDescriptor, query, repository, callback, errCallback) {
+        BDA_REPOSITORY.executeQueryItems(domain, itemDescriptor, query, repository, callback, errCallback);
+    };
+
+    $.fn.executeRql = function(domain, xmlText, repository, callback, errCallback) {
+        BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
+    };
+
+    $.fn.previewRql = function(queryType, values) {
+        return BDA_REPOSITORY.previewRql(queryType, values);
     }
-  };
 
-  // Reference to BDA_STORAGE
-  var BDA_STORAGE, BDA;
-
-  // Jquery plugin creation
-  $.fn.bdaRepository = function(theBDA) {
-    logTrace('Init plugin {0}'.format('bdaRepository'));
-    //settings = $.extend({}, defaults, options);
-    BDA = theBDA;
-    BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
-    BDA_REPOSITORY.build();
-    return this;
-  };
-
-  $.fn.bdaRepository.reloadQueryList = function() {
-    if (BDA_REPOSITORY.isRepositoryPage)
-      BDA_REPOSITORY.reloadQueryList();
-  };
-
-  $.fn.executePrintItem = function(domain, itemDescriptor, id, repository, callback, errCallback) {
-    BDA_REPOSITORY.executePrintItem(domain, itemDescriptor, id, repository, callback, errCallback);
-  };
-
-  $.fn.executeQueryItems = function(domain, itemDescriptor, query, repository, callback, errCallback) {
-    BDA_REPOSITORY.executeQueryItems(domain, itemDescriptor, query, repository, callback, errCallback);
-  };
-
-  $.fn.executeRql = function(domain, xmlText, repository, callback, errCallback) {
-    BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
-  };
-
-  $.fn.previewRql = function(queryType, values) {
-    return BDA_REPOSITORY.previewRql(queryType, values);
-  }
-
-  $.fn.getBdaRepository = function() {
-    return BDA_REPOSITORY;
-  };
+    $.fn.getBdaRepository = function() {
+        return BDA_REPOSITORY;
+    };
 
 })(jQuery);

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1220,7 +1220,8 @@
       $outputDiv.append("<div class='prop_attr prop_attr_red'>R</div> : read-only " +
         "<div class='prop_attr prop_attr_green'>D</div> : derived " +
         "<div class='prop_attr prop_attr_blue'>E</div> : export is false," +
-        '&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i> : Link to other Repository');
+        '&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i> : Link to other Repository,' +
+        '&nbsp;<span class="default">grey</span> : default value');
 
       // show all button
       let showAll = $('<button>Show All <i class="fa fa-expand" aria-hidden="true"></i></button>');
@@ -1505,6 +1506,7 @@
 
     buildPropertyValueCell: function(item, property, referencePropertyValue, repository) {
       let propertyValue = item.values[property.name];
+      console.log('buildPropertyValueCell : propertyValue', propertyValue);
       let val;
       try {
         val = propertyValue.value;
@@ -1525,6 +1527,9 @@
       res = $(BDA_REPOSITORY.templates.propertyCell.format(innerVal, item.id, property.name));
       if (long) {
         res.addClass('toggable');
+      }
+      if (propertyValue.isDefault) {
+        res.addClass('default');
       }
 
       //enable local collapse/expand

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -172,14 +172,14 @@
       printItem: '<print-item item-descriptor="{0}" id="{1}"/>',
       queryItems: '<query-items item-descriptor="{0}">\n{1}\n</query-items>',
       resultHeader: '<p class="nbResults"> {0} items in {1} descriptor(s)</p>',
-      resultTable: '<table class="dataTable" data-descriptor="{0}" data-repository="{1}"></table>',
+      resultTable: '<table class="dataTable twbs" data-descriptor="{0}" data-repository="{1}"></table>',
       idCell: '<td class="property idCell" data-identifier="id_{0}_{1}" data-id="{0}" data-item="{1}" data-repository="{2}" >' +
         '<div class="flex-wrapper">' +
         '<div class="value-elem">{0}</div>' +
         '<span class="actions">' +
-        '<i class="fa fa-refresh action reload-item" aria-hidden="true"></i>' +
-        '<i class="fa fa-code action copy-xml" aria-hidden="true"></i>' +
-        '<i class="fa fa-close action close-elem" aria-hidden="true"></i>' +
+        '<i class="fa fa-refresh action reload-item" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Refresh this item\'s view"></i>' +
+        '<i class="fa fa-code action copy-xml" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Copy xml to clipboard"></i>' +
+        '<i class="fa fa-close action close-elem" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Close the view for this item"></i>' +
         '</div>' +
         '</span>' +
         '</div>' +
@@ -188,9 +188,9 @@
       propertyCell: '<td data-property="{2}" data-id="{1}" class="property show-short {3} {4}"><div class="flex-wrapper">' +
         '{0}' +
         '<span class="actions">' +
-        '<i class="fa fa-edit action start-edit" aria-hidden="true"></i>' +
-        '<i class="fa fa-compress action collapse" aria-hidden="true"></i>' +
-        '<i class="fa fa-expand action expand" aria-hidden="true"></i>' +
+        '<i class="fa fa-edit action start-edit" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Edit this field"></i>' +
+        '<i class="fa fa-compress action collapse" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Collapse view"></i>' +
+        '<i class="fa fa-expand action expand" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Expand this field"></i>' +
         '<i class="fa fa-spinner fa-spin passive-loading-icon" aria-hidden="true"></i>' +
         '</span>' +
         '</div></td>',
@@ -1542,6 +1542,7 @@
           .on('click', '.loadable_property', function() {
             BDA_REPOSITORY.onClickOnLoadSubItem($(this));
           })
+        table.find('[data-toggle="tooltip"]').tooltip();
         console.timeEnd('bind actions');
 
         console.timeEnd('build all items');

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -73,7 +73,7 @@
     hasResults: false,
     templates: {
       printItem: '<print-item item-descriptor="{0}" id="{1}"/>',
-      queryItems: '<query-items item-descriptor="{0}">{1}</query-items>'
+      queryItems: '<query-items item-descriptor="{0}">\n{1}\n</query-items>'
     },
     cmAutocomplete: {
       tags: {
@@ -1884,6 +1884,22 @@
       BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
     },
 
+    previewRql: function(queryType, values) {
+      let xmlText;
+      switch (queryType) {
+        case 'print':
+          xmlText = BDA_REPOSITORY.templates.printItem.format(values.itemDescriptor, values.id);
+          break;
+        case 'query':
+          xmlText = BDA_REPOSITORY.templates.queryItems.format(values.itemDescriptor, values.text);
+          break;
+        default:
+          xmlText = values.text
+
+      }
+      return xmlText;
+    },
+
     setupRepositoryCacheSection: function() {
 
       try {
@@ -2219,6 +2235,10 @@
   $.fn.executeRql = function(domain, xmlText, repository, callback, errCallback) {
     BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
   };
+
+  $.fn.previewRql = function(queryType, values) {
+    return BDA_REPOSITORY.previewRql(queryType, values);
+  }
 
   $.fn.getBdaRepository = function() {
     return BDA_REPOSITORY;

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -263,6 +263,9 @@
 
       $(BDA_REPOSITORY.descriptorTableSelector).attr("id", "descriptorTable");
 
+      //save the native form in variable before adding more forms with the showRQLResults methods (inline forms)
+      BDA_REPOSITORY.initialForm = $("form:eq(1)");
+
       $("<div id='RQLEditor'></div>").insertBefore("h2:first");
       $("<div id='RQLResults'></div>").insertBefore("#RQLEditor");
       if (BDA_REPOSITORY.hasErrors)
@@ -270,8 +273,9 @@
       if (BDA_REPOSITORY.hasResults && !BDA_REPOSITORY.hasErrors)
         BDA_REPOSITORY.showRQLResults();
 
-      $("form:eq(1)").appendTo("#RQLEditor");
-      $("form:eq(1)").attr("id", "RQLForm");
+      BDA_REPOSITORY.initialForm
+        .appendTo("#RQLEditor")
+        .attr("id", "RQLForm");
       var $children = $("#RQLForm").children();
       $("#RQLForm").empty().append($children);
       $("textarea[name=xmltext]").attr("id", "xmltext");

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1277,9 +1277,32 @@
             doDisplay = false;
           }
           if (doDisplay) {
-            let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property));
             let line = $('<tr class="{0}"></tr>'.format(getEvenOddClass(index)));
-            $('<th>{0}</th>'.format(property.name)).appendTo(line);
+
+
+
+            //build property name cell
+            // the following flags have been set on the repoItem level :
+
+            let propertyNameCell = $('<th>{0}<span class="prop_name"></span></th>'.format(property.name)).appendTo(line);
+
+            let sampleItem = _.find(items, item => !_.isNil(item.values[property.name]));
+
+            if (!_.isNil(sampleItem)) {
+              let sampleProperty = sampleItem.values[property.name];
+              if (!!sampleProperty.derived) {
+                propertyNameCell.append('<div class="prop_attr prop_attr_red">R</div>');
+              }
+              if (!!sampleProperty.rdonly) {
+                propertyNameCell.append('<div class="prop_attr prop_attr_green">D</div>');
+              }
+              if (!!sampleProperty.exportable) {
+                propertyNameCell.append('<div class="prop_attr prop_attr_blue">E</div>');
+              }
+            }
+
+            // add all cells
+            let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property));
             _.each(cells, cell => cell.appendTo(line));
             line.appendTo(table);
             index++;
@@ -1294,7 +1317,6 @@
     buildPropertyValueCell: function(item, property) {
       let val;
       try {
-
         val = item.values[property.name].value;
       } catch (e) {
         val = '';
@@ -1308,7 +1330,7 @@
     oldShowXMLAsTab: function(xmlContent, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
 
 
-      console.time("renderTab");
+      console.time("oldShowXMLAsTab");
       var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
       var $xml = $(xmlDoc);
       var $addItems = $xml.find("add-item");
@@ -1441,7 +1463,7 @@
       if (isItemTree)
         BDA_REPOSITORY.createSpeedbar();
 
-      console.timeEnd("renderTab");
+      console.timeEnd("oldShowXMLAsTab");
       return log;
     },
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1591,10 +1591,12 @@
                 //find the item if same id
                 // load the result in the parent section (repo/itemtree/dashscreen)
                 let outputDiv = $this.closest('.rqlResultContainer');
-                let resultTable = outputDiv.find('[data-identifier="id_{0}_{1}"]'.format(elem.id, property.itemType));
+                let selector = '[data-identifier="id_{0}_{1}"]'.format(elem.id, property.itemType);
+                let resultTable = outputDiv.find(selector);
                 // if the result already exists, just scroll to it
                 if (resultTable.length > 0) {
                   resultTable.scrollTo();
+                  resultTable.find('[data-id="{0}"]'.format(elem.id)).flash();
                 } else {
                   let $property = $this.parent().parent();
                   $property.addClass('loading');
@@ -1793,6 +1795,8 @@
               let idSelector = '.idCell[data-identifier="id_{0}_{1}"]'.format(id, itemDescriptorName);
               parentTab.find(idSelector).replaceWith(tempResult.find(idSelector));
 
+              parentTab.find('[data-id="{0}"]'.format(id)).flash();
+
               if (cb) {
                 cb();
               }
@@ -1839,6 +1843,7 @@
             BDA_REPOSITORY.reloadSpeedBar($outputDiv);
             if (top) {
               top.scrollTo();
+              top.find('[data-id="{0}"]'.format(id)).flash();
             }
             if (cbSuccess) {
               cbSuccess();

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1749,7 +1749,7 @@
           let resultTable = outputDiv.find(selector);
           // if the result already exists, just scroll to it
           if (resultTable.length > 0) {
-            resultTable.scrollTo();
+            $(window).scrollTo(resultTable, 100);
             resultTable.find('[data-id="{0}"]'.format(itemId)).flash(); //flash the whole tab
           } else {
             let $property = $this.parent().parent();
@@ -1993,7 +1993,7 @@
 
             BDA_REPOSITORY.reloadSpeedBar($outputDiv);
             if (top) {
-              top.scrollTo();
+              $(window).scrollTo(top, 100);
               top.find('[data-id="{0}"]'.format(id)).flash();
             }
             if (cbSuccess) {
@@ -2746,7 +2746,7 @@
 
           var nbItem = $tab.find("td").length / $tab.find("tr").length;
           let elem = $("<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<span class='clickable_property'>" + descriptor + "</span> (" + nbItem + ")</li>");
-          elem.on('click', () => $tab.scrollTo());
+          elem.on('click', () => $(window).scrollTo($tab, 100));
           list.append(elem);
         });
 
@@ -2755,12 +2755,7 @@
           .on('click', () => resultElem.find('.speedbar').fadeIn(200));
 
         resultElem.find('#resultToolbar').append(button);
-
-
-
         speedbar.prependTo(resultElem);
-
-
 
         let container = $(resultElem);
 
@@ -3267,7 +3262,7 @@
       var setupDone = false;
       $(window).scroll(function() { // scroll event
         var $window = $(window);
-        var windowTop = $window.scrollTop();
+        var windowTop = $$(window).scrollTop();
         //get the value now because it changes on show/hide/collapse
         var top = $cacheTable.offset().top;
         var bot = top + $cacheTable.height();

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1520,6 +1520,22 @@ console.timeEnd('formatTabResult');
             index++;
 
           });
+
+        //enable local collapse/expand
+        console.time('bind actions');
+        tbody.find('.actions')
+        .on('click', '.collapse', function() {
+          $(this).closest('.property').addClass('show-short').removeClass('show-long');
+        })
+        .on('click', '.expand', function() {
+          $(this).closest('.property').removeClass('show-short').addClass('show-long');
+        })
+        .on('click', '.start-edit', function() {
+          $(this).closest('.property').addClass('show-edit').find('.inline-input').focus();
+
+        })
+        console.timeEnd('bind actions');
+
         console.timeEnd('build all items');
         res = table;
       }
@@ -1556,18 +1572,6 @@ console.timeEnd('formatTabResult');
         res.addClass('default');
       }
 
-      // //enable local collapse/expand
-      // res.find('.actions')
-      //   .on('click', '.collapse', function() {
-      //     $(this).closest('.property').addClass('show-short').removeClass('show-long');
-      //   })
-      //   .on('click', '.expand', function() {
-      //     $(this).closest('.property').removeClass('show-short').addClass('show-long');
-      //   })
-      //   .on('click', '.start-edit', function() {
-      //     $(this).closest('.property').addClass('show-edit').find('.inline-input').focus();
-
-      //   })
 
       // for id of other items, load sub item on click
       let longCell = res.find('.propertyValue');
@@ -1575,14 +1579,14 @@ console.timeEnd('formatTabResult');
 
       if (property.isItem) {
 
-       // BDA_REPOSITORY.buildLinkToOtherItem(longCell, val, property);
+        BDA_REPOSITORY.buildLinkToOtherItem(longCell, val, property);
 
       } else {
         longCell.append(val);
       }
 
       if (!_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
-     //   BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
+        BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
       }
       // console.timeEnd('buildPropertyValueCell ' + property.name);
       return res;

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1267,11 +1267,6 @@
 
       $outputDiv.append($('<p></p>').append(showAll).append(hideAll));
 
-      if (isItemTree) {
-        $('<button>Show speedbar</button></p>')
-          .on('click', () => $('#speedbar').fadeIn(200))
-          .appendTo($outputDiv);
-      }
 
 
       BDA_REPOSITORY.formatTabResult(repository, items, $outputDiv);
@@ -2741,7 +2736,8 @@
         })
 
         let list = speedbar.find('ul');
-        resultElem.find(".dataTable").each(function(index) {
+        let dataTable = resultElem.find(".dataTable");
+        dataTable.each(function(index) {
           var $tab = $(this);
           var id = $tab.attr("id");
           var descriptor = $tab.attr('data-descriptor');
@@ -2751,7 +2747,14 @@
           elem.on('click', () => $tab.scrollTo());
           list.append(elem);
         });
+
+        $('<button>Show speedbar</button></p>')
+          .on('click', () => resultElem.find('.speedbar').fadeIn(200))
+          .prependTo(resultElem);
+
         speedbar.prependTo(resultElem);
+
+
 
         let container = $(resultElem);
 
@@ -2766,6 +2769,8 @@
             widget.removeClass('sticky-top-100');
           }
         });
+
+
 
       } catch (e) {
         console.error(e);

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1611,17 +1611,22 @@
                 _callback: function() {
                   BDA_REPOSITORY.executeQuery('', xmlText, getCurrentComponentPath(),
                     (result) => {
-                      var xmlContent = $('<div>' + result + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
-                      let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
+                      try {
+                        var xmlContent = $('<div>' + result + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
+                        let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
+                        $.notify(
+                          "Success: \n{0}".format(logs), {
+                            className: "success",
+                            position: "top center",
+                            autoHideDelay: 5000
 
-                      $.notify(
-                        $("<div>Success: \n<pre>{0}</pre></div>".format(logs)), {
-                          className: "success",
-                          position: "top center",
-                          autoHideDelay: 5000
+                          }
+                        );
 
-                        }
-                      );
+                      } catch (e) {
+                        console.error(e);
+                      }
+
                     },
                     (jqXHR, textStatus, errorThrown) => {
                       $.notify(

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1445,7 +1445,7 @@ console.timeEnd('formatTabResult');
 
         let tbody = $('<tbody></tbody>').appendTo(table);
         //for each property, get 
-        let index = 0;
+        let index = 1;
         console.time('build all items');
         _(itemDescriptor.properties)
           .each((property) => {
@@ -1453,45 +1453,47 @@ console.timeEnd('formatTabResult');
             // hiden lines that have all null values
             let lineIsVisible = !!renderContext[itemDescriptor.name][property.name]
 
-            let line = $('<tr class="item-line {0} {1}" data-property="{2}"></tr>'.format('', lineIsVisible ? '' : 'hidden', property.name));
+            let line = $('<tr class="item-line {0} {1}" data-property="{2}"></tr>'.format(getEvenOddClass(index), lineIsVisible ? '' : 'hidden', property.name));
 
             //build property name cell
             // the following flags have been set on the repoItem level :
+            if(lineIsVisible){
+              index++;
 
-            let propertyNameCell = $('<th>{0}<span class="prop_name"></span></th>'.format(property.name)).appendTo(line);
+              let propertyNameCell = $('<th>{0}<span class="prop_name"></span></th>'.format(property.name)).appendTo(line);
 
-            let sampleItem = _.find(items, item => !_.isNil(item.values[property.name]));
+              let sampleItem = _.find(items, item => !_.isNil(item.values[property.name]));
 
-            if (!_.isNil(sampleItem)) {
-              let sampleValue = sampleItem.values[property.name];
-              if (!!sampleValue.derived) {
-                propertyNameCell.append('<div class="prop_attr prop_attr_green">D</div>');
-                line.addClass('derived');
+              if (!_.isNil(sampleItem)) {
+                let sampleValue = sampleItem.values[property.name];
+                if (!!sampleValue.derived) {
+                  propertyNameCell.append('<div class="prop_attr prop_attr_green">D</div>');
+                  line.addClass('derived');
+                }
+                if (!!sampleValue.rdonly) {
+                  propertyNameCell.append('<div class="prop_attr prop_attr_red">R</div>');
+                  line.addClass('rdonly');
+                }
+                if (!!sampleValue.exportable) {
+                  propertyNameCell.append('<div class="prop_attr prop_attr_blue">E</div>');
+                  line.addClass('exportable');
+                }
+                if (property.isItem && !property.isItemOfSameRepository) {
+                  propertyNameCell.append('&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i>');
+                  line.addClass('other-repository');
+                }
               }
-              if (!!sampleValue.rdonly) {
-                propertyNameCell.append('<div class="prop_attr prop_attr_red">R</div>');
-                line.addClass('rdonly');
-              }
-              if (!!sampleValue.exportable) {
-                propertyNameCell.append('<div class="prop_attr prop_attr_blue">E</div>');
-                line.addClass('exportable');
-              }
-              if (property.isItem && !property.isItemOfSameRepository) {
-                propertyNameCell.append('&nbsp;<i class="fa fa-external-link-square" aria-hidden="true"></i>');
-                line.addClass('other-repository');
-              }
+
+              // add all cells
+               //   console.time('build all cells');
+              let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem, repo));
+             // console.timeEnd('build all cells');
+              //console.time('append all cells');
+
+              _.each(cells, cell => cell.appendTo(line));
             }
-
-            // add all cells
-             //   console.time('build all cells');
-            let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem, repo));
-           // console.timeEnd('build all cells');
-            //console.time('append all cells');
-
-            _.each(cells, cell => cell.appendTo(line));
          //   console.timeEnd('append all cells');
             line.appendTo(tbody);
-            index++;
 
           });
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1749,13 +1749,12 @@
           let resultTable = outputDiv.find(selector);
           // if the result already exists, just scroll to it
           if (resultTable.length > 0) {
-            $(window).scrollTo(resultTable, 100);
+            $(window).scrollTo(resultTable, 500);
             resultTable.find('[data-id="{0}"]'.format(itemId)).flash(); //flash the whole tab
           } else {
-            let $property = $this.parent().parent();
-            $property.addClass('loading');
+            property.addClass('loading');
             let endLoadingFc = () => {
-              $property.removeClass('loading');
+              property.removeClass('loading');
             };
             BDA_REPOSITORY.loadSubItem(itemId, itemType, repositoryPath, outputDiv, null, null, endLoadingFc);
           }
@@ -1993,7 +1992,7 @@
 
             BDA_REPOSITORY.reloadSpeedBar($outputDiv);
             if (top) {
-              $(window).scrollTo(top, 100);
+              $(window).scrollTo(top, 500);
               top.find('[data-id="{0}"]'.format(id)).flash();
             }
             if (cbSuccess) {
@@ -2746,12 +2745,12 @@
 
           var nbItem = $tab.find("td").length / $tab.find("tr").length;
           let elem = $("<li><i class='fa fa-arrow-right'></i>&nbsp;&nbsp;<span class='clickable_property'>" + descriptor + "</span> (" + nbItem + ")</li>");
-          elem.on('click', () => $(window).scrollTo($tab, 100));
+          elem.on('click', () => $(window).scrollTo($tab, 500));
           list.append(elem);
         });
 
 
-        let button = $('<button>Show Quick Links <i class="fa fa-bars" aria-hidden="true"></i></button>')
+        let button = $('<button class="showSpeedbar">Show Quick Links <i class="fa fa-bars" aria-hidden="true"></i></button>')
           .on('click', () => resultElem.find('.speedbar').fadeIn(200));
 
         resultElem.find('#resultToolbar').append(button);
@@ -2781,6 +2780,7 @@
 
     reloadSpeedBar: function(resultElem) {
       resultElem.find('.speedbar').remove();
+      resultElem.find('.showSpeedbar').remove();
       BDA_REPOSITORY.createSpeedbar_new(resultElem);
     },
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -252,7 +252,7 @@
       BDA_REPOSITORY.isRepositoryPage = BDA_REPOSITORY.isRepositoryPageFct();
       BDA_REPOSITORY.hasErrors = BDA_REPOSITORY.hasErrorsFct();
       BDA_REPOSITORY.hasResults = BDA_REPOSITORY.hasResultsFct(BDA_REPOSITORY.hasErrors);
-      console.log("isRepositoryPage : " + BDA_REPOSITORY.isRepositoryPage + " Page has results : " + BDA_REPOSITORY.hasResults + ". Page has errors : " + BDA_REPOSITORY.hasErrors);
+      logTrace("isRepositoryPage : " + BDA_REPOSITORY.isRepositoryPage + " Page has results : " + BDA_REPOSITORY.hasResults + ". Page has errors : " + BDA_REPOSITORY.hasErrors);
       // Setup repository page
       if (BDA_REPOSITORY.isRepositoryPage)
         BDA_REPOSITORY.setupRepositoryPage();
@@ -338,7 +338,7 @@
       $("#storedQueries").css("display", "none");
 
       $("#queriesTab").click(function() {
-        console.log("show stored queries");
+        logTrace("show stored queries");
         $("#descProperties").css("display", "none");
         $("#storedQueries").css("display", "inline-block");
         $(this).addClass("selected");
@@ -346,7 +346,7 @@
       });
 
       $("#propertiesTab").click(function() {
-        console.log("show properties");
+        logTrace("show properties");
         $("#descProperties").css("display", "inline-block");
         $("#storedQueries").css("display", "none");
         $(this).addClass("selected");
@@ -356,7 +356,7 @@
 
       $("#RQLAction").change(function() {
         var action = $(this).val();
-        console.log("Action change : " + action);
+        logTrace("Action change : " + action);
         if (action == "print-item")
           BDA_REPOSITORY.getPrintItemEditor();
         else if (action == "query-items")
@@ -873,7 +873,7 @@
     getRQLQuery: function() {
       var query = "";
       var action = $("#RQLAction").val();
-      console.log("getRQLQuery : " + action);
+      logTrace("getRQLQuery : " + action);
       if (action == "print-item")
         query = BDA_REPOSITORY.getPrintItemQuery();
       else if (action == "query-items")
@@ -1164,7 +1164,7 @@
     },
 
     getRepositoryAsync: function(path, callback) {
-      console.log('getRepositoryAsync', path);
+      logTrace('getRepositoryAsync', path);
       let repository = BDA_REPOSITORY.repositories[path];
       if (_.isNil(repository)) {
         processRepositoryXmlDef("definitionFiles",
@@ -1180,7 +1180,7 @@
     },
 
     getRepository: function($xmlDef, repositoryPath) {
-      console.log('getRepository', repositoryPath);
+      logTrace('getRepository', repositoryPath);
       let repository = BDA_REPOSITORY.repositories[repositoryPath];
       if (_.isNil(repository)) {
         repository = new Repository({
@@ -1261,12 +1261,12 @@
 
       BDA_REPOSITORY.getRepositoryAsync(repositoryPath, (repository) => {
         try {
-          console.log('parseXhrResult', repositoryPath, xhrResult);
+          logTrace('parseXhrResult', repositoryPath, xhrResult);
           var rawXml = $('<div>' + xhrResult + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
           let xmlContent = sanitizeXml(rawXml);
           let result = BDA_REPOSITORY.parseXmlResult(xmlContent, repository, rawXml);
           result.repository = repository;
-          console.log('parseXhrResult result:', result);
+          logTrace('parseXhrResult result:', result);
           callback(result);
         } catch (e) {
           console.error(e);
@@ -1454,7 +1454,7 @@
           copyToClipboard($(this).closest('.property').data('repositoryItem').rawXml);
         })
         idLine.find('.close-elem').on('click', function() {
-          console.log('close-elem', $(this));
+          logTrace('close-elem', $(this));
           BDA_REPOSITORY.closeTab($(this).closest('.property'));
         })
 
@@ -1514,7 +1514,7 @@
 
     buildPropertyValueCell: function(item, property, referencePropertyValue, repository) {
       let propertyValue = item.values[property.name];
-      console.log('buildPropertyValueCell : propertyValue', propertyValue);
+      logTrace('buildPropertyValueCell : propertyValue', propertyValue);
       let val;
       try {
         val = propertyValue.value;
@@ -1738,7 +1738,7 @@
     },
     closeTab: function(idCell, container) {
       try {
-        console.log('closetab', idCell);
+        logTrace('closetab', idCell);
         let tab = idCell.closest('.dataTable');
         tab.find('[data-id="{0}"]'.format(idCell.attr('data-id'))).remove();
         //if last item remove tab
@@ -1758,10 +1758,10 @@
       let dataTables = outputDiv.find('.dataTable[data-descriptor="{0}"]'.format(itemDescriptorName));
       var max = BDA_REPOSITORY.getChunkSize();
       let res;
-      console.log('dataTables', dataTables);
+      logTrace('dataTables', dataTables);
       dataTables.each(function(idx, table) {
         let $table = $(table);
-        console.log('table', $table);
+        logTrace('table', $table);
         if ($table.find('.idCell').length < max) {
           res = $table;
         }
@@ -2031,7 +2031,7 @@
     },
 
     showLoadSubItemAlert: function() {
-      console.log('click on loadable');
+      logTrace('click on loadable');
       var $elm = $(this);
       var id = $elm.attr("data-id");
       var itemDesc = $elm.attr("data-descriptor");
@@ -2187,7 +2187,7 @@
 
       // Ensure that getSubItems is not call more than maxItem times
       if (nbItem >= maxItem) {
-        console.log("max Item (" + maxItem + ") reached, stopping recursion");
+        logTrace("max Item (" + maxItem + ") reached, stopping recursion");
         return;
       }
 
@@ -2288,7 +2288,7 @@
     },
 
     getItemTree: function(id, descriptor, maxItem, outputType, printRepoAttr) {
-      console.log("getItemTree - start");
+      logTrace("getItemTree - start");
       // reset divs
       $("#itemTreeResult").empty();
       $("#itemTreeInfo").empty();
@@ -2320,7 +2320,7 @@
 
     renderItemTreeTab: function(outputType, printRepoAttr, $xmlDef, maxItem) {
       console.timeEnd("retrieveItem");
-      console.log("Render item tree tab : " + outputType);
+      logTrace("Render item tree tab : " + outputType);
 
       //  If the max item is reached before recursion ended, we notify the user
       if (BDA_REPOSITORY.nbItemReceived >= maxItem) {
@@ -2386,7 +2386,7 @@
     },
 
     renderAsTree: function($xmlDef) {
-      console.log("render as tree");
+      logTrace("render as tree");
       console.time('renderAsTree.setup');
       var nodes = new vis.DataSet();
       var edges = new vis.DataSet();
@@ -2447,7 +2447,7 @@
       $("#itemTreeResult").empty()
         .append("<div class='popup_block' id='treePopup'>" + "<div><a href='javascript:void(0)' class='close'><i class='fa fa-times'></i></a></div>" + "<div id='treeLegend'></div>" + "<div class='flexContainer'>" + "<div id='treeInfo'></div>" + "<div id='treeContainer'></div>" + "</div>" + "</div>");
       $("#treePopup .close").click(function() {
-        console.log("click on close");
+        logTrace("click on close");
         $("#treePopup").hide();
       });
 
@@ -2456,8 +2456,8 @@
         $("#treeLegend").append("<div class='legend' style='background-color:" + value + "' id='" + key + "'>" + key + "</div>");
       });
 
-      console.log("Number for nodes : " + nodes.length);
-      console.log("Number for edges : " + edges.length);
+      logTrace("Number for nodes : " + nodes.length);
+      logTrace("Number for edges : " + edges.length);
 
       $("#treePopup").show();
       console.time('renderAsTree.render');
@@ -2492,7 +2492,7 @@
           $("#treeInfo").empty();
           var visId = params.nodes[0];
           var itemId = null;
-          console.log("Click on " + visId);
+          logTrace("Click on " + visId);
           // Find itemId from visID
           for (var id in itemIdToVisId) {
             if (visId === itemIdToVisId[id]) {
@@ -2500,10 +2500,10 @@
               break;
             }
           }
-          console.log("itemId : " + itemId);
-          console.log(BDA_REPOSITORY.itemTree.get(itemId));
+          logTrace("itemId : " + itemId);
+          logTrace(BDA_REPOSITORY.itemTree.get(itemId));
           BDA_REPOSITORY.showXMLAsTab(BDA_REPOSITORY.itemTree.get(itemId), null, $("#treeInfo"), false);
-          console.log($("#treeInfo").html());
+          logTrace($("#treeInfo").html());
           $("#treeInfo").show();
         }
       });
@@ -2511,9 +2511,9 @@
       $(".legend").click(function() {
         // This feature is disabled for now.
         return;
-        console.log("click on legend");
+        logTrace("click on legend");
         var id = $(this).attr('id');
-        console.log(id);
+        logTrace(id);
         var ids = descById.get(id);
         var nodesAndEdgesToHide = {};
         for (var i = 0; i != ids.length; i++) {
@@ -2538,38 +2538,38 @@
     },
 
     findNodesAndEdgesToHide: function(id, network, edges, nodes) {
-      console.log("findNodesAndEdgesToHide for ID : " + id);
+      logTrace("findNodesAndEdgesToHide for ID : " + id);
       var nodesAndEdgesToHide = {};
       nodesAndEdgesToHide.nodes = BDA_REPOSITORY.findOrphanSon(id, network, edges, nodes, [id]);
       nodesAndEdgesToHide.edges = [];
       for (var i = 0; i != nodesAndEdgesToHide.nodes.length; i++) {
         nodesAndEdgesToHide.edges = nodesAndEdgesToHide.edges.concat(network.getConnectedEdges(nodesAndEdgesToHide.nodes[i]));
       }
-      console.log("nodesAndEdgesToHide.nodes : ");
-      console.log(nodesAndEdgesToHide.nodes);
-      console.log("nodesAndEdgesToHide.edges : ");
-      console.log(nodesAndEdgesToHide.edges);
+      logTrace("nodesAndEdgesToHide.nodes : ");
+      logTrace(nodesAndEdgesToHide.nodes);
+      logTrace("nodesAndEdgesToHide.edges : ");
+      logTrace(nodesAndEdgesToHide.edges);
       return nodesAndEdgesToHide;
     },
 
     findOrphanSon: function(id, network, edges, nodes, orphanSons) {
-      console.log("About to find orphan for node : " + id);
+      logTrace("About to find orphan for node : " + id);
       edges.forEach(function(elm) {
-        //console.log(elm);
+        //logTrace(elm);
         if (elm.from == id) {
           var isOrphan = true;
           var connectedEdges = network.getConnectedEdges(elm.to);
 
           for (var i = 0; i != connectedEdges.length; i++) {
             var edge = edges.get(connectedEdges[i]);
-            console.log("connectedEdge - from : " + edge.to + " - " + edge.from);
+            logTrace("connectedEdge - from : " + edge.to + " - " + edge.from);
             if (edge.to == elm.to && edge.from != id) {
               isOrphan = false;
               break;
             }
           }
           if (isOrphan && orphanSons.indexOf(elm.to) === -1) {
-            console.log(elm.to + " is a new orphan son of node : " + id);
+            logTrace(elm.to + " is a new orphan son of node : " + id);
             orphanSons.push(elm.to);
             BDA_REPOSITORY.findOrphanSon(elm.to, network, edges, nodes, orphanSons);
           }
@@ -2580,7 +2580,7 @@
 
 
     createSpeedbar_new: function(resultElem) {
-      console.log('createSpeedbar_new')
+      logTrace('createSpeedbar_new')
       try {
 
         let speedbar = $('<div class="speedbar"><div class="widget"><i class="fa fa-times close"></i><p>Quick links :</p><ul></ul></div></div>');
@@ -2696,7 +2696,7 @@
       // });
 
       $(".savedQuery").on('click', 'a', function() {
-        console.log("click on query : " + $(this).find("a").html());
+        logTrace("click on query : " + $(this).find("a").html());
         BDA_REPOSITORY.printStoredQuery($(this).find("a").html());
       });
 
@@ -2726,7 +2726,7 @@
       $(".deleteQuery")
         .click(function() {
           var index = this.id.replace("deleteQuery", "");
-          console.log("Delete query #" + index);
+          logTrace("Delete query #" + index);
           logTrace(BDA_STORAGE.deleteRQLQuery);
           BDA_STORAGE.deleteRQLQuery(index);
           BDA_REPOSITORY.reloadQueryList();
@@ -2751,7 +2751,7 @@
     },
 
     printStoredQuery: function(name) {
-      console.log("printStoredQuery : " + name);
+      logTrace("printStoredQuery : " + name);
       var rqlQueries = BDA_STORAGE.getStoredRQLQueries();
       logTrace(rqlQueries);
       if (rqlQueries) {
@@ -3059,7 +3059,7 @@
 
       //make the header fixed with css
       $cacheTable.addClass('fixed_headers');
-      console.log('isOldDynamo ' + BDA.isOldDynamo)
+      logTrace('isOldDynamo ' + BDA.isOldDynamo)
       if (BDA.isOldDynamo) {
         $cacheTable.addClass('oldDynamo');
       }
@@ -3216,7 +3216,7 @@
 
   // Jquery plugin creation
   $.fn.bdaRepository = function(theBDA) {
-    console.log('Init plugin {0}'.format('bdaRepository'));
+    logTrace('Init plugin {0}'.format('bdaRepository'));
     //settings = $.extend({}, defaults, options);
     BDA = theBDA;
     BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1720,13 +1720,15 @@
 
 
     },
-    closeTab: function(idCell) {
+    closeTab: function(idCell, container) {
       try {
         console.log('closetab', idCell);
         let tab = idCell.closest('.dataTable');
         tab.find('[data-id="{0}"]'.format(idCell.attr('data-id'))).remove();
         //if last item remove tab
         let tabSize = tab.find('.idCell').length;
+        let container = tab.closest('.rqlResultContainer');
+        BDA_REPOSITORY.reloadSpeedBar(container);
         if (tabSize == 0) {
           tab.remove();
         }

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1591,12 +1591,12 @@
                 //find the item if same id
                 // load the result in the parent section (repo/itemtree/dashscreen)
                 let outputDiv = $this.closest('.rqlResultContainer');
-                let selector = '[data-identifier="id_{0}_{1}"]'.format(elem.id, property.itemType);
+                let selector = '.idCell[data-id="{0}"]'.format(elem.id);
                 let resultTable = outputDiv.find(selector);
                 // if the result already exists, just scroll to it
                 if (resultTable.length > 0) {
                   resultTable.scrollTo();
-                  resultTable.find('[data-id="{0}"]'.format(elem.id)).flash();
+                  resultTable.find('[data-id="{0}"]'.format(elem.id)).flash(); //flash the whole tab
                 } else {
                   let $property = $this.parent().parent();
                   $property.addClass('loading');
@@ -1764,7 +1764,7 @@
       })
 
       //  update the data
-      let idSelector = '.idCell[data-identifier="id_{0}_{1}"]'.format(id, itemDescriptorName);
+      let idSelector = '.idCell[data-id="{0}"]'.format(id, itemDescriptorName);
       dataTable.find('tr.id').append(tempResult.find(idSelector));
       if (cb) {
         cb();
@@ -1832,11 +1832,14 @@
             let temp = $('<div></div>');
 
             let top = BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, temp);
-            let targetTab = BDA_REPOSITORY.findTabToAppendTo(itemDescriptorName, $outputDiv);
+            //use the itemDescriptor from the result, not the query (ex payment group vs creditCard)
+
+            let resultDescriptorName = _.first(parsed.items).itemDescriptor.name;
+            let targetTab = BDA_REPOSITORY.findTabToAppendTo(resultDescriptorName, $outputDiv);
             if (_.isNil(targetTab) || targetTab.length === 0) {
               temp.children().appendTo($outputDiv);
             } else {
-              BDA_REPOSITORY.appendToDataTable(id, itemDescriptorName, repositoryPath, targetTab, temp);
+              BDA_REPOSITORY.appendToDataTable(id, resultDescriptorName, repositoryPath, targetTab, temp);
               top = targetTab;
             }
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1207,9 +1207,9 @@
 
       BDA_REPOSITORY.renderResultSection(items, repository, $outputDiv, isItemTree);
 
-      if (isItemTree) {
-        BDA_REPOSITORY.createSpeedbar_new();
-      }
+      //  if (isItemTree) {
+      BDA_REPOSITORY.createSpeedbar_new($outputDiv);
+      //}
 
       console.timeEnd('showXMLAsTab_new');
       return logs;
@@ -1758,8 +1758,9 @@
         function(result) {
           BDA_REPOSITORY.parseXhrResult(result, repositoryPath, (parsed) => {
 
+
             let top = BDA_REPOSITORY.formatTabResult(parsed.repository, parsed.items, $outputDiv);
-            console.log('top', top);
+            BDA_REPOSITORY.reloadSpeedBar($outputDiv);
             if (top) {
               top.scrollTo();
             }
@@ -2476,17 +2477,18 @@
       return orphanSons;
     },
 
-    createSpeedbar_new: function() {
+
+    createSpeedbar_new: function(resultElem) {
       console.log('createSpeedbar_new')
       try {
 
-        let speedbar = $('<div id="speedbar"><div id="widget"><a class="close" href="javascript:void(0)"><i class="fa fa-times"></i></a><p>Quick links :</p><ul></ul></div></div>');
+        let speedbar = $('<div class="speedbar"><div class="widget"><i class="fa fa-times close"></i><p>Quick links :</p><ul></ul></div></div>');
         speedbar.find('.close').on('click', () => {
           speedbar.fadeOut(200);
         })
 
         let list = speedbar.find('ul');
-        $("#itemTreeResult .dataTable").each(function(index) {
+        resultElem.find(".dataTable").each(function(index) {
           var $tab = $(this);
           var id = $tab.attr("id");
           var descriptor = $tab.attr('data-descriptor');
@@ -2496,11 +2498,11 @@
           elem.on('click', () => $tab.scrollTo());
           list.append(elem);
         });
-        speedbar.appendTo('#itemTreeInfo');
+        speedbar.prependTo(resultElem);
 
-        let container = $('#itemTreeResult');
+        let container = $(resultElem);
 
-        let widget = speedbar.find('#widget');
+        let widget = speedbar.find('.widget');
         let initialTop = container.offset().top;
         var initialBot = initialTop + container.height();
         $(window).scroll(function() {
@@ -2516,6 +2518,11 @@
         console.error(e);
       }
 
+    },
+
+    reloadSpeedBar: function(resultElem) {
+      resultElem.find('.speedbar').remove();
+      BDA_REPOSITORY.createSpeedbar_new(resultElem);
     },
 
     createSpeedbar: function() {

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1593,7 +1593,7 @@
               innerVal,
               item.id, 
               property.name,
-              long?'toggagble':'',
+              long?'toggable':'',
               (propertyValue && propertyValue.isDefault)?'default':'',
               displayedVal);
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1526,7 +1526,7 @@
           $(this).closest('.property').removeClass('show-short').addClass('show-long');
         })
         .on('click', '.start-edit', function() {
-          $(this).closest('.property').addClass('show-edit').find('input').focus();
+          $(this).closest('.property').addClass('show-edit').find('.inline-input').focus();
 
         })
 
@@ -1613,7 +1613,7 @@
     addInlineEditForm: function(output, val, property, item, repository) {
       try {
 
-        let form = $('<form class="edit"><textarea class="inline-input"></input></form>');
+        let form = $('<form class="edit"><textarea class="inline-input" rows="1"></input></form>');
         let input = form.find('.inline-input').val(val);
         input.on('blur', function() {
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -309,6 +309,8 @@
       // Init select2 plugin
       $("#RQLAction").select2({
         width: "style",
+        containerCssClass: 'bda-repository',
+        dropdownCssClass: 'bda-repository',
         minimumResultsForSearch: -1
       });
 
@@ -316,6 +318,8 @@
         placeholder: "Select a descriptor",
         allowClear: false,
         width: "element",
+        containerCssClass: 'bda-repository',
+        dropdownCssClass: 'bda-repository',
         matcher: function(params, data) {
           // If there are no search terms, return all of the data
           if ($.trim(params) === '') {

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1424,7 +1424,7 @@
             }
 
             // add all cells
-            let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property));
+            let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem));
             _.each(cells, cell => cell.appendTo(line));
             line.appendTo(tbody);
             index++;
@@ -1436,7 +1436,7 @@
       return res;
     },
 
-    buildPropertyValueCell: function(item, property) {
+    buildPropertyValueCell: function(item, property, referencePropertyValue) {
       let propertyValue = item.values[property.name];
       let val;
       try {
@@ -1482,7 +1482,7 @@
         longCell.append(val);
       }
 
-      if (!_.isNil(propertyValue) && !propertyValue.rdonly && !propertyValue.derived) {
+      if (!_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
         BDA_REPOSITORY.addInlineEditForm(res, val, property, item);
       }
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1404,6 +1404,18 @@
       });
     },
 
+    showNonEmptyLines: function(resultTable) {
+      resultTable.find('.item-line.hidden').each(function() {
+        let line = $(this);
+        let mustShow = _.some(line.find('.propertyValue').get(),
+          (elem) => !_.isEmpty($(elem).attr('data-raw'))
+        );
+        if (mustShow) {
+          line.removeClass('hidden');
+        }
+      })
+    },
+
     buildResultTable: function(items, renderContext, repo) {
       let res;
       if (!_.isNil(items) && items.length > 0) {
@@ -1453,16 +1465,12 @@
         //for each property, get 
         let index = 0;
         _(itemDescriptor.properties)
-          .filter((property, key) => {
-            try {
-              return !!renderContext[itemDescriptor.name][property.name];
-            } catch (e) {
-              return false;
-            }
-          })
           .each((property) => {
 
-            let line = $('<tr class="item-line {0}" data-property="{1}"></tr>'.format(getEvenOddClass(index), property.name));
+            // hiden lines that have all null values
+            let lineIsVisible = !!renderContext[itemDescriptor.name][property.name]
+
+            let line = $('<tr class="item-line {0} {1}" data-property="{2}"></tr>'.format(getEvenOddClass(index), lineIsVisible ? '' : 'hidden', property.name));
 
             //build property name cell
             // the following flags have been set on the repoItem level :
@@ -1528,7 +1536,7 @@
       if (long) {
         res.addClass('toggable');
       }
-      if (propertyValue.isDefault) {
+      if (propertyValue && propertyValue.isDefault) {
         res.addClass('default');
       }
 
@@ -1547,6 +1555,7 @@
 
       // for id of other items, load sub item on click
       let longCell = res.find('.propertyValue');
+      longCell.attr('data-raw', val);
 
       if (property.isItem) {
 
@@ -1771,6 +1780,7 @@
       //  update the data
       let idSelector = '.idCell[data-id="{0}"]'.format(id, itemDescriptorName);
       dataTable.find('tr.id').append(tempResult.find(idSelector));
+      BDA_REPOSITORY.showNonEmptyLines(dataTable);
       if (cb) {
         cb();
       }
@@ -1801,6 +1811,8 @@
               parentTab.find(idSelector).replaceWith(tempResult.find(idSelector));
 
               parentTab.find('[data-id="{0}"]'.format(id)).flash();
+
+              BDA_REPOSITORY.showNonEmptyLines(parentTab);
 
               if (cb) {
                 cb();

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -133,7 +133,8 @@
     hasResults: false,
     templates: {
       printItem: '<print-item item-descriptor="{0}" id="{1}"/>',
-      queryItems: '<query-items item-descriptor="{0}">\n{1}\n</query-items>'
+      queryItems: '<query-items item-descriptor="{0}">\n{1}\n</query-items>',
+      resultHeader: '<p class="nbResults"> {0} items in {1} descriptor(s)</p>'
     },
     cmAutocomplete: {
       tags: {
@@ -1076,12 +1077,7 @@
       return desc;
     },
 
-
-    showXMLAsTab: function(xmlContent, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
-      console.time('renderTab_new');
-      if (_.isEmpty(repositoryPath)) {
-        repositoryPath = getCurrentComponentPath();
-      }
+    getRepository: function(repositoryPath) {
       let repository = BDA_REPOSITORY.repositories[repositoryPath];
       if (_.isNil(repository)) {
         repository = new Repository({
@@ -1090,6 +1086,16 @@
         })
         BDA_REPOSITORY.repositories[repositoryPath] = repository;
       }
+      retun repository;
+    },
+
+
+    showXMLAsTab: function(xmlContent, $xmlDef, $outputDiv, isItemTree, loadSubItemCb, repositoryPath) {
+      console.time('renderTab_new');
+      if (_.isEmpty(repositoryPath)) {
+        repositoryPath = getCurrentComponentPath();
+      }
+      let repository = BDA_REPOSITORY.getRepository(repositoryPath);
       var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
       var $xml = $(xmlDoc);
       var $addItems = $xml.find("add-item");
@@ -1114,7 +1120,7 @@
           let val = new PropertyValue(currentProperty, propertyDescriptor);
           repositoryItem.values[propertyName] = val;
         })
-        console.log('repoItem', repositoryItem);
+        logTrace('repoItem', repositoryItem);
       });
 
 
@@ -1125,6 +1131,17 @@
         .text()
         .trim();
       console.timeEnd('renderTab_new');
+    },
+
+    formatTabResult: function(repository, repositoryItems) {
+      let nbItemDescriptors = _(repositoryItems)
+        .groupBy((repoItem) => repoItem.itemDescriptor ? repoItem.itemDescriptor.name : null)
+        .map((items, name) => ({
+          name,
+          count: items.length
+        }))
+        .value();
+      let res = $(BDA_REPOSITORY.templates.resultHeader.format(repositoryItems.length, nbItemDescriptors))
     },
 
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -253,6 +253,7 @@
 
     build: function() {
       console.time("bdaRepository");
+      BDA_REPOSITORY.PERF_MONITOR = new PerformanceMonitor(true);
       BDA_REPOSITORY.isRepositoryPage = BDA_REPOSITORY.isRepositoryPageFct();
       BDA_REPOSITORY.hasErrors = BDA_REPOSITORY.hasErrorsFct();
       BDA_REPOSITORY.hasResults = BDA_REPOSITORY.hasResultsFct(BDA_REPOSITORY.hasErrors);
@@ -272,7 +273,6 @@
 
       console.time('preparePage');
 
-      BDA_REPOSITORY.PERF_MONITOR = new PerformanceMonitor(true);
       BDA_REPOSITORY.PERF_MONITOR.reset();
 
       $(BDA_REPOSITORY.descriptorTableSelector).attr("id", "descriptorTable");

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1607,9 +1607,9 @@ console.timeEnd('formatTabResult');
         longCell.append(val);
       }
 
-      // if (lineIsVisible && !_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
-      //   BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
-      // }
+      if (lineIsVisible && !_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
+        BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
+      }
        BDA_REPOSITORY.PERF_MONITOR.cumul('buildPropertyValueCell');
       // console.timeEnd('buildPropertyValueCell ' + property.name);
       return res;

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -171,15 +171,15 @@
       resultTable: '<table class="dataTable" data-descriptor="{0}"></table>',
       idCell: '<td data-identifier="id_{0}_{1}">{0}</td>',
       descriptorCell: '<td>{0}</td>',
-      propertyCell: '<td data-property="{1}" data-item-id="{2}" class="property show-short">' +
+      propertyCell: '<td data-property="{1}" data-item-id="{2}" class="property show-short"><div class="flex-wrapper">' +
         '{0}' +
         '<span class="actions">' +
+        '<i class="fa fa-edit action start-edit" aria-hidden="true"></i>' +
         '<i class="fa fa-compress action collapse" aria-hidden="true"></i>' +
         '<i class="fa fa-expand action expand" aria-hidden="true"></i>' +
         '<i class="fa fa-spinner fa-spin passive-loading-icon" aria-hidden="true"></i>' +
-        '<i class="fa fa-edit action start-edit" aria-hidden="true"></i>' +
         '</span>' +
-        '</td>',
+        '</div></td>',
       shortPropertyCell: '<div class="value-elem propertyValue"></div>',
       longPropertyCell: '<span class="value-elem long propertyValue"></span><span class="value-elem short">{0}</span>',
       editProperty: '<update-item item-descriptor="{0}" id="{1}">\n\t<set-property name="{2}">\n\t<![CDATA[{3}]]>\n\t</set-property>\n</update-item>'
@@ -1463,13 +1463,13 @@
       //enable local collapse/expand
       res.find('.actions')
         .on('click', '.collapse', function() {
-          $(this).parent().parent().addClass('show-short').removeClass('show-long');
+          $(this).closest('.property').addClass('show-short').removeClass('show-long');
         })
         .on('click', '.expand', function() {
-          $(this).parent().parent().removeClass('show-short').addClass('show-long');
+          $(this).closest('.property').removeClass('show-short').addClass('show-long');
         })
         .on('click', '.start-edit', function() {
-          $(this).parent().parent().addClass('show-edit').find('input').focus();
+          $(this).closest('.property').addClass('show-edit').find('input').focus();
 
         })
 
@@ -1482,7 +1482,7 @@
         longCell.append(val);
       }
 
-      if (!propertyValue.rdonly && !propertyValue.derived) {
+      if (!_.isNil(propertyValue) && !propertyValue.rdonly && !propertyValue.derived) {
         BDA_REPOSITORY.addInlineEditForm(res, val, property, item);
       }
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -2214,4 +2214,8 @@
     BDA_REPOSITORY.executeQuery(domain, xmlText, repository, callback, errCallback);
   };
 
+  $.fn.getBdaRepository = function() {
+    return BDA_REPOSITORY;
+  };
+
 })(jQuery);

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -190,7 +190,7 @@
         '</div></td>',
       shortPropertyCell: '<div class="value-elem propertyValue"></div>',
       longPropertyCell: '<span class="value-elem long propertyValue"></span><span class="value-elem short">{0}</span>',
-      editProperty: '<update-item item-descriptor="{0}" id="{1}">\n\t<set-property name="{2}">\n\t<![CDATA[{3}]]>\n\t</set-property>\n</update-item>'
+      editProperty: '<update-item item-descriptor="{0}" id="{1}">\n    <set-property name="{2}"><![CDATA[{3}]]></set-property>\n</update-item>'
 
 
     },
@@ -1592,6 +1592,7 @@
         input.on('blur', function() {
 
           try {
+
             let newVal = input.val();
             if (newVal === val) {
               input.closest('.property').removeClass('show-edit');
@@ -1614,14 +1615,20 @@
                       try {
                         var xmlContent = $('<div>' + result + '</div>').find(BDA_REPOSITORY.resultsSelector).next().text().trim();
                         let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
-                        $.notify(
-                          "Success: \n{0}".format(logs), {
-                            className: "success",
-                            position: "top center",
-                            autoHideDelay: 5000
 
-                          }
-                        );
+                        let parentTab = input.closest('.dataTable');
+                        BDA_REPOSITORY.reloadTab(item.id, item.itemDescriptor.name, getCurrentComponentPath(), parentTab, () => {
+
+                          $.notify(
+                            "Success: \n{0}".format(logs), {
+                              className: "success",
+                              position: "top center",
+                              autoHideDelay: 5000
+
+                            }
+                          );
+
+                        });
 
                       } catch (e) {
                         console.error(e);

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -1216,6 +1216,7 @@
     },
 
     renderResultSection: function(items, repository, $outputDiv, isItemTree) {
+       console.time('renderResultSection');
       // now render the result section
       $outputDiv.append("<div class='prop_attr prop_attr_red'>R</div> : read-only " +
         "<div class='prop_attr prop_attr_green'>D</div> : derived " +
@@ -1254,6 +1255,7 @@
 
 
       BDA_REPOSITORY.formatTabResult(repository, items, $outputDiv);
+       console.timeEnd('renderResultSection');
 
     },
 
@@ -1276,6 +1278,7 @@
     },
 
     parseXmlResult: function(xmlContent, repository, rawXml) {
+      console.time('parseXmlResult');
       try {
 
         var xmlDoc = $.parseXML("<xml>" + xmlContent + "</xml>");
@@ -1284,13 +1287,16 @@
         var $addItems = $xml.find("add-item");
         let items = BDA_REPOSITORY.parseXmlAsObjects($addItems, repository, rawXmlDoc);
         let logs = BDA_REPOSITORY.getExecutionLogs(xmlContent);
+        console.timeEnd('parseXmlResult');
         return {
           items: items,
           logs: logs
         }
       } catch (e) {
         console.error(e);
+        console.timeEnd('parseXmlResult');
       }
+
     },
     getExecutionLogs: function(xmlContent) {
       var log = $("<xml>" + xmlContent + "</xml>")
@@ -1318,6 +1324,7 @@
     },
 
     formatTabResult: function(repository, repositoryItems, result) {
+      console.time('formatTabResult');
       try {
         let itemsByType = _.groupBy(repositoryItems, repoItem => !_.isNil(repoItem.itemDescriptor) ? repoItem.itemDescriptor.name : null);
         let nbItemDescriptors = _.keys(itemsByType).length;
@@ -1364,7 +1371,7 @@
       } catch (e) {
         console.error(e);
       }
-
+console.timeEnd('formatTabResult');
     },
 
     parseXmlAsObjects: function($addItems, repository, rawXmlDoc) {
@@ -1417,6 +1424,7 @@
     },
 
     buildResultTable: function(items, renderContext, repo) {
+      console.time('buildResultTable')
       let res;
       if (!_.isNil(items) && items.length > 0) {
         let itemDescriptor = items[0].itemDescriptor;
@@ -1464,6 +1472,7 @@
         let tbody = $('<tbody></tbody>').appendTo(table);
         //for each property, get 
         let index = 0;
+        console.time('build all items');
         _(itemDescriptor.properties)
           .each((property) => {
 
@@ -1500,19 +1509,26 @@
             }
 
             // add all cells
+             //   console.time('build all cells');
             let cells = _.map(items, item => BDA_REPOSITORY.buildPropertyValueCell(item, property, sampleItem, repo));
+           // console.timeEnd('build all cells');
+            //console.time('append all cells');
+
             _.each(cells, cell => cell.appendTo(line));
+         //   console.timeEnd('append all cells');
             line.appendTo(tbody);
             index++;
 
           });
-
+        console.timeEnd('build all items');
         res = table;
       }
+       console.timeEnd('buildResultTable')
       return res;
     },
 
     buildPropertyValueCell: function(item, property, referencePropertyValue, repository) {
+  //    console.time('buildPropertyValueCell ' + property.name);
       let propertyValue = item.values[property.name];
       logTrace('buildPropertyValueCell : propertyValue', propertyValue);
       let val;
@@ -1540,18 +1556,18 @@
         res.addClass('default');
       }
 
-      //enable local collapse/expand
-      res.find('.actions')
-        .on('click', '.collapse', function() {
-          $(this).closest('.property').addClass('show-short').removeClass('show-long');
-        })
-        .on('click', '.expand', function() {
-          $(this).closest('.property').removeClass('show-short').addClass('show-long');
-        })
-        .on('click', '.start-edit', function() {
-          $(this).closest('.property').addClass('show-edit').find('.inline-input').focus();
+      // //enable local collapse/expand
+      // res.find('.actions')
+      //   .on('click', '.collapse', function() {
+      //     $(this).closest('.property').addClass('show-short').removeClass('show-long');
+      //   })
+      //   .on('click', '.expand', function() {
+      //     $(this).closest('.property').removeClass('show-short').addClass('show-long');
+      //   })
+      //   .on('click', '.start-edit', function() {
+      //     $(this).closest('.property').addClass('show-edit').find('.inline-input').focus();
 
-        })
+      //   })
 
       // for id of other items, load sub item on click
       let longCell = res.find('.propertyValue');
@@ -1559,16 +1575,16 @@
 
       if (property.isItem) {
 
-        BDA_REPOSITORY.buildLinkToOtherItem(longCell, val, property);
+       // BDA_REPOSITORY.buildLinkToOtherItem(longCell, val, property);
 
       } else {
         longCell.append(val);
       }
 
       if (!_.isNil(referencePropertyValue) && !referencePropertyValue.rdonly && !referencePropertyValue.derived) {
-        BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
+     //   BDA_REPOSITORY.addInlineEditForm(res, val, property, item, repository);
       }
-
+      // console.timeEnd('buildPropertyValueCell ' + property.name);
       return res;
     },
 

--- a/bda.repository.js
+++ b/bda.repository.js
@@ -176,6 +176,7 @@
         '<i class="fa fa-refresh action reload-item" aria-hidden="true"></i>' +
         '</div>' +
         '</span>' +
+        '</div>' +
         '</td>',
       descriptorCell: '<td>{0}</td>',
       propertyCell: '<td data-property="{2}" data-item-id="{1}" class="property show-short"><div class="flex-wrapper">' +
@@ -1398,7 +1399,7 @@
           BDA_REPOSITORY.reloadTab(id, item, getCurrentComponentPath(), parentTab, () => {
             $this.removeClass('fa-spin');
             $.notify(
-              $("<div>Success: Reloaded {0} {1}</div>".format(item, id)), {
+              "Success: Reloaded {0} {1}".format(item, id), {
                 className: "success",
                 position: "top center",
                 autoHideDelay: 3000

--- a/bda.search.js
+++ b/bda.search.js
@@ -25,12 +25,19 @@
 
         //init bloodhound
 
+        let favs = [];
+        var comps = BDA_STORAGE.getStoredComponents();
+        _.forEach(comps, (fav) => {
+          favs.push({
+            value: fav.componentPath.replace(/\/dyn\/admin\/nucleus/g, '').replace(/\/$/g, '')
+          });
+        })
+
         BDA_SEARCH.suggestionEngineOptions = {
           initialize: true,
-          queryTokenizer: Bloodhound.tokenizers.whitespace,
-          datumTokenizer: function(datum) {
-            return Bloodhound.tokenizers.whitespace(datum.value);
-          },
+          local: favs,
+          queryTokenizer: (query) => query.split('/'),
+          datumTokenizer: (datum) => datum.value.split('/'),
           identify: function(obj) {
             return obj.value;
           },
@@ -105,10 +112,14 @@
       }
     },
   };
+
+  var BDA_STORAGE;
   // Reference to BDA
   // Jquery plugin creation
+
   $.fn.bdaSearch = function(options) {
     console.log('Init plugin {0}'.format('bdaSearch'));
+    BDA_STORAGE = $.fn.bdaStorage.getBdaStorage();
     BDA_SEARCH.build($(this), $.extend({}, BDA_SEARCH.defaultOptions, options));
     return this;
   };

--- a/bda.user.js
+++ b/bda.user.js
@@ -34,6 +34,8 @@
 // @require https://cdnjs.cloudflare.com/ajax/libs/notify/0.4.2/notify.min.js
 // @require https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js
 // @require https://cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js
+// @require https://cdn.jsdelivr.net/bluebird/latest/bluebird.min.js
+
 // custom bootstrap
 // @require lib/bootstrap/js/bootstrap.min.js
 // @require http://twitter.github.io/typeahead.js/releases/latest/typeahead.bundle.min.js

--- a/bda.user.js
+++ b/bda.user.js
@@ -70,6 +70,7 @@
 // @require parser/bda.dash.parser.js
 // @require bda.dash.js
 // @require bda.scheduler.js
+// @require bda.repo-explorer.js
 
 // @updateUrl http://raw.githubusercontent.com/jc7447/bda/master/bda.user.js
 // @downloadUrl https://raw.githubusercontent.com/jc7447/bda/master/bda.user.js
@@ -192,6 +193,8 @@ jQuery(document).ready(function() {
         $().initDASH(BDA);
 
         $().bdaScheduler();
+
+        $().initRepositoryExplorer(BDA);
 
         var autocomplete = $.fn.bdaStorage.getBdaStorage().getConfigurationValue('search_autocomplete');
         autocomplete = (autocomplete == true) ? true : false;

--- a/bda.user.js
+++ b/bda.user.js
@@ -33,6 +33,7 @@
 // @require https://cdnjs.cloudflare.com/ajax/libs/vis/4.15.0/vis.min.js
 // @require https://cdnjs.cloudflare.com/ajax/libs/notify/0.4.2/notify.min.js
 // @require https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js
+// @require https://cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js
 // custom bootstrap
 // @require lib/bootstrap/js/bootstrap.min.js
 // @require http://twitter.github.io/typeahead.js/releases/latest/typeahead.bundle.min.js

--- a/bda.user.js
+++ b/bda.user.js
@@ -194,7 +194,7 @@ jQuery(document).ready(function() {
 
         $().bdaScheduler();
 
-        $().initRepositoryExplorer(BDA);
+       // $().initRepositoryExplorer(BDA);
 
         var autocomplete = $.fn.bdaStorage.getBdaStorage().getConfigurationValue('search_autocomplete');
         autocomplete = (autocomplete == true) ? true : false;

--- a/bda.xmldef.js
+++ b/bda.xmldef.js
@@ -361,31 +361,31 @@
         BDA_XML_DEF.$ITEMS = $container.find('.panel');
         var searchTimeOut;
 
-        $('.item-descriptor-heading').on('click', function() {
-          var $this = $(this);
-          var target = $this.attr('data-target');
-          if ($this.hasClass('open')) {
-            $this.removeClass('open').addClass('closed');
-            $('#item_' + target).find('.panel-body .row').hide();
-          } else {
-            $this.removeClass('closed').addClass('open');
-            $('#item_' + target).find('.panel-body .row').show();
-          }
-        });
+//         $('.item-descriptor-heading').on('click', function() {
+//           var $this = $(this);
+//           var target = $this.attr('data-target');
+//           if ($this.hasClass('open')) {
+//             $this.removeClass('open').addClass('closed');
+//             $('#item_' + target).find('.panel-body .row').hide();
+//           } else {
+//             $this.removeClass('closed').addClass('open');
+//             $('#item_' + target).find('.panel-body .row').show();
+//           }
+//         });
 
-        $('.table-def').on('click', function() {
-          var $this = $(this);
-          var id = $this.attr('id');
-          if ($this.hasClass('open')) {
-            $this.removeClass('open').addClass('closed');
-            $('.row[data-table=' + id + ']').hide();
+//         $('.table-def').on('click', function() {
+//           var $this = $(this);
+//           var id = $this.attr('id');
+//           if ($this.hasClass('open')) {
+//             $this.removeClass('open').addClass('closed');
+//             $('.row[data-table=' + id + ']').hide();
 
-          } else {
-            $this.removeClass('closed').addClass('open');
-            $('.row[data-table=' + id + ']').show();
+//           } else {
+//             $this.removeClass('closed').addClass('open');
+//             $('.row[data-table=' + id + ']').show();
 
-          }
-        });
+//           }
+//         });
 
         $row.prepend(BDA_XML_DEF.buildQuickNav());
 

--- a/html/dash.html
+++ b/html/dash.html
@@ -1,89 +1,89 @@
-'<div class="twbs">'+
-'<div id="dashModal" class="modal fade" tabindex="-1" role="dialog" data-fullscreen="false">'+
-'<div id="dashModalDialog" class="modal-dialog modal-lg">'+
-'<div class="modal-content">'+
-'<div class="modal-header">'+
-'<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span >&times;</span></button>'+
-'<h4 class="modal-title">DASH - DynAdmin SHell</h4>'+
-'</div>'+
-'<div class="modal-body">'+
-'<div class="container-fluid">'+
-'<div id="dashInnerBody" class="row">'+
-'<div id="dashScreen" class="dashcol col-lg-12" >'+
-''+
-'<div id="" class="progress" style="display:none;" >'+
-'<div id="dashProgressBar" class="progress-bar  progress-bar-success" " role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="">'+
-'</div>'+
-'</div>'+
-'</div>'+
-'<div id="dashControl" class="tab-content dashcol col-lg-12">'+
-'<div role="tabpanel" class="tab-pane fade in active" id="dash-console-tab">'+
-'<form id="dashForm" class="">'+
-'<div class="form-group">'+
-'<div class="input-group">'+
-'<div class="input-group-addon"><span id="dash_dollar">$</span><i class="fa fa-spinner fa-spin" id="dash_spinner" style="display: none;"></i></div>'+
-'<input type="text" class="form-control dash-input main-input" id="dashInput" placeholder="" name="cmd" data-provide="typeahead" autocomplete="off"/>'+
-'<span  class="input-group-btn"><button type="button" id="dashCleanInput" class="btn btn-default">&times;</button></span>'+
-'</div>'+
-'</div>'+
-'</form>'+
-'</div>'+
-'<div role="tabpanel" class="tab-pane fade" id="dash-editor-tab">'+
-'<form id="dashEditorForm" class="form-horizontal">'+
-'<div class="form-group top-row">'+
-'<div class="col-sm-3">'+
-'<select id="dashEditorScriptList" class="form-control">'+
-'</select>'+
-'</div>'+
-'<div class="col-sm-5">'+
-'<div class="btn-group" role="group" >'+
-'<button type="button" id="dashLoadScript" class="btn btn-primary" title="load">'+
-'<i class="fa fa-folder-open" />&nbsp;'+
-'</i>'+
-'</button>'+
-'<button type="button" id="dashDeleteScript" class="btn btn-primary" title="delete">'+
-'<i class="fa fa-trash-o" />&nbsp;'+
-'</i>'+
-'</button>'+
-'<button type="button" id="dashRunEditor" class="btn btn-primary" title="run">'+
-'<i class="fa fa-play" />&nbsp;'+
-'</i>'+
-'</button>'+
-'<button type="button" id="dashSaveEditor" class="btn btn-primary" title="save">'+
-'<i class="fa fa-floppy-o" />&nbsp;'+
-'</i>'+
-'</button>'+
-'<button type="button" id="dashClearEditor" class="btn btn-primary" title="clear">'+
-'<i class="fa fa-eraser" />&nbsp;'+
-'</i>'+
-'</button>'+
-'</div>'+
-'</div>'+
-'<label for="dashSaveScriptName" class="col-sm-1 control-label">Name</label>'+
-'<div class="col-sm-3">'+
-'<input type="text" class="form-control dash-input main-input" id="dashSaveScriptName" placeholder="Name" name="save" autocomplete="off"></input>'+
-'</div>'+
-'</div>'+
-'<div class="form-group middle-row">'+
-'<div class="col-sm-12">'+
-'<textarea id="dashEditor" class="form-control dash-input main-input" rows="12  " placeholder=""></textarea>'+
-'</div>'+
-'</div>'+
-'</form>'+
-'</div>'+
-'</div>'+
-'</div>'+
-'</div>'+
-'</div>'+
-'<div id="dashFooter" class="modal-footer">'+
-'<ul class="nav nav-pills">'+
-'<li role="presentation" class="active"><a id="dashConsoleButton" href="#dash-console-tab" aria-controls="console" role="tab" data-toggle="tab" data-fs-mode="false">Console</a></li>'+
-'<li role="presentation"><a id="dashEditorButton"  href="#dash-editor-tab" aria-controls="editor" role="tab" data-toggle="tab"  data-fs-mode="true">Editor</a></li>'+
-'<li role="presentation" class="pull-right footer-right" ><a id="dashClearScreen" class="btn-default"   role="tab" aria-controls="clearScreen" >Clear Screen <i class="fa fa-ban" ></i></a></li>'+
-'</ul>'+
-'<div id="dashTips"></div>'+
-'</div>'+
-'</div>'+
-'</div>'+
-'</div>'+
-'</div>',
+<div class="twbs"> 
+          <div id="dashModal" class="modal fade" tabindex="-1" role="dialog" data-fullscreen="false"> 
+          <div id="dashModalDialog" class="modal-dialog modal-lg"> 
+          <div class="modal-content"> 
+          <div class="modal-header"> 
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span >&times;</span></button> 
+          <h4 class="modal-title">DASH - DynAdmin SHell - v{0}</h4> 
+          </div> 
+          <div class="modal-body"> 
+          <div class="container-fluid"> 
+          <div id="dashInnerBody" class="row"> 
+          <div id="dashScreen" class="dashcol col-lg-12" > 
+           
+          <div id="" class="progress" style="display:none;" > 
+          <div id="dashProgressBar" class="progress-bar  progress-bar-success" " role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style=""> 
+          </div> 
+          </div> 
+          </div> 
+          <div id="dashControl" class="tab-content dashcol col-lg-12"> 
+          <div role="tabpanel" class="tab-pane fade in active" id="dash-console-tab"> 
+          <form id="dashForm" class=""> 
+          <div class="form-group"> 
+          <div class="input-group"> 
+          <div class="input-group-addon"><span id="dash_dollar">$</span><i class="fa fa-spinner fa-spin" id="dash_spinner" style="display: none;"></i></div> 
+          <input type="text" class="form-control dash-input main-input dash-autocomplete" id="dashInput" placeholder="" name="cmd" data-provide="typeahead" autocomplete="off"/> 
+          <span  class="input-group-btn"><button type="button" id="dashCleanInput" class="btn btn-default">&times;</button></span> 
+          </div> 
+          </div> 
+          </form> 
+          </div> 
+          <div role="tabpanel" class="tab-pane fade" id="dash-editor-tab"> 
+          <form id="dashEditorForm" class="form-horizontal"> 
+          <div class="form-group top-row"> 
+          <div class="col-sm-3"> 
+          <select id="dashEditorScriptList" class="form-control"> 
+          </select> 
+          </div> 
+          <div class="col-sm-5"> 
+          <div class="btn-group" role="group" > 
+          /*<button type="button" id="dashLoadScript" class="btn btn-primary" title="load"> 
+          <i class="fa fa-folder-open" />&nbsp; 
+          </i> 
+          </button> +*/
+          <button type="button" id="dashDeleteScript" class="btn btn-primary" title="delete"> 
+          <i class="fa fa-trash-o" />&nbsp; 
+          </i> 
+          </button> 
+          <button type="button" id="dashRunEditor" class="btn btn-primary" title="run"> 
+          <i class="fa fa-play" />&nbsp; 
+          </i> 
+          </button> 
+          <button type="button" id="dashSaveEditor" class="btn btn-primary" title="save"> 
+          <i class="fa fa-floppy-o" />&nbsp; 
+          </i> 
+          </button> 
+          <button type="button" id="dashClearEditor" class="btn btn-primary" title="clear"> 
+          <i class="fa fa-eraser" />&nbsp; 
+          </i> 
+          </button> 
+          </div> 
+          </div> 
+          <label for="dashSaveScriptName" class="col-sm-1 control-label">Name</label> 
+          <div class="col-sm-3"> 
+          <input type="text" class="form-control dash-input main-input" id="dashSaveScriptName" placeholder="Name" name="save" autocomplete="off"></input> 
+          </div> 
+          </div> 
+          <div class="form-group middle-row"> 
+          <div class="col-sm-12"> 
+          <textarea id="dashEditor" class="form-control dash-input main-input dash-autocomplete" rows="12  " placeholder=""></textarea> 
+          </div> 
+          </div> 
+          </form> 
+          </div> 
+          </div> 
+          </div> 
+          </div> 
+          </div> 
+          <div id="dashFooter" class="modal-footer"> 
+          <ul class="nav nav-pills"> 
+          <li role="presentation" class="active"><a id="dashConsoleButton" href="#dash-console-tab" aria-controls="console" role="tab" data-toggle="tab" data-fs-mode="false">Console</a></li> 
+          <li role="presentation"><a id="dashEditorButton"  href="#dash-editor-tab" aria-controls="editor" role="tab" data-toggle="tab"  data-fs-mode="true">Editor</a></li> 
+          <li role="presentation" class="pull-right footer-right" ><a id="dashClearScreen" class="btn-default"   role="tab" aria-controls="clearScreen" >Clear Screen <i class="fa fa-ban" ></i></a></li> 
+          </ul> 
+          <div id="dashTips" class="text-muted"></div> 
+          </div> 
+          </div> 
+          </div> 
+          </div> 
+          </div>,


### PR DESCRIPTION
This PR is a work in progress, I opened	it to start a discussion before going further

My initial goal was to make a new page which would serve as a cross repository explorer, with visual editing features and full ajax queries to be quicker.

To achieve that, I needed to leverage part of the repo's page methods (display as tab, tree) and ended refactoring it quite a lot, not only the "backend part" but also the repo page itsef : display as tab, edit inline, link to child item.

I'm now at a state with a almost full iso-functionnal repository page, with a new "engine" under the hood, and also fixed some bugs / inconsistencies in the UI/UX.

In short, what's new:

- New "MVC" model that uses classes to formalize models:
    - Using objects makes it clearer, less arrays everywhere that store bits of data.
    - Repository :
        - holds the whole repo definition in memory for when using multiple repositories.
    - ItemDescriptor :
        - contains self and parent properties
        - xmlDef is parsed on demand and stored for further use
    - PropertyDescriptor : 
        - stores default value, item type of property if required.
    - RepositoryItem :  model of a parsed xml result
    - PropertyValue : each value, default or actual, with its flags parsed from the xml (rdonly, etc )
- Result as tab:
    - Fully compatible and agnostic between itemtree and standard result (+ repo explorer when it's done)
    - properties sorted alphabetically
    - load sub item :
        - now uses an ajax call, saves the time to reload the page & BDA - **several seconds**. 
        - If the item is already on the page, **scroll to it**. (like for item tree)
        - Now available for multi items (lists & maps)
    - more constistent collapse expand of long properties:
        - added collapse all button
        - per cell collapse/expand
    - inline edition more consistent across fields types (not finished yet)
    - TODO : reload item view, delete view
- TODO: 
    - change the item tree generation to use the same model for each type of visualization, instead of reloading the tree each time.
    - add help/hints overlays.
    - performance testing


